### PR TITLE
Proposed fix of the PUID:PGID scrob:scrob chown failure.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,7 +17,7 @@ groupadd -g "$PGID" scrob 2>/dev/null || true
 useradd -u "$PUID" -g "$PGID" -M -s /bin/false scrob 2>/dev/null || true
 
 # Fix ownership so the scrob user can write to the data directory
-chown -R scrob:scrob /app/backend/data
+chown -R "$PUID:$PGID" /app/backend/data
 
 # Allow the unprivileged user to write to Docker's stdout/stderr
 chmod o+w /dev/stdout /dev/stderr


### PR DESCRIPTION
Issue raised in
#39

Suggest for the chown to work with dynamic assignment instead of the literal scrob:scrob reference. 