### PR TITLE
feat(nuvio): add cloud sync and fix collection clearing and Trakt imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 ---
 
-Scrob syncs your libraries from **Jellyfin**, **Plex**, and **Emby**, tracks your watch history, ratings, and personal lists, and lets you push your activity back to your media server - all from a clean, app-like web interface that installs as a PWA on any device.
+Scrob syncs your libraries from **Jellyfin**, **Plex**, **Emby**, and **Nuvio**, tracks your watch history, ratings, and personal lists, and can push watched activity back to connected providers - all from a clean, app-like web interface that installs as a PWA on any device.
 
 ## Table of Contents
 
@@ -40,8 +40,8 @@ Scrob syncs your libraries from **Jellyfin**, **Plex**, and **Emby**, tracks you
 
 ## Features
 
-- **Multi-source sync**: Import your full library, watch history, and ratings from Jellyfin, Plex, and Emby. Incremental syncs keep everything up to date.
-- **Keep all servers in sync**: Keep your watched status in sync between all your servers. Supports multiple instances.
+- **Multi-source sync**: Import libraries and watch history from Jellyfin, Plex, Emby, and Nuvio. Nuvio also imports playback progress for Continue Watching.
+- **Keep providers in sync**: Keep watched status synchronized between your media servers and Nuvio. Supports multiple instances and Nuvio profiles.
 - **Real-time scrobbling**: Webhooks from Jellyfin, Plex, Emby, and Kodi update your watch state as you play - no manual sync needed.
 - **Manual scrobble**: Start a watching session directly from any movie or episode page. Pause, resume, stop, or mark as watched - session progress shows live on the home screen.
 - **Trakt integration**: Sync your watched history and ratings from Trakt, and push Scrob activity back to Trakt automatically.
@@ -111,7 +111,7 @@ Scrob syncs your libraries from **Jellyfin**, **Plex**, and **Emby**, tracks you
 ### Prerequisites
 
 - [Docker](https://docs.docker.com/get-docker/) and [Docker Compose](https://docs.docker.com/compose/install/)
-- A [TMDB API key](https://www.themoviedb.org/settings/api) (free) - used for metadata, search, and images
+- A [TMDB Read Access Token](https://www.themoviedb.org/settings/api) (free) - used for metadata, search, and images
 
 ### Docker Compose
 
@@ -249,8 +249,10 @@ docker run -d \
 ### First Setup
 
 1. Open `http://localhost:7330` and create your account.
-2. Go to **Settings → Integrations** to add your TMDB API key and connect Jellyfin, Plex, or Emby.
-3. Select which libraries to sync, then trigger your first sync from **Settings → Sync**.
+2. Go to **Settings → Integrations** to add your TMDB Read Access Token and connect Jellyfin, Plex, Emby, or Nuvio.
+3. Select which media-server libraries to sync, or select a Nuvio profile, then trigger your first sync.
+
+For Nuvio, choose **Nuvio** as the provider, sign in with your Nuvio email and password, and select one of the returned profiles. Scrob exchanges the password for a refresh token and does not store the password. **Sync now** pulls the profile's library, watch history, and playback progress through Nuvio's public sync API; **Auto Pull** repeats that sync at the selected interval.
 
 ### Updating
 

--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ Scrob connects to the [Nuvio public Cloud API](https://nuvio.tv/docs) at `https:
 3. Select **Test** to authenticate and load the profiles attached to the account.
 4. Select the Nuvio profile to synchronize, choose the pull and push options, then select **Add**.
 
-Scrob exchanges the email and password for a refresh token. The password is never persisted. Refresh-token rotation is handled automatically during connection checks, synchronization, and watched-state pushes.
+Scrob exchanges the email and password for a refresh token. The password is never persisted. Refresh-token rotation is handled automatically during connection checks and synchronization.
 
 Each connection targets one Nuvio profile. Add another connection if you need to synchronize another profile from the same account.
 
@@ -325,16 +325,17 @@ Each connection targets one Nuvio profile. Add another connection if you need to
 | Nuvio → Scrob | **Watched status** | Imports watched movies and episodes with their latest watch timestamps. |
 | Nuvio → Scrob | **Playback progress** | Imports position and duration into Continue Watching. |
 | Scrob → Nuvio | **Watched status** | Pushes watched and unwatched changes made in Scrob or imported from another connected provider. |
+| Scrob → Nuvio | **Playback progress** | Pushes current playback positions into Nuvio's Continue Watching state as non-destructive upserts. |
 
-**Sync now** runs an inbound synchronization using the enabled Nuvio → Scrob settings. **Push** sends all watched items currently known to Scrob to Nuvio as non-destructive upserts; it does not remove Nuvio watched items merely because they are absent from Scrob.
+**Sync now** runs an inbound synchronization using the enabled Nuvio → Scrob settings. **Push** sends the enabled watched-history and playback-progress data from Scrob to Nuvio. Both operations use non-destructive upserts; items absent from Scrob are not removed from Nuvio.
 
-Library membership and playback progress are currently pull-only. Ratings are not synchronized with Nuvio.
+Library membership is currently pull-only. Ratings are not synchronized with Nuvio.
 
 ### Scheduling and Limitations
 
 **Auto Pull** repeats the enabled inbound synchronization every 15 minutes, 30 minutes, 1 hour, 3 hours, 6 hours, 12 hours, 24 hours, or 48 hours. Nuvio synchronization is polling-based; Nuvio does not use the media-server webhook URLs documented below.
 
-Content matching prefers TMDB identifiers. Bare IMDb identifiers returned by Nuvio are resolved through TMDB before import. Unsupported identifiers are skipped rather than attached to the wrong title.
+Inbound Nuvio identifiers are normalized to TMDB for Scrob's internal matching. Before an outbound push, Scrob resolves those TMDB identifiers to Nuvio-compatible bare IMDb identifiers (`tt...`) and caches the mapping. Unsupported identifiers are skipped rather than attached to the wrong title.
 
 ## Webhooks (Real-time Scrobbling)
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ Scrob syncs your libraries from **Jellyfin**, **Plex**, **Emby**, and **Nuvio**,
   - [Updating](#updating)
 - [Configuration](#configuration)
 - [Development](#development)
+- [Nuvio Cloud Synchronization](#nuvio-cloud-synchronization)
+  - [Connect Nuvio](#connect-nuvio)
+  - [Synchronization Directions](#synchronization-directions)
+  - [Scheduling and Limitations](#scheduling-and-limitations)
 - [Webhooks](#webhooks-real-time-scrobbling)
   - [Jellyfin](#jellyfin)
   - [Plex](#plex)
@@ -252,7 +256,7 @@ docker run -d \
 2. Go to **Settings → Integrations** to add your TMDB Read Access Token and connect Jellyfin, Plex, Emby, or Nuvio.
 3. Select which media-server libraries to sync, or select a Nuvio profile, then trigger your first sync.
 
-For Nuvio, choose **Nuvio** as the provider, sign in with your Nuvio email and password, and select one of the returned profiles. Scrob exchanges the password for a refresh token and does not store the password. **Sync now** pulls the profile's library, watch history, and playback progress through Nuvio's public sync API; **Auto Pull** repeats that sync at the selected interval.
+For Nuvio, choose **Nuvio** as the provider, sign in, and select one of the returned profiles. See [Nuvio Cloud Synchronization](#nuvio-cloud-synchronization) for credential handling, sync directions, scheduling, and current limitations.
 
 ### Updating
 
@@ -297,6 +301,40 @@ Remove the `scrob-db` service and set `DATABASE_URL` to your existing instance:
 ```yaml
 DATABASE_URL: postgresql+asyncpg://user:password@your-db-host:5432/scrob
 ```
+
+## Nuvio Cloud Synchronization
+
+Scrob connects to the [Nuvio public Cloud API](https://nuvio.tv/docs) at `https://api.nuvio.tv`. A TMDB Read Access Token must be configured in Scrob so Nuvio content identifiers can be matched to movies and shows.
+
+### Connect Nuvio
+
+1. Open **Settings → Media Server Connections** and select **Add Connection**.
+2. Choose **Nuvio**, then enter a connection name, your Nuvio email, and your Nuvio password.
+3. Select **Test** to authenticate and load the profiles attached to the account.
+4. Select the Nuvio profile to synchronize, choose the pull and push options, then select **Add**.
+
+Scrob exchanges the email and password for a refresh token. The password is never persisted. Refresh-token rotation is handled automatically during connection checks, synchronization, and watched-state pushes.
+
+Each connection targets one Nuvio profile. Add another connection if you need to synchronize another profile from the same account.
+
+### Synchronization Directions
+
+| Direction | Setting | Behavior |
+|---|---|---|
+| Nuvio → Scrob | **Collection status** | Imports the profile's library movies and series. |
+| Nuvio → Scrob | **Watched status** | Imports watched movies and episodes with their latest watch timestamps. |
+| Nuvio → Scrob | **Playback progress** | Imports position and duration into Continue Watching. |
+| Scrob → Nuvio | **Watched status** | Pushes watched and unwatched changes made in Scrob or imported from another connected provider. |
+
+**Sync now** runs an inbound synchronization using the enabled Nuvio → Scrob settings. **Push** sends all watched items currently known to Scrob to Nuvio as non-destructive upserts; it does not remove Nuvio watched items merely because they are absent from Scrob.
+
+Library membership and playback progress are currently pull-only. Ratings are not synchronized with Nuvio.
+
+### Scheduling and Limitations
+
+**Auto Pull** repeats the enabled inbound synchronization every 15 minutes, 30 minutes, 1 hour, 3 hours, 6 hours, 12 hours, 24 hours, or 48 hours. Nuvio synchronization is polling-based; Nuvio does not use the media-server webhook URLs documented below.
+
+Content matching prefers TMDB identifiers. Bare IMDb identifiers returned by Nuvio are resolved through TMDB before import. Unsupported identifiers are skipped rather than attached to the wrong title.
 
 ## Webhooks (Real-time Scrobbling)
 

--- a/backend/core/enrichment.py
+++ b/backend/core/enrichment.py
@@ -36,6 +36,7 @@ async def enrich_media(media: Media, api_key: str = None, series_tmdb_id: int = 
             media.tmdb_data = {
                 "runtime": data.get("runtime"),
                 "genres": [g["name"] for g in data.get("genres", [])],
+                "external_ids": data.get("external_ids", {}),
                 "cast": [
                     {"name": c["name"], "character": c["character"], "profile_path": tmdb.poster_url(c.get("profile_path"), size="w185")}
                     for c in data.get("credits", {}).get("cast", [])[:10]

--- a/backend/core/nuvio.py
+++ b/backend/core/nuvio.py
@@ -1,0 +1,259 @@
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+
+DEFAULT_URL = "https://api.nuvio.tv"
+PUBLISHABLE_KEY = "sb_publishable_1Clq8rlTVACkdcZuqr6_AD__xUUC_EN"
+_PAGE_SIZE = 500
+
+
+class NuvioAPIError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class NuvioSession:
+    access_token: str
+    refresh_token: str
+    expires_in: int
+
+
+def _base_url(url: str) -> str:
+    return url.rstrip("/")
+
+
+def _public_headers() -> dict[str, str]:
+    return {"apikey": PUBLISHABLE_KEY, "Content-Type": "application/json"}
+
+
+def _auth_headers(access_token: str) -> dict[str, str]:
+    return {**_public_headers(), "Authorization": f"Bearer {access_token}"}
+
+
+async def _raise_api_error(response: httpx.Response, operation: str) -> None:
+    if response.is_success:
+        return
+    try:
+        payload = response.json()
+        detail = payload.get("message") or payload.get("error_description") or payload.get("error")
+    except (ValueError, AttributeError):
+        detail = None
+    suffix = f": {detail}" if detail else ""
+    raise NuvioAPIError(f"Nuvio {operation} failed ({response.status_code}){suffix}")
+
+
+def _parse_session(payload: dict[str, Any]) -> NuvioSession:
+    access_token = payload.get("access_token")
+    refresh_token = payload.get("refresh_token")
+    if not access_token or not refresh_token:
+        raise NuvioAPIError("Nuvio authentication returned an incomplete session")
+    return NuvioSession(
+        access_token=str(access_token),
+        refresh_token=str(refresh_token),
+        expires_in=int(payload.get("expires_in") or 0),
+    )
+
+
+async def sign_in(url: str, email: str, password: str) -> NuvioSession:
+    async with httpx.AsyncClient(timeout=20.0, follow_redirects=False) as client:
+        response = await client.post(
+            f"{_base_url(url)}/auth/v1/token",
+            params={"grant_type": "password"},
+            headers=_public_headers(),
+            json={"email": email, "password": password},
+        )
+    await _raise_api_error(response, "sign-in")
+    return _parse_session(response.json())
+
+
+async def refresh_session(
+    url: str,
+    refresh_token: str,
+    client: httpx.AsyncClient | None = None,
+) -> NuvioSession:
+    owns_client = client is None
+    if client is None:
+        client = httpx.AsyncClient(timeout=20.0, follow_redirects=False)
+    try:
+        response = await client.post(
+            f"{_base_url(url)}/auth/v1/token",
+            params={"grant_type": "refresh_token"},
+            headers=_public_headers(),
+            json={"refresh_token": refresh_token},
+        )
+        await _raise_api_error(response, "token refresh")
+        return _parse_session(response.json())
+    finally:
+        if owns_client:
+            await client.aclose()
+
+
+async def _rpc(
+    client: httpx.AsyncClient,
+    url: str,
+    access_token: str,
+    function_name: str,
+    payload: dict[str, Any] | None = None,
+) -> Any:
+    response = await client.post(
+        f"{_base_url(url)}/rest/v1/rpc/{function_name}",
+        headers=_auth_headers(access_token),
+        json=payload,
+    )
+    await _raise_api_error(response, function_name)
+    if response.status_code == 204 or not response.content:
+        return None
+    return response.json()
+
+
+async def get_profiles(
+    url: str,
+    access_token: str,
+    client: httpx.AsyncClient | None = None,
+) -> list[dict[str, Any]]:
+    owns_client = client is None
+    if client is None:
+        client = httpx.AsyncClient(timeout=20.0, follow_redirects=False)
+    try:
+        profiles = await _rpc(client, url, access_token, "sync_pull_profiles")
+        return profiles if isinstance(profiles, list) else []
+    finally:
+        if owns_client:
+            await client.aclose()
+
+
+async def authenticate(url: str, email: str, password: str) -> tuple[NuvioSession, list[dict[str, Any]]]:
+    session = await sign_in(url, email, password)
+    profiles = await get_profiles(url, session.access_token)
+    return session, profiles
+
+
+async def validate_connection(
+    url: str,
+    refresh_token: str,
+    profile_id: int | None = None,
+) -> tuple[NuvioSession, list[dict[str, Any]]]:
+    async with httpx.AsyncClient(timeout=20.0, follow_redirects=False) as client:
+        session = await refresh_session(url, refresh_token, client=client)
+        profiles = await get_profiles(url, session.access_token, client=client)
+    if profile_id is not None and not any(int(profile.get("profile_index", 0)) == profile_id for profile in profiles):
+        raise NuvioAPIError(f"Nuvio profile {profile_id} was not found")
+    return session, profiles
+
+
+async def _pull_library(
+    client: httpx.AsyncClient,
+    url: str,
+    access_token: str,
+    profile_id: int,
+) -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = []
+    offset = 0
+    while True:
+        page = await _rpc(
+            client,
+            url,
+            access_token,
+            "sync_pull_library",
+            {"p_profile_id": profile_id, "p_limit": _PAGE_SIZE, "p_offset": offset},
+        )
+        page = page if isinstance(page, list) else []
+        items.extend(page)
+        if len(page) < _PAGE_SIZE:
+            return items
+        offset += _PAGE_SIZE
+
+
+async def _pull_watched_items(
+    client: httpx.AsyncClient,
+    url: str,
+    access_token: str,
+    profile_id: int,
+) -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = []
+    page_number = 1
+    while True:
+        page = await _rpc(
+            client,
+            url,
+            access_token,
+            "sync_pull_watched_items",
+            {"p_profile_id": profile_id, "p_page": page_number, "p_page_size": _PAGE_SIZE},
+        )
+        page = page if isinstance(page, list) else []
+        items.extend(page)
+        if len(page) < _PAGE_SIZE:
+            return items
+        page_number += 1
+
+
+async def _pull_watch_progress(
+    client: httpx.AsyncClient,
+    url: str,
+    access_token: str,
+    profile_id: int,
+) -> list[dict[str, Any]]:
+    rows = await _rpc(
+        client,
+        url,
+        access_token,
+        "sync_pull_watch_progress",
+        {"p_profile_id": profile_id, "p_limit": 200},
+    )
+    return rows if isinstance(rows, list) else []
+
+
+async def pull_sync_data(
+    url: str,
+    refresh_token: str,
+    profile_id: int,
+) -> tuple[NuvioSession, dict[str, list[dict[str, Any]]]]:
+    async with httpx.AsyncClient(timeout=30.0, follow_redirects=False) as client:
+        session = await refresh_session(url, refresh_token, client=client)
+        profiles = await get_profiles(url, session.access_token, client=client)
+        if not any(int(profile.get("profile_index", 0)) == profile_id for profile in profiles):
+            raise NuvioAPIError(f"Nuvio profile {profile_id} was not found")
+        library = await _pull_library(client, url, session.access_token, profile_id)
+        watched = await _pull_watched_items(client, url, session.access_token, profile_id)
+        progress = await _pull_watch_progress(client, url, session.access_token, profile_id)
+    return session, {"library": library, "watched": watched, "progress": progress}
+
+
+async def push_watched_items(
+    url: str,
+    refresh_token: str,
+    profile_id: int,
+    items: list[dict[str, Any]],
+) -> NuvioSession:
+    async with httpx.AsyncClient(timeout=30.0, follow_redirects=False) as client:
+        session = await refresh_session(url, refresh_token, client=client)
+        for offset in range(0, len(items), _PAGE_SIZE):
+            await _rpc(
+                client,
+                url,
+                session.access_token,
+                "sync_push_watched_items",
+                {"p_profile_id": profile_id, "p_items": items[offset : offset + _PAGE_SIZE]},
+            )
+    return session
+
+
+async def delete_watched_items(
+    url: str,
+    refresh_token: str,
+    profile_id: int,
+    keys: list[dict[str, Any]],
+) -> NuvioSession:
+    async with httpx.AsyncClient(timeout=30.0, follow_redirects=False) as client:
+        session = await refresh_session(url, refresh_token, client=client)
+        for offset in range(0, len(keys), _PAGE_SIZE):
+            await _rpc(
+                client,
+                url,
+                session.access_token,
+                "sync_delete_watched_items",
+                {"p_profile_id": profile_id, "p_keys": keys[offset : offset + _PAGE_SIZE]},
+            )
+    return session

--- a/backend/core/nuvio.py
+++ b/backend/core/nuvio.py
@@ -221,23 +221,62 @@ async def pull_sync_data(
     return session, {"library": library, "watched": watched, "progress": progress}
 
 
+async def _push_sync_items(
+    url: str,
+    refresh_token: str,
+    profile_id: int,
+    watched_items: list[dict[str, Any]] | None = None,
+    progress_items: list[dict[str, Any]] | None = None,
+) -> NuvioSession:
+    async with httpx.AsyncClient(timeout=30.0, follow_redirects=False) as client:
+        session = await refresh_session(url, refresh_token, client=client)
+        for function_name, items_key, items in (
+            ("sync_push_watched_items", "p_items", watched_items or []),
+            ("sync_push_watch_progress", "p_entries", progress_items or []),
+        ):
+            for offset in range(0, len(items), _PAGE_SIZE):
+                await _rpc(
+                    client,
+                    url,
+                    session.access_token,
+                    function_name,
+                    {"p_profile_id": profile_id, items_key: items[offset : offset + _PAGE_SIZE]},
+                )
+    return session
+
+
 async def push_watched_items(
     url: str,
     refresh_token: str,
     profile_id: int,
     items: list[dict[str, Any]],
 ) -> NuvioSession:
-    async with httpx.AsyncClient(timeout=30.0, follow_redirects=False) as client:
-        session = await refresh_session(url, refresh_token, client=client)
-        for offset in range(0, len(items), _PAGE_SIZE):
-            await _rpc(
-                client,
-                url,
-                session.access_token,
-                "sync_push_watched_items",
-                {"p_profile_id": profile_id, "p_items": items[offset : offset + _PAGE_SIZE]},
-            )
-    return session
+    return await _push_sync_items(url, refresh_token, profile_id, watched_items=items)
+
+
+async def push_watch_progress(
+    url: str,
+    refresh_token: str,
+    profile_id: int,
+    items: list[dict[str, Any]],
+) -> NuvioSession:
+    return await _push_sync_items(url, refresh_token, profile_id, progress_items=items)
+
+
+async def push_sync_items(
+    url: str,
+    refresh_token: str,
+    profile_id: int,
+    watched_items: list[dict[str, Any]],
+    progress_items: list[dict[str, Any]],
+) -> NuvioSession:
+    return await _push_sync_items(
+        url,
+        refresh_token,
+        profile_id,
+        watched_items=watched_items,
+        progress_items=progress_items,
+    )
 
 
 async def delete_watched_items(

--- a/backend/core/tmdb.py
+++ b/backend/core/tmdb.py
@@ -52,7 +52,7 @@ async def validate_api_key(api_key: str) -> bool:
 
 
 async def get_movie(tmdb_id: int, api_key: str = None, language: str | None = None) -> dict:
-    params: dict = {"append_to_response": "credits,release_dates,recommendations"}
+    params: dict = {"append_to_response": "credits,release_dates,recommendations,external_ids"}
     if language:
         params["language"] = language
     return await _get(

--- a/backend/core/trakt.py
+++ b/backend/core/trakt.py
@@ -16,6 +16,35 @@ logger = logging.getLogger(__name__)
 
 TRAKT_BASE = "https://api.trakt.tv"
 TIMEOUT = 30.0
+PAGE_SIZE = 100
+
+
+async def _get_all_pages(
+    client: httpx.AsyncClient,
+    path: str,
+    headers: dict,
+) -> list[dict]:
+    items: list[dict] = []
+    page = 1
+    while True:
+        response = await client.get(
+            f"{TRAKT_BASE}{path}",
+            headers=headers,
+            params={"page": page, "limit": PAGE_SIZE},
+        )
+        response.raise_for_status()
+        page_items = response.json()
+        if not isinstance(page_items, list):
+            raise TypeError(f"Trakt {path} returned a non-list response")
+        items.extend(page_items)
+
+        try:
+            page_count = int(response.headers.get("X-Pagination-Page-Count", page))
+        except (TypeError, ValueError):
+            page_count = page
+        if page >= page_count or not page_items:
+            return items
+        page += 1
 
 
 def _headers(client_id: str, access_token: Optional[str] = None) -> dict:
@@ -127,12 +156,11 @@ async def get_watched_movies(client_id: str, access_token: str) -> list[dict]:
     Returns list of: {plays, last_watched_at, movie: {title, ids: {tmdb, ...}}}
     """
     async with httpx.AsyncClient(timeout=60.0) as client:
-        resp = await client.get(
-            f"{TRAKT_BASE}/sync/watched/movies",
-            headers=_headers(client_id, access_token),
+        return await _get_all_pages(
+            client,
+            "/sync/watched/movies",
+            _headers(client_id, access_token),
         )
-        resp.raise_for_status()
-        return resp.json()
 
 
 async def get_watched_shows(client_id: str, access_token: str) -> list[dict]:
@@ -141,12 +169,11 @@ async def get_watched_shows(client_id: str, access_token: str) -> list[dict]:
     Returns list of: {show: {title, ids: {tmdb, ...}}, seasons: [{number, episodes: [{number, plays, last_watched_at}]}]}
     """
     async with httpx.AsyncClient(timeout=120.0) as client:
-        resp = await client.get(
-            f"{TRAKT_BASE}/sync/watched/shows",
-            headers=_headers(client_id, access_token),
+        return await _get_all_pages(
+            client,
+            "/sync/watched/shows",
+            _headers(client_id, access_token),
         )
-        resp.raise_for_status()
-        return resp.json()
 
 
 async def get_ratings(client_id: str, access_token: str) -> dict:

--- a/backend/core/trakt.py
+++ b/backend/core/trakt.py
@@ -23,14 +23,17 @@ async def _get_all_pages(
     client: httpx.AsyncClient,
     path: str,
     headers: dict,
+    extra_params: dict[str, str] | None = None,
 ) -> list[dict]:
     items: list[dict] = []
     page = 1
     while True:
+        params = dict(extra_params or {})
+        params.update({"page": page, "limit": PAGE_SIZE})
         response = await client.get(
             f"{TRAKT_BASE}{path}",
             headers=headers,
-            params={"page": page, "limit": PAGE_SIZE},
+            params=params,
         )
         response.raise_for_status()
         page_items = response.json()
@@ -38,11 +41,13 @@ async def _get_all_pages(
             raise TypeError(f"Trakt {path} returned a non-list response")
         items.extend(page_items)
 
+        if not page_items:
+            return items
         try:
-            page_count = int(response.headers.get("X-Pagination-Page-Count", page))
-        except (TypeError, ValueError):
-            page_count = page
-        if page >= page_count or not page_items:
+            page_count = int(response.headers["X-Pagination-Page-Count"])
+        except (KeyError, TypeError, ValueError):
+            page_count = None
+        if page_count is not None and page >= page_count:
             return items
         page += 1
 
@@ -173,6 +178,7 @@ async def get_watched_shows(client_id: str, access_token: str) -> list[dict]:
             client,
             "/sync/watched/shows",
             _headers(client_id, access_token),
+            extra_params={"extended": "progress"},
         )
 
 

--- a/backend/core/trakt.py
+++ b/backend/core/trakt.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 TRAKT_BASE = "https://api.trakt.tv"
 TIMEOUT = 30.0
-PAGE_SIZE = 100
+PAGE_SIZE = 250
 
 
 async def _get_all_pages(

--- a/backend/main.py
+++ b/backend/main.py
@@ -22,13 +22,13 @@ from models.playback_session import PlaybackSession
 async def _auto_sync_scheduler():
     from db import async_sessionmaker
     from models.connections import MediaServerConnection
-    from routers.sync import run_jellyfin_sync, run_emby_sync, run_plex_sync
+    from routers.sync import run_jellyfin_sync, run_emby_sync, run_plex_sync, run_nuvio_sync
     from datetime import datetime, timezone
 
     CHECK_INTERVAL = 300  # seconds between scheduler ticks
 
-    source_map = {"jellyfin": CollectionSource.jellyfin, "emby": CollectionSource.emby, "plex": CollectionSource.plex}
-    runner_map = {"jellyfin": run_jellyfin_sync, "emby": run_emby_sync, "plex": run_plex_sync}
+    source_map = {"jellyfin": CollectionSource.jellyfin, "emby": CollectionSource.emby, "plex": CollectionSource.plex, "nuvio": CollectionSource.nuvio}
+    runner_map = {"jellyfin": run_jellyfin_sync, "emby": run_emby_sync, "plex": run_plex_sync, "nuvio": run_nuvio_sync}
 
     while True:
         await asyncio.sleep(CHECK_INTERVAL)
@@ -51,11 +51,12 @@ async def _auto_sync_scheduler():
                     if not source or not run_fn:
                         continue
 
-                    # Skip if a sync is already pending or running for this user+source
+                    # Skip if a sync is already pending or running for this connection
                     active_q = await db.execute(
                         select(SyncJob).where(
                             SyncJob.user_id == user_id,
                             SyncJob.source == source,
+                            SyncJob.connection_id == conn.id,
                             SyncJob.status.in_([SyncStatus.pending, SyncStatus.running]),
                         )
                     )
@@ -67,6 +68,7 @@ async def _auto_sync_scheduler():
                         select(SyncJob).where(
                             SyncJob.user_id == user_id,
                             SyncJob.source == source,
+                            SyncJob.connection_id == conn.id,
                             SyncJob.status.in_([SyncStatus.completed, SyncStatus.failed]),
                         ).order_by(SyncJob.updated_at.desc()).limit(1)
                     )
@@ -77,7 +79,7 @@ async def _auto_sync_scheduler():
                         if elapsed_hours < conn.auto_sync_interval:
                             continue
 
-                    job = SyncJob(user_id=user_id, source=source, status=SyncStatus.pending)
+                    job = SyncJob(user_id=user_id, source=source, status=SyncStatus.pending, connection_id=conn.id)
                     db.add(job)
                     await db.flush()
                     job_id = job.id

--- a/backend/migrations/versions/s3t4u5v6w7x8_add_nuvio_provider.py
+++ b/backend/migrations/versions/s3t4u5v6w7x8_add_nuvio_provider.py
@@ -1,7 +1,7 @@
 """add Nuvio provider
 
 Revision ID: s3t4u5v6w7x8
-Revises: m7n8o9p0q1r2, r2s3t4u5v6w7
+Revises: r2s3t4u5v6w7
 Create Date: 2026-07-14
 """
 
@@ -9,7 +9,7 @@ from alembic import op
 
 
 revision = "s3t4u5v6w7x8"
-down_revision = ("m7n8o9p0q1r2", "r2s3t4u5v6w7")
+down_revision = "r2s3t4u5v6w7"
 branch_labels = None
 depends_on = None
 

--- a/backend/migrations/versions/s3t4u5v6w7x8_add_nuvio_provider.py
+++ b/backend/migrations/versions/s3t4u5v6w7x8_add_nuvio_provider.py
@@ -1,0 +1,30 @@
+"""add Nuvio provider
+
+Revision ID: s3t4u5v6w7x8
+Revises: m7n8o9p0q1r2, r2s3t4u5v6w7
+Create Date: 2026-07-14
+"""
+
+from alembic import op
+
+
+revision = "s3t4u5v6w7x8"
+down_revision = ("m7n8o9p0q1r2", "r2s3t4u5v6w7")
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TYPE collectionsource ADD VALUE IF NOT EXISTS 'nuvio'")
+    op.drop_constraint("ck_msc_type", "media_server_connections", type_="check")
+    op.create_check_constraint(
+        "ck_msc_type",
+        "media_server_connections",
+        "type IN ('plex', 'jellyfin', 'emby', 'nuvio')",
+    )
+
+
+def downgrade() -> None:
+    # PostgreSQL enum values cannot be removed safely in-place. Keep the value and
+    # the compatible constraint; older application versions simply do not create it.
+    pass

--- a/backend/migrations/versions/t4u5v6w7x8y9_allow_subhour_sync_intervals.py
+++ b/backend/migrations/versions/t4u5v6w7x8y9_allow_subhour_sync_intervals.py
@@ -1,0 +1,37 @@
+"""allow sub-hour connection sync intervals
+
+Revision ID: t4u5v6w7x8y9
+Revises: s3t4u5v6w7x8
+Create Date: 2026-07-14
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "t4u5v6w7x8y9"
+down_revision: Union[str, Sequence[str], None] = "s3t4u5v6w7x8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "media_server_connections",
+        "auto_sync_interval",
+        existing_type=sa.Integer(),
+        type_=sa.Float(),
+        existing_nullable=True,
+        postgresql_using="auto_sync_interval::double precision",
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "media_server_connections",
+        "auto_sync_interval",
+        existing_type=sa.Float(),
+        type_=sa.Integer(),
+        existing_nullable=True,
+        postgresql_using="GREATEST(1, ROUND(auto_sync_interval))::integer",
+    )

--- a/backend/migrations/versions/u5v6w7x8y9z0_add_push_playback.py
+++ b/backend/migrations/versions/u5v6w7x8y9z0_add_push_playback.py
@@ -1,0 +1,26 @@
+"""add outbound playback progress flag
+
+Revision ID: u5v6w7x8y9z0
+Revises: t4u5v6w7x8y9
+Create Date: 2026-07-14
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "u5v6w7x8y9z0"
+down_revision = "t4u5v6w7x8y9"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "media_server_connections",
+        sa.Column("push_playback", sa.Boolean(), nullable=False, server_default="false"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("media_server_connections", "push_playback")

--- a/backend/models/base.py
+++ b/backend/models/base.py
@@ -19,6 +19,7 @@ class CollectionSource(str, enum.Enum):
     jellyfin = "jellyfin"
     emby     = "emby"
     plex     = "plex"
+    nuvio    = "nuvio"
     trakt    = "trakt"
     simkl    = "simkl"
     manual   = "manual"

--- a/backend/models/connections.py
+++ b/backend/models/connections.py
@@ -28,6 +28,7 @@ class MediaServerConnection(Base):
 
     # Outbound push flags (Scrob → source)
     push_watched     : Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="false")
+    push_playback    : Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="false")
     push_ratings     : Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="false")
 
     # Auto sync interval in hours (null = disabled)

--- a/backend/models/connections.py
+++ b/backend/models/connections.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Optional
 
-from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, String, func
+from sqlalchemy import Boolean, DateTime, Float, ForeignKey, Integer, String, func
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -31,7 +31,7 @@ class MediaServerConnection(Base):
     push_ratings     : Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="false")
 
     # Auto sync interval in hours (null = disabled)
-    auto_sync_interval : Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    auto_sync_interval : Mapped[Optional[float]] = mapped_column(Float, nullable=True)
 
     # Plex watchlist → Radarr/Sonarr auto-request (Plex connections only)
     watchlist_to_radarr       : Mapped[bool]           = mapped_column(Boolean, nullable=False, default=False, server_default="false")

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -43,6 +43,28 @@ def _generate_api_key() -> str:
     return secrets.token_urlsafe(32)
 
 router = APIRouter()
+def _parse_nuvio_profile_id(value: str | None) -> int:
+    try:
+        profile_id = int(value or "")
+    except (TypeError, ValueError):
+        raise HTTPException(status_code=400, detail="Nuvio profile must be an integer from 1 to 6")
+    if profile_id < 1 or profile_id > 6:
+        raise HTTPException(status_code=400, detail="Nuvio profile must be an integer from 1 to 6")
+    return profile_id
+
+
+def _nuvio_profile_name(profiles: list[dict], profile_id: int) -> str:
+    for profile in profiles:
+        try:
+            matches = int(profile.get("profile_index", 0)) == profile_id
+        except (TypeError, ValueError):
+            continue
+        if matches:
+            name = str(profile.get("name") or "").strip()
+            return name or f"Profile {profile_id}"
+    return f"Profile {profile_id}"
+
+
 
 
 async def _registration_allowed(db: AsyncSession) -> bool:
@@ -418,23 +440,38 @@ async def create_connection(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    if body.type not in ("plex", "jellyfin", "emby"):
-        raise HTTPException(status_code=400, detail="type must be plex, jellyfin, or emby")
+    if body.type not in ("plex", "jellyfin", "emby", "nuvio"):
+        raise HTTPException(status_code=400, detail="type must be plex, jellyfin, emby, or nuvio")
     validated_url = await validate_service_url(body.url, f"{body.type.capitalize()} URL")
+    connection_token = body.token
+    server_user_id = body.server_user_id
+    server_username = body.server_username
+    if body.type == "nuvio":
+        from core import nuvio
+
+        profile_id = _parse_nuvio_profile_id(server_user_id)
+        try:
+            session, profiles = await nuvio.validate_connection(validated_url, connection_token, profile_id)
+        except nuvio.NuvioAPIError as exc:
+            raise HTTPException(status_code=400, detail=str(exc))
+        connection_token = session.refresh_token
+        server_user_id = str(profile_id)
+        server_username = _nuvio_profile_name(profiles, profile_id)
+
     conn = MediaServerConnection(
         user_id=current_user.id,
         type=body.type,
         name=body.name,
         url=validated_url,
-        token=body.token,
-        server_user_id=body.server_user_id,
-        server_username=body.server_username,
+        token=connection_token,
+        server_user_id=server_user_id,
+        server_username=server_username,
         sync_collection=body.sync_collection,
         sync_watched=body.sync_watched,
-        sync_ratings=body.sync_ratings,
+        sync_ratings=body.sync_ratings if body.type != "nuvio" else False,
         sync_playback=body.sync_playback,
         push_watched=body.push_watched,
-        push_ratings=body.push_ratings,
+        push_ratings=body.push_ratings if body.type != "nuvio" else False,
         auto_sync_interval=body.auto_sync_interval,
     )
     db.add(conn)
@@ -463,6 +500,22 @@ async def update_connection(
     update_data = body.model_dump(exclude_unset=True)
     if "url" in update_data and update_data["url"]:
         update_data["url"] = await validate_service_url(update_data["url"], f"{conn.type.capitalize()} URL")
+
+    if conn.type == "nuvio":
+        from core import nuvio
+
+        candidate_url = update_data.get("url", conn.url)
+        candidate_token = update_data.get("token", conn.token)
+        profile_id = _parse_nuvio_profile_id(update_data.get("server_user_id", conn.server_user_id))
+        try:
+            session, profiles = await nuvio.validate_connection(candidate_url, candidate_token, profile_id)
+        except nuvio.NuvioAPIError as exc:
+            raise HTTPException(status_code=400, detail=str(exc))
+        update_data["token"] = session.refresh_token
+        update_data["server_user_id"] = str(profile_id)
+        update_data["server_username"] = _nuvio_profile_name(profiles, profile_id)
+        update_data["sync_ratings"] = False
+        update_data["push_ratings"] = False
 
     for field, value in update_data.items():
         setattr(conn, field, value)
@@ -668,6 +721,46 @@ async def test_plex(
         raise HTTPException(status_code=400, detail="Failed to connect to Plex")
     return {"status": "ok"}
 
+
+@router.post("/nuvio-login")
+async def login_nuvio(
+    body: schemas.NuvioLoginRequest,
+    current_user: User = Depends(get_current_user),
+):
+    from core import nuvio
+
+    url = await validate_service_url(body.url, "Nuvio URL")
+    try:
+        session, profiles = await nuvio.authenticate(url, body.email, body.password)
+    except nuvio.NuvioAPIError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    return {
+        "url": url,
+        "refresh_token": session.refresh_token,
+        "profiles": profiles,
+    }
+
+
+@router.post("/test-nuvio")
+async def test_nuvio(
+    body: schemas.NuvioConnectionTestRequest,
+    current_user: User = Depends(get_current_user),
+):
+    from core import nuvio
+
+    url = await validate_service_url(body.url, "Nuvio URL")
+    profile_id = _parse_nuvio_profile_id(str(body.profile_id))
+    try:
+        session, profiles = await nuvio.validate_connection(url, body.token, profile_id)
+    except nuvio.NuvioAPIError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    return {
+        "status": "ok",
+        "message": "Nuvio connection is valid.",
+        "refresh_token": session.refresh_token,
+        "profiles": profiles,
+    }
+
 @router.post("/test-radarr")
 async def test_radarr(
     url: str = Query(...),
@@ -776,15 +869,34 @@ async def get_connection_status(
         return {"configured": True, "connected": connected}
 
     async def check_media_server(conn):
-        from core import jellyfin, plex
+        from core import jellyfin, nuvio, plex
+
         try:
             if conn.type == "plex":
                 connected = await plex.validate_connection(conn.url, conn.token)
+            elif conn.type == "nuvio":
+                profile_id = _parse_nuvio_profile_id(conn.server_user_id)
+                session, profiles = await nuvio.validate_connection(conn.url, conn.token, profile_id)
+                conn.token = session.refresh_token
+                conn.server_username = _nuvio_profile_name(profiles, profile_id)
+                connected = True
             else:
                 connected = await jellyfin.validate_connection(conn.url, conn.token, conn.server_user_id)
         except Exception:
             connected = False
-        return {"id": conn.id, "connected": connected}
+        result = {"id": conn.id, "connected": connected}
+        if conn.type == "nuvio" and connected:
+            result["token"] = conn.token
+            result["profile_name"] = conn.server_username
+            result["profiles"] = [
+                {
+                    "profile_index": profile.get("profile_index"),
+                    "name": str(profile.get("name") or "").strip()
+                    or f"Profile {profile.get('profile_index')}",
+                }
+                for profile in profiles
+            ]
+        return result
 
     async def check_simkl():
         from core import simkl as simkl_client
@@ -797,6 +909,8 @@ async def get_connection_status(
     rdr_status, snr_status, trakt_status, simkl_status, *ms_statuses = await asyncio.gather(
         check_radarr(), check_sonarr(), check_trakt(), check_simkl(), *media_server_tasks
     )
+    if any(conn.type == "nuvio" for conn in media_server_conns):
+        await db.commit()
 
     return {"radarr": rdr_status, "sonarr": snr_status, "trakt": trakt_status, "simkl": simkl_status, "connections": ms_statuses}
 

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -471,6 +471,7 @@ async def create_connection(
         sync_ratings=body.sync_ratings if body.type != "nuvio" else False,
         sync_playback=body.sync_playback,
         push_watched=body.push_watched,
+        push_playback=body.push_playback if body.type == "nuvio" else False,
         push_ratings=body.push_ratings if body.type != "nuvio" else False,
         auto_sync_interval=body.auto_sync_interval,
     )
@@ -516,6 +517,9 @@ async def update_connection(
         update_data["server_username"] = _nuvio_profile_name(profiles, profile_id)
         update_data["sync_ratings"] = False
         update_data["push_ratings"] = False
+        update_data["push_playback"] = update_data.get("push_playback", conn.push_playback)
+    else:
+        update_data["push_playback"] = False
 
     for field, value in update_data.items():
         setattr(conn, field, value)

--- a/backend/routers/history.py
+++ b/backend/routers/history.py
@@ -144,6 +144,10 @@ async def _push_watch_state(
         if show_ids:
             show_result = await db.execute(select(Show).where(Show.id.in_(show_ids)))
             shows_by_id = {show.id: show for show in show_result.scalars().all()}
+        from routers.sync import _ensure_nuvio_imdb_ids, _nuvio_watched_item
+
+        api_key = await get_user_tmdb_key(db, user_id)
+        await _ensure_nuvio_imdb_ids(media_items, shows_by_id, api_key)
 
         watched_at_by_media: dict[int, datetime] = {}
         if watched:
@@ -162,45 +166,19 @@ async def _push_watch_state(
         nuvio_items: list[dict] = []
         nuvio_keys: list[dict] = []
         for media in media_items:
-            if media.media_type == MediaType.movie and media.tmdb_id:
-                key = {"content_id": f"tmdb:{media.tmdb_id}"}
-                payload = {
-                    **key,
-                    "content_type": "movie",
-                    "title": media.title,
-                }
-            elif (
-                media.media_type == MediaType.episode
-                and media.show_id is not None
-                and media.season_number is not None
-                and media.episode_number is not None
-            ):
-                show = shows_by_id.get(media.show_id)
-                if not show or not show.tmdb_id:
-                    continue
-                key = {
-                    "content_id": f"tmdb:{show.tmdb_id}",
-                    "season": media.season_number,
-                    "episode": media.episode_number,
-                }
-                payload = {
-                    **key,
-                    "content_type": "series",
-                    "title": media.title,
-                }
-            elif media.media_type == MediaType.series and media.tmdb_id:
-                key = {"content_id": f"tmdb:{media.tmdb_id}"}
-                payload = {
-                    **key,
-                    "content_type": "series",
-                    "title": media.title,
-                }
-            else:
+            payload = _nuvio_watched_item(
+                media,
+                watched_at_by_media.get(media.id, datetime.utcnow()),
+                shows_by_id.get(media.show_id),
+            )
+            if not payload:
                 continue
-
+            key = {
+                field: payload[field]
+                for field in ("content_id", "season", "episode")
+                if field in payload
+            }
             if watched:
-                watched_at = watched_at_by_media.get(media.id, datetime.utcnow())
-                payload["watched_at"] = int(watched_at.replace(tzinfo=timezone.utc).timestamp() * 1000)
                 nuvio_items.append(payload)
             else:
                 nuvio_keys.append(key)

--- a/backend/routers/history.py
+++ b/backend/routers/history.py
@@ -1,5 +1,5 @@
 import asyncio
-from datetime import datetime
+from datetime import datetime, timezone
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import and_, or_, select, desc, func, delete
@@ -23,6 +23,7 @@ import core.plex as plex_client
 import core.jellyfin as jellyfin_client
 import core.emby as emby_client
 import core.trakt as trakt_client
+import core.nuvio as nuvio_client
 
 router = APIRouter()
 
@@ -133,6 +134,96 @@ async def _push_watch_state(
 
     if tasks:
         await asyncio.gather(*tasks, return_exceptions=True)
+
+    nuvio_connections = [conn for conn in connections if conn.type == "nuvio"]
+    if nuvio_connections:
+        media_result = await db.execute(select(Media).where(Media.id.in_(media_ids)))
+        media_items = media_result.scalars().all()
+        show_ids = {media.show_id for media in media_items if media.show_id is not None}
+        shows_by_id: dict[int, Show] = {}
+        if show_ids:
+            show_result = await db.execute(select(Show).where(Show.id.in_(show_ids)))
+            shows_by_id = {show.id: show for show in show_result.scalars().all()}
+
+        watched_at_by_media: dict[int, datetime] = {}
+        if watched:
+            event_result = await db.execute(
+                select(WatchEvent.media_id, WatchEvent.watched_at)
+                .where(
+                    WatchEvent.user_id == user_id,
+                    WatchEvent.media_id.in_(media_ids),
+                    WatchEvent.completed == True,
+                )
+                .order_by(WatchEvent.watched_at.desc())
+            )
+            for media_id, watched_at in event_result.all():
+                watched_at_by_media.setdefault(media_id, watched_at)
+
+        nuvio_items: list[dict] = []
+        nuvio_keys: list[dict] = []
+        for media in media_items:
+            if media.media_type == MediaType.movie and media.tmdb_id:
+                key = {"content_id": f"tmdb:{media.tmdb_id}"}
+                payload = {
+                    **key,
+                    "content_type": "movie",
+                    "title": media.title,
+                }
+            elif (
+                media.media_type == MediaType.episode
+                and media.show_id is not None
+                and media.season_number is not None
+                and media.episode_number is not None
+            ):
+                show = shows_by_id.get(media.show_id)
+                if not show or not show.tmdb_id:
+                    continue
+                key = {
+                    "content_id": f"tmdb:{show.tmdb_id}",
+                    "season": media.season_number,
+                    "episode": media.episode_number,
+                }
+                payload = {
+                    **key,
+                    "content_type": "series",
+                    "title": media.title,
+                }
+            elif media.media_type == MediaType.series and media.tmdb_id:
+                key = {"content_id": f"tmdb:{media.tmdb_id}"}
+                payload = {
+                    **key,
+                    "content_type": "series",
+                    "title": media.title,
+                }
+            else:
+                continue
+
+            if watched:
+                watched_at = watched_at_by_media.get(media.id, datetime.utcnow())
+                payload["watched_at"] = int(watched_at.replace(tzinfo=timezone.utc).timestamp() * 1000)
+                nuvio_items.append(payload)
+            else:
+                nuvio_keys.append(key)
+
+        for conn in nuvio_connections:
+            try:
+                profile_id = int(conn.server_user_id or "")
+                if profile_id < 1 or profile_id > 6:
+                    continue
+                if watched and nuvio_items:
+                    session = await nuvio_client.push_watched_items(
+                        conn.url, conn.token, profile_id, nuvio_items
+                    )
+                elif not watched and nuvio_keys:
+                    session = await nuvio_client.delete_watched_items(
+                        conn.url, conn.token, profile_id, nuvio_keys
+                    )
+                else:
+                    continue
+                conn.token = session.refresh_token
+            except Exception:
+                continue
+        await db.commit()
 
 
 def format_event(event: WatchEvent | PlaybackProgress, media: Media) -> dict:

--- a/backend/routers/media.py
+++ b/backend/routers/media.py
@@ -12,7 +12,7 @@ from fastapi import APIRouter, Depends, Query, HTTPException, Request
 from fastapi.responses import StreamingResponse, Response
 from starlette.background import BackgroundTask
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy import select, or_, and_, func, cast as sa_cast, Text
+from sqlalchemy import select, or_, and_, delete, func, cast as sa_cast, Text
 from sqlalchemy.orm import joinedload
 
 from db import get_db, AsyncSessionLocal

--- a/backend/routers/shows.py
+++ b/backend/routers/shows.py
@@ -81,9 +81,10 @@ async def list_shows(
 ):
     offset = (page - 1) * page_size
 
-    # A show is "in the user's collection" if they have at least one countable episode
-    # collected — same criteria used by enrich_with_state for the percentage calculation.
-    user_show_ids = (
+    # A show is in the user's collection when either the series itself is
+    # collected (cloud/watchlist providers) or at least one countable episode
+    # is collected (media-server libraries).
+    episode_show_ids = (
         select(Media.show_id)
         .join(Collection, Collection.media_id == Media.id)
         .where(
@@ -97,8 +98,24 @@ async def list_shows(
         .distinct()
         .subquery()
     )
+    direct_series_tmdb_ids = (
+        select(Media.tmdb_id)
+        .join(Collection, Collection.media_id == Media.id)
+        .where(
+            Collection.user_id == current_user.id,
+            Media.media_type == MediaType.series,
+            Media.tmdb_id.isnot(None),
+        )
+        .distinct()
+        .subquery()
+    )
 
-    base_query = select(ShowModel).where(ShowModel.id.in_(select(user_show_ids)))
+    base_query = select(ShowModel).where(
+        or_(
+            ShowModel.id.in_(select(episode_show_ids)),
+            ShowModel.tmdb_id.in_(select(direct_series_tmdb_ids)),
+        )
+    )
     if genre:
         base_query = base_query.where(sa_cast(ShowModel.tmdb_data["genres"], Text).contains(f'"{genre}"'))
     if year:

--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -302,10 +302,112 @@ def _nuvio_profile_id(conn: MediaServerConnection) -> int:
     return profile_id
 
 
+def _nuvio_imdb_id(entity: Media | Show | None) -> str | None:
+    if entity is None:
+        return None
+    data = entity.tmdb_data or {}
+    value = data.get("imdb_id") or (data.get("external_ids") or {}).get("imdb_id")
+    imdb_id = str(value or "").strip()
+    return imdb_id if imdb_id.startswith("tt") and imdb_id[2:].isdigit() else None
+
+
+async def _ensure_nuvio_imdb_ids(
+    media_rows: list[Media],
+    shows_by_id: dict[int, Show],
+    api_key: str | None,
+) -> None:
+    if not api_key:
+        return
+
+    targets: dict[tuple[str, int], Media | Show] = {}
+    for media in media_rows:
+        if media.media_type == MediaType.episode:
+            show = shows_by_id.get(media.show_id)
+            if show and show.tmdb_id and not _nuvio_imdb_id(show):
+                targets[("tv", show.tmdb_id)] = show
+        elif media.tmdb_id and not _nuvio_imdb_id(media):
+            target_type = "movie" if media.media_type == MediaType.movie else "tv"
+            targets[(target_type, media.tmdb_id)] = media
+    if not targets:
+        return
+
+    semaphore = asyncio.Semaphore(TMDB_CONCURRENCY)
+
+    async def fetch_imdb_id(target_type: str, tmdb_id: int, entity: Media | Show) -> None:
+        async with semaphore:
+            try:
+                external_ids = await tmdb.get_external_ids(tmdb_id, target_type, api_key=api_key)
+            except Exception as exc:
+                logger.warning(
+                    "Failed to resolve outbound Nuvio IMDb ID for TMDB %s (%s): %s",
+                    tmdb_id,
+                    target_type,
+                    exc,
+                )
+                return
+        imdb_id = str(external_ids.get("imdb_id") or "").strip()
+        if not (imdb_id.startswith("tt") and imdb_id[2:].isdigit()):
+            return
+        tmdb_data = dict(entity.tmdb_data or {})
+        stored_external_ids = dict(tmdb_data.get("external_ids") or {})
+        stored_external_ids["imdb_id"] = imdb_id
+        tmdb_data["external_ids"] = stored_external_ids
+        entity.tmdb_data = tmdb_data
+
+    await asyncio.gather(
+        *[
+            fetch_imdb_id(target_type, tmdb_id, entity)
+            for (target_type, tmdb_id), entity in targets.items()
+        ]
+    )
+    logger.info("Resolved %s outbound Nuvio IMDb identifiers through TMDB", len(targets))
+
+
+def _nuvio_watched_item(
+    media: Media,
+    watched_at: datetime,
+    show: Show | None = None,
+) -> dict | None:
+    if watched_at.tzinfo is None:
+        watched_at = watched_at.replace(tzinfo=timezone.utc)
+    watched_epoch_ms = int(watched_at.timestamp() * 1000)
+
+    if media.media_type == MediaType.movie and (content_id := _nuvio_imdb_id(media)):
+        return {
+            "content_id": content_id,
+            "content_type": "movie",
+            "title": media.title,
+            "watched_at": watched_epoch_ms,
+        }
+    if (
+        media.media_type == MediaType.episode
+        and (content_id := _nuvio_imdb_id(show))
+        and media.season_number is not None
+        and media.episode_number is not None
+    ):
+        return {
+            "content_id": content_id,
+            "content_type": "series",
+            "title": media.title,
+            "season": media.season_number,
+            "episode": media.episode_number,
+            "watched_at": watched_epoch_ms,
+        }
+    if media.media_type == MediaType.series and (content_id := _nuvio_imdb_id(media)):
+        return {
+            "content_id": content_id,
+            "content_type": "series",
+            "title": media.title,
+            "watched_at": watched_epoch_ms,
+        }
+    return None
+
+
 async def _build_nuvio_watched_items(
     db: AsyncSession,
     user_id: int,
     media_ids: set[int] | None = None,
+    api_key: str | None = None,
 ) -> list[dict]:
     event_query = (
         select(WatchEvent.media_id, WatchEvent.watched_at)
@@ -338,40 +440,100 @@ async def _build_nuvio_watched_items(
         )
         shows_by_id = {show.id: show for show in shows}
 
+    await _ensure_nuvio_imdb_ids(media_rows, shows_by_id, api_key)
     items: list[dict] = []
     for media in media_rows:
-        watched_at = latest_watched_at[media.id]
-        watched_epoch_ms = int(watched_at.replace(tzinfo=timezone.utc).timestamp() * 1000)
-        if media.media_type == MediaType.movie and media.tmdb_id:
-            items.append({
-                "content_id": f"tmdb:{media.tmdb_id}",
-                "content_type": "movie",
-                "title": media.title,
-                "watched_at": watched_epoch_ms,
-            })
-        elif (
-            media.media_type == MediaType.episode
-            and media.show_id is not None
-            and media.season_number is not None
-            and media.episode_number is not None
-        ):
-            show = shows_by_id.get(media.show_id)
-            if show and show.tmdb_id:
-                items.append({
-                    "content_id": f"tmdb:{show.tmdb_id}",
-                    "content_type": "series",
-                    "title": media.title,
-                    "season": media.season_number,
-                    "episode": media.episode_number,
-                    "watched_at": watched_epoch_ms,
-                })
-        elif media.media_type == MediaType.series and media.tmdb_id:
-            items.append({
-                "content_id": f"tmdb:{media.tmdb_id}",
-                "content_type": "series",
-                "title": media.title,
-                "watched_at": watched_epoch_ms,
-            })
+        item = _nuvio_watched_item(
+            media,
+            latest_watched_at[media.id],
+            shows_by_id.get(media.show_id),
+        )
+        if item:
+            items.append(item)
+    return items
+
+
+def _nuvio_progress_item(
+    progress: PlaybackProgress,
+    media: Media,
+    show: Show | None = None,
+) -> dict | None:
+    try:
+        progress_seconds = max(0, int(progress.progress_seconds))
+        progress_percent = float(progress.progress_percent)
+    except (TypeError, ValueError):
+        return None
+    if progress_seconds <= 0 or progress_percent <= 0:
+        return None
+
+    position_ms = progress_seconds * 1000
+    if media.runtime and media.runtime > 0:
+        duration_ms = media.runtime * 60_000
+    else:
+        duration_ms = round(position_ms / min(progress_percent, 1.0))
+    duration_ms = max(position_ms, duration_ms)
+
+    updated_at = progress.updated_at
+    if updated_at.tzinfo is None:
+        updated_at = updated_at.replace(tzinfo=timezone.utc)
+    last_watched = int(updated_at.timestamp() * 1000)
+
+    if media.media_type == MediaType.movie and (content_id := _nuvio_imdb_id(media)):
+        return {
+            "content_id": content_id,
+            "content_type": "movie",
+            "video_id": content_id,
+            "position": position_ms,
+            "duration": duration_ms,
+            "last_watched": last_watched,
+        }
+    if (
+        media.media_type == MediaType.episode
+        and (content_id := _nuvio_imdb_id(show))
+        and media.season_number is not None
+        and media.episode_number is not None
+    ):
+        return {
+            "content_id": content_id,
+            "content_type": "series",
+            "video_id": f"{content_id}:{media.season_number}:{media.episode_number}",
+            "season": media.season_number,
+            "episode": media.episode_number,
+            "position": position_ms,
+            "duration": duration_ms,
+            "last_watched": last_watched,
+        }
+    return None
+
+
+async def _build_nuvio_progress_items(
+    db: AsyncSession,
+    user_id: int,
+    api_key: str | None = None,
+) -> list[dict]:
+    result = await db.execute(
+        select(PlaybackProgress, Media)
+        .join(Media, Media.id == PlaybackProgress.media_id)
+        .where(PlaybackProgress.user_id == user_id)
+        .order_by(Media.id)
+    )
+    rows = result.all()
+    show_ids = {
+        media.show_id
+        for _, media in rows
+        if media.media_type == MediaType.episode and media.show_id is not None
+    }
+    shows_by_id: dict[int, Show] = {}
+    if show_ids:
+        shows_result = await db.execute(select(Show).where(Show.id.in_(show_ids)))
+        shows_by_id = {show.id: show for show in shows_result.scalars().all()}
+    await _ensure_nuvio_imdb_ids([media for _, media in rows], shows_by_id, api_key)
+
+    items: list[dict] = []
+    for progress, media in rows:
+        item = _nuvio_progress_item(progress, media, shows_by_id.get(media.show_id))
+        if item:
+            items.append(item)
     return items
 
 
@@ -435,6 +597,11 @@ async def _fan_out_changes_to_other_connections(
                 return await coro
 
         nuvio_watched_items: list[dict] | None = None
+        nuvio_api_key = (
+            await _get_effective_tmdb_key(db, settings)
+            if any(conn.type == "nuvio" and conn.push_watched for conn in push_candidates)
+            else None
+        )
 
         async def _push_to_nuvio(conn: MediaServerConnection, items: list[dict]) -> bool:
             session = await nuvio.push_watched_items(
@@ -450,7 +617,12 @@ async def _fan_out_changes_to_other_connections(
             if conn.type == "nuvio":
                 if conn.push_watched:
                     if nuvio_watched_items is None:
-                        nuvio_watched_items = await _build_nuvio_watched_items(db, user_id, new_watched_ids)
+                        nuvio_watched_items = await _build_nuvio_watched_items(
+                            db,
+                            user_id,
+                            new_watched_ids,
+                            api_key=nuvio_api_key,
+                        )
                     if nuvio_watched_items:
                         push_tasks.append(_guarded(_push_to_nuvio(conn, nuvio_watched_items)))
                 continue
@@ -2583,24 +2755,35 @@ async def _run_full_push(user_id: int, connection_id: int, job_id: int) -> None:
                 return
 
             if conn.type == "nuvio":
+                settings_result = await db.execute(
+                    select(UserSettings).where(UserSettings.user_id == user_id)
+                )
+                user_settings = settings_result.scalar_one_or_none()
+                api_key = await _get_effective_tmdb_key(db, user_settings)
                 watched_items = (
-                    await _build_nuvio_watched_items(db, user_id)
+                    await _build_nuvio_watched_items(db, user_id, api_key=api_key)
                     if conn.push_watched
                     else []
                 )
-                total = len(watched_items)
+                progress_items = (
+                    await _build_nuvio_progress_items(db, user_id, api_key=api_key)
+                    if conn.push_playback
+                    else []
+                )
+                total = len(watched_items) + len(progress_items)
                 await db.execute(
                     update(SyncJob)
                     .where(SyncJob.id == job_id)
                     .values(total_items=total, processed_items=0)
                 )
                 await db.commit()
-                if watched_items:
-                    session = await nuvio.push_watched_items(
+                if watched_items or progress_items:
+                    session = await nuvio.push_sync_items(
                         conn.url,
                         conn.token,
                         _nuvio_profile_id(conn),
                         watched_items,
+                        progress_items,
                     )
                     conn.token = session.refresh_token
                 await db.execute(
@@ -2609,14 +2792,20 @@ async def _run_full_push(user_id: int, connection_id: int, job_id: int) -> None:
                     .values(
                         status=SyncStatus.completed,
                         processed_items=total,
-                        stats={"succeeded": total, "failed": 0},
+                        stats={
+                            "succeeded": total,
+                            "failed": 0,
+                            "watched": len(watched_items),
+                            "progress": len(progress_items),
+                        },
                     )
                 )
                 await db.commit()
                 logger.info(
-                    "Full Nuvio push for connection %s: %s watched items",
+                    "Full Nuvio push for connection %s: %s watched and %s progress items",
                     connection_id,
-                    total,
+                    len(watched_items),
+                    len(progress_items),
                 )
                 return
 

--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 import re
 from fastapi import APIRouter, Depends, Query, HTTPException, BackgroundTasks
 from pydantic import BaseModel
@@ -30,6 +31,8 @@ from core.enrichment import enrich_media
 from core.image_cache import pre_cache_all_collected_bg
 
 from dependencies import get_current_user
+logger = logging.getLogger("uvicorn.error")
+
 
 
 async def _get_effective_tmdb_key(db: AsyncSession, user_settings: UserSettings | None) -> str | None:
@@ -1890,13 +1893,18 @@ async def _resolve_nuvio_tmdb_ids(
                 if matches and matches[0].get("id") is not None:
                     resolved[content_id] = int(matches[0]["id"])
             except Exception as exc:
-                print(f"  Failed to resolve Nuvio IMDb ID {content_id} through TMDB: {exc}")
+                logger.warning(
+                    "Failed to resolve Nuvio IMDb ID %s through TMDB: %s",
+                    content_id,
+                    exc,
+                )
 
     if unresolved:
         await asyncio.gather(*(resolve_imdb_id(content_id) for content_id in sorted(unresolved)))
-        print(
-            f"  Resolved {len(unresolved & set(resolved))}/{len(unresolved)} "
-            "new Nuvio IMDb IDs through TMDB"
+        logger.info(
+            "Resolved %s/%s new Nuvio IMDb IDs through TMDB",
+            len(unresolved & set(resolved)),
+            len(unresolved),
         )
     return resolved
 
@@ -2071,7 +2079,7 @@ async def _run_nuvio_sync(
     show_limit: int,
     connection_id: int | None = None,
 ):
-    print(f"Starting Nuvio sync for user {user_id}, job {job_id}")
+    logger.info("Starting Nuvio sync for user %s, job %s", user_id, job_id)
     async_session = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
     async with async_session() as db:
         try:
@@ -2115,12 +2123,18 @@ async def _run_nuvio_sync(
             library_records = data["library"] if conn.sync_collection else []
             watched_records = data["watched"] if conn.sync_watched else []
             progress_records = data["progress"] if conn.sync_playback else []
-            print(
-                f"Nuvio profile {conn.server_username or f'#{profile_id}'} (index #{profile_id}): "
-                f"pulled {len(data['library'])} library, {len(data['watched'])} watched, "
-                f"and {len(data['progress'])} progress records; enabled for this sync: "
-                f"{len(library_records)} library, {len(watched_records)} watched, "
-                f"{len(progress_records)} progress"
+            logger.info(
+                "Nuvio profile %s (index #%s): pulled %s library, %s watched, "
+                "and %s progress records; enabled for this sync: %s library, "
+                "%s watched, %s progress",
+                conn.server_username or f"#{profile_id}",
+                profile_id,
+                len(data["library"]),
+                len(data["watched"]),
+                len(data["progress"]),
+                len(library_records),
+                len(watched_records),
+                len(progress_records),
             )
 
             all_nuvio_records = [*library_records, *watched_records, *progress_records]
@@ -2282,12 +2296,9 @@ async def _run_nuvio_sync(
             )
             await db.commit()
             asyncio.create_task(pre_cache_all_collected_bg())
-            print(f"Nuvio sync job {job_id} completed. Stats: {stats}")
+            logger.info("Nuvio sync job %s completed. Stats: %s", job_id, stats)
         except Exception as exc:
-            print(f"Nuvio sync job {job_id} failed: {exc}")
-            import traceback
-
-            traceback.print_exc()
+            logger.exception("Nuvio sync job %s failed", job_id)
             await db.rollback()
             await db.execute(
                 update(SyncJob)
@@ -2602,7 +2613,11 @@ async def _run_full_push(user_id: int, connection_id: int, job_id: int) -> None:
                     )
                 )
                 await db.commit()
-                print(f"Full Nuvio push for connection {connection_id}: {total} watched items")
+                logger.info(
+                    "Full Nuvio push for connection %s: %s watched items",
+                    connection_id,
+                    total,
+                )
                 return
 
             conn_source = CollectionSource(conn.type)

--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -17,13 +17,14 @@ from models.connections import MediaServerConnection
 from models.sync import SyncJob, SyncStatus
 from models.events import WatchEvent
 from models.ratings import Rating
+from models.playback_progress import PlaybackProgress
 from models.library_selections import JellyfinLibrarySelection, EmbyLibrarySelection, PlexLibrarySelection
 from models.season_override import ShowSeasonOverride
 from datetime import datetime, timezone
 from dateutil import parser
 from models.base import MediaType, CollectionSource
 from models.global_settings import GlobalSettings
-from core import jellyfin, emby, plex, tmdb
+from core import jellyfin, emby, plex, nuvio, tmdb
 import core.trakt as trakt_client
 from core.enrichment import enrich_media
 from core.image_cache import pre_cache_all_collected_bg
@@ -47,6 +48,7 @@ BATCH_SIZE = 500
 TMDB_CONCURRENCY = 5  # Max concurrent TMDB requests
 # asyncpg hard limit is 32767 parameters per query; stay well under it
 _MAX_IN_PARAMS = 30_000
+_MEDIA_BROWSER_ITEM_SOURCES = (CollectionSource.jellyfin, CollectionSource.emby, CollectionSource.nuvio)
 
 
 async def _select_in_chunks(db: AsyncSession, stmt_builder, ids: list):
@@ -64,7 +66,7 @@ async def _select_in_chunks(db: AsyncSession, stmt_builder, ids: list):
 def extract_watch_state(item: dict, source: CollectionSource) -> dict:
     state = {"completed": False, "last_played": None, "play_count": 0, "user_rating": None}
 
-    if source in (CollectionSource.jellyfin, CollectionSource.emby):
+    if source in _MEDIA_BROWSER_ITEM_SOURCES:
         user_data = item.get("UserData", {})
         state["completed"] = user_data.get("Played", False)
         state["play_count"] = user_data.get("PlayCount", 1 if state["completed"] else 0)
@@ -287,6 +289,89 @@ async def batch_enrich_items(
     return warnings
 
 
+def _nuvio_profile_id(conn: MediaServerConnection) -> int:
+    try:
+        profile_id = int(conn.server_user_id or "")
+    except ValueError:
+        raise RuntimeError("Invalid Nuvio profile index")
+    if profile_id < 1 or profile_id > 6:
+        raise RuntimeError("Invalid Nuvio profile index")
+    return profile_id
+
+
+async def _build_nuvio_watched_items(
+    db: AsyncSession,
+    user_id: int,
+    media_ids: set[int] | None = None,
+) -> list[dict]:
+    event_query = (
+        select(WatchEvent.media_id, WatchEvent.watched_at)
+        .where(WatchEvent.user_id == user_id, WatchEvent.completed == True)
+        .order_by(WatchEvent.watched_at.desc())
+    )
+    if media_ids is not None:
+        if not media_ids:
+            return []
+        event_query = event_query.where(WatchEvent.media_id.in_(media_ids))
+    event_result = await db.execute(event_query)
+    latest_watched_at: dict[int, datetime] = {}
+    for media_id, watched_at in event_result.all():
+        latest_watched_at.setdefault(media_id, watched_at)
+    if not latest_watched_at:
+        return []
+
+    media_rows = await _select_in_chunks(
+        db,
+        lambda chunk: select(Media).where(Media.id.in_(chunk)),
+        list(latest_watched_at),
+    )
+    show_ids = {media.show_id for media in media_rows if media.show_id is not None}
+    shows_by_id: dict[int, Show] = {}
+    if show_ids:
+        shows = await _select_in_chunks(
+            db,
+            lambda chunk: select(Show).where(Show.id.in_(chunk)),
+            list(show_ids),
+        )
+        shows_by_id = {show.id: show for show in shows}
+
+    items: list[dict] = []
+    for media in media_rows:
+        watched_at = latest_watched_at[media.id]
+        watched_epoch_ms = int(watched_at.replace(tzinfo=timezone.utc).timestamp() * 1000)
+        if media.media_type == MediaType.movie and media.tmdb_id:
+            items.append({
+                "content_id": f"tmdb:{media.tmdb_id}",
+                "content_type": "movie",
+                "title": media.title,
+                "watched_at": watched_epoch_ms,
+            })
+        elif (
+            media.media_type == MediaType.episode
+            and media.show_id is not None
+            and media.season_number is not None
+            and media.episode_number is not None
+        ):
+            show = shows_by_id.get(media.show_id)
+            if show and show.tmdb_id:
+                items.append({
+                    "content_id": f"tmdb:{show.tmdb_id}",
+                    "content_type": "series",
+                    "title": media.title,
+                    "season": media.season_number,
+                    "episode": media.episode_number,
+                    "watched_at": watched_epoch_ms,
+                })
+        elif media.media_type == MediaType.series and media.tmdb_id:
+            items.append({
+                "content_id": f"tmdb:{media.tmdb_id}",
+                "content_type": "series",
+                "title": media.title,
+                "watched_at": watched_epoch_ms,
+            })
+    return items
+
+
 async def _fan_out_changes_to_other_connections(
     db: AsyncSession,
     user_id: int,
@@ -346,7 +431,26 @@ async def _fan_out_changes_to_other_connections(
             async with sem:
                 return await coro
 
+        nuvio_watched_items: list[dict] | None = None
+
+        async def _push_to_nuvio(conn: MediaServerConnection, items: list[dict]) -> bool:
+            session = await nuvio.push_watched_items(
+                conn.url,
+                conn.token,
+                _nuvio_profile_id(conn),
+                items,
+            )
+            conn.token = session.refresh_token
+            return True
+
         for conn in push_candidates:
+            if conn.type == "nuvio":
+                if conn.push_watched:
+                    if nuvio_watched_items is None:
+                        nuvio_watched_items = await _build_nuvio_watched_items(db, user_id, new_watched_ids)
+                    if nuvio_watched_items:
+                        push_tasks.append(_guarded(_push_to_nuvio(conn, nuvio_watched_items)))
+                continue
             conn_source = CollectionSource(conn.type)
             if conn.push_watched:
                 for mid in new_watched_ids:
@@ -435,6 +539,8 @@ async def _fan_out_changes_to_other_connections(
         failed = sum(1 for r in results if isinstance(r, Exception))
         if failed:
             print(f"  {failed}/{len(push_tasks)} fan-out push tasks failed (non-fatal)")
+        if any(conn.type == "nuvio" for conn in push_candidates):
+            await db.commit()
 
 
 async def sync_items(
@@ -504,7 +610,7 @@ async def sync_items(
         for item in items:
             tid = (
                 get_jellyfin_tmdb_id(item.get("ProviderIds", {}))
-                if source in (CollectionSource.jellyfin, CollectionSource.emby)
+                if source in _MEDIA_BROWSER_ITEM_SOURCES
                 else plex.extract_tmdb_id(item.get("Guid", []))
             )
             if tid:
@@ -526,7 +632,7 @@ async def sync_items(
         for item in items:
             tid = (
                 get_jellyfin_tmdb_id(item.get("ProviderIds", {}))
-                if source in (CollectionSource.jellyfin, CollectionSource.emby)
+                if source in _MEDIA_BROWSER_ITEM_SOURCES
                 else plex.extract_tmdb_id(item.get("Guid", []))
             )
             if tid:
@@ -561,7 +667,7 @@ async def sync_items(
         new_media: Media | None = None
         try:
             async with db.begin_nested():
-                if source in (CollectionSource.jellyfin, CollectionSource.emby):
+                if source in _MEDIA_BROWSER_ITEM_SOURCES:
                     source_id = str(item.get("Id"))
                     quality = extract_jellyfin_quality(item)
                     tmdb_id = get_jellyfin_tmdb_id(item.get("ProviderIds", {}))
@@ -660,7 +766,7 @@ async def sync_items(
                                 and not (existing_media_obj.tmdb_data or {}).get("show_title")
                             ):
                                 _series_name = (
-                                    item.get("SeriesName") if source in (CollectionSource.jellyfin, CollectionSource.emby)
+                                    item.get("SeriesName") if source in _MEDIA_BROWSER_ITEM_SOURCES
                                     else item.get("grandparentTitle")
                                 )
                                 if _series_name:
@@ -736,7 +842,7 @@ async def sync_items(
                                 # Jellyfin hasn't finished fetching episode metadata yet).
                                 # Everything else (movies, episodes without show context) is skipped.
                                 series_name = (
-                                    item.get("SeriesName") if source in (CollectionSource.jellyfin, CollectionSource.emby)
+                                    item.get("SeriesName") if source in _MEDIA_BROWSER_ITEM_SOURCES
                                     else item.get("grandparentTitle")
                                 ) if media_type == MediaType.episode else None
 
@@ -823,7 +929,8 @@ async def sync_items(
                                 )
                                 coll_id = coll_result.scalar_one()
                                 existing_coll_by_media_id[media.id] = coll_id
-                                stats["movies" if media_type == MediaType.movie else "episodes"] += 1
+                                stat_key = "movies" if media_type == MediaType.movie else "series" if media_type == MediaType.series else "episodes"
+                                stats[stat_key] = stats.get(stat_key, 0) + 1
                             # else: collection already exists from another source — just add the file
                             db.add(CollectionFile(
                                 collection_id=coll_id,
@@ -914,7 +1021,7 @@ async def sync_items(
         series_title_map: dict[int, str] = {}
         if media_type == MediaType.episode:
             for item in items:
-                if source in (CollectionSource.jellyfin, CollectionSource.emby):
+                if source in _MEDIA_BROWSER_ITEM_SOURCES:
                     parent_id = str(item.get("SeriesId", ""))
                     title = item.get("SeriesName")
                 else:
@@ -1727,6 +1834,469 @@ async def _run_plex_sync(user_id: int, job_id: int, movie_limit: int, show_limit
             await db.commit()
 
 
+def _parse_nuvio_tmdb_id(content_id: object) -> int | None:
+    value = str(content_id or "")
+    if not value.startswith("tmdb:"):
+        return None
+    try:
+        return int(value[5:])
+    except ValueError:
+        return None
+
+
+async def _resolve_nuvio_tmdb_ids(
+    records: list[dict],
+    db: AsyncSession,
+    user_id: int,
+    api_key: str,
+) -> dict[str, int]:
+    content_types: dict[str, str] = {}
+    resolved: dict[str, int] = {}
+    for record in records:
+        content_id = str(record.get("content_id") or "").strip()
+        if not content_id:
+            continue
+        if tmdb_id := _parse_nuvio_tmdb_id(content_id):
+            resolved[content_id] = tmdb_id
+        elif re.fullmatch(r"tt\d+", content_id, flags=re.IGNORECASE):
+            content_types.setdefault(content_id, str(record.get("content_type") or "").lower())
+
+    unresolved = set(content_types) - set(resolved)
+    if unresolved:
+        existing_result = await db.execute(
+            select(CollectionFile.source_id, Media.tmdb_id)
+            .join(Collection, Collection.id == CollectionFile.collection_id)
+            .join(Media, Media.id == Collection.media_id)
+            .where(
+                Collection.user_id == user_id,
+                CollectionFile.source == CollectionSource.nuvio,
+                Media.tmdb_id.isnot(None),
+            )
+        )
+        for source_id, tmdb_id in existing_result.all():
+            parts = str(source_id).split(":")
+            if len(parts) >= 2 and parts[1] in unresolved:
+                resolved[parts[1]] = int(tmdb_id)
+        unresolved -= set(resolved)
+
+    semaphore = asyncio.Semaphore(TMDB_CONCURRENCY)
+
+    async def resolve_imdb_id(content_id: str) -> None:
+        async with semaphore:
+            try:
+                result = await tmdb.find_by_external_id(content_id, "imdb_id", api_key=api_key)
+                result_key = "movie_results" if content_types[content_id] == "movie" else "tv_results"
+                matches = result.get(result_key) or []
+                if matches and matches[0].get("id") is not None:
+                    resolved[content_id] = int(matches[0]["id"])
+            except Exception as exc:
+                print(f"  Failed to resolve Nuvio IMDb ID {content_id} through TMDB: {exc}")
+
+    if unresolved:
+        await asyncio.gather(*(resolve_imdb_id(content_id) for content_id in sorted(unresolved)))
+        print(
+            f"  Resolved {len(unresolved & set(resolved))}/{len(unresolved)} "
+            "new Nuvio IMDb IDs through TMDB"
+        )
+    return resolved
+
+
+def _nuvio_datetime(epoch_ms: object) -> datetime | None:
+    try:
+        return datetime.fromtimestamp(int(epoch_ms) / 1000, tz=timezone.utc).replace(tzinfo=None)
+    except (TypeError, ValueError, OSError, OverflowError):
+        return None
+
+
+def _normalize_nuvio_item(
+    record: dict,
+    profile_id: int,
+    watched: bool = False,
+    tmdb_id: int | None = None,
+) -> tuple[MediaType, dict] | None:
+    tmdb_id = tmdb_id or _parse_nuvio_tmdb_id(record.get("content_id"))
+    if tmdb_id is None:
+        return None
+
+    content_type = str(record.get("content_type") or "").lower()
+    season = record.get("season")
+    episode = record.get("episode")
+    is_episode = content_type == "series" and season is not None and episode is not None
+    if content_type == "movie":
+        media_type = MediaType.movie
+    elif is_episode:
+        media_type = MediaType.episode
+    elif content_type == "series":
+        media_type = MediaType.series
+    else:
+        return None
+
+    content_id = str(record["content_id"])
+    source_id = f"{profile_id}:{content_id}"
+    if is_episode:
+        source_id = f"{source_id}:s{season}e{episode}"
+    last_played = _nuvio_datetime(record.get("watched_at") or record.get("last_watched"))
+    title = record.get("title") or record.get("name") or content_id
+
+    item = {
+        "Id": source_id,
+        "Name": title,
+        "ProviderIds": {} if is_episode else {"Tmdb": str(tmdb_id)},
+        "MediaStreams": [],
+        "Path": None,
+        "SeriesId": content_id if is_episode else None,
+        "SeriesName": title if is_episode else None,
+        "ParentIndexNumber": int(season) if season is not None else None,
+        "IndexNumber": int(episode) if episode is not None else None,
+        "UserData": {
+            "Played": watched,
+            "PlayCount": 1 if watched else 0,
+            "LastPlayedDate": last_played.isoformat() if last_played else None,
+        },
+    }
+    return media_type, item
+
+
+async def _apply_nuvio_progress(
+    db: AsyncSession,
+    user_id: int,
+    rows: list[dict],
+    show_map: dict[str, int],
+    tmdb_ids: dict[str, int],
+) -> None:
+    movie_tmdb_ids = {
+        tmdb_id
+        for row in rows
+        if str(row.get("content_type") or "").lower() == "movie"
+        if (tmdb_id := tmdb_ids.get(str(row.get("content_id") or ""))) is not None
+    }
+    movies_by_tmdb: dict[int, Media] = {}
+    if movie_tmdb_ids:
+        result = await db.execute(
+            select(Media).where(Media.media_type == MediaType.movie, Media.tmdb_id.in_(movie_tmdb_ids))
+        )
+        movies_by_tmdb = {media.tmdb_id: media for media in result.scalars().all() if media.tmdb_id is not None}
+
+    show_ids = set(show_map.values())
+    episodes_by_key: dict[tuple[int, int, int], Media] = {}
+    if show_ids:
+        result = await db.execute(
+            select(Media).where(Media.media_type == MediaType.episode, Media.show_id.in_(show_ids))
+        )
+        episodes_by_key = {
+            (media.show_id, media.season_number, media.episode_number): media
+            for media in result.scalars().all()
+            if media.show_id is not None and media.season_number is not None and media.episode_number is not None
+        }
+
+    media_rows: list[tuple[dict, Media]] = []
+    for row in rows:
+        content_id = str(row.get("content_id") or "")
+        tmdb_id = tmdb_ids.get(content_id)
+        if tmdb_id is None:
+            continue
+        if str(row.get("content_type") or "").lower() == "movie":
+            media = movies_by_tmdb.get(tmdb_id)
+        else:
+            season = row.get("season")
+            episode = row.get("episode")
+            show_id = show_map.get(content_id)
+            media = (
+                episodes_by_key.get((show_id, int(season), int(episode)))
+                if show_id is not None and season is not None and episode is not None
+                else None
+            )
+        if media is not None:
+            media_rows.append((row, media))
+
+    if not media_rows:
+        return
+
+    media_ids = {media.id for _, media in media_rows}
+    existing_result = await db.execute(
+        select(PlaybackProgress).where(
+            PlaybackProgress.user_id == user_id,
+            PlaybackProgress.media_id.in_(media_ids),
+        )
+    )
+    existing = {progress.media_id: progress for progress in existing_result.scalars().all()}
+
+    for row, media in media_rows:
+        try:
+            position_ms = max(0, int(row.get("position") or 0))
+            duration_ms = max(0, int(row.get("duration") or 0))
+        except (TypeError, ValueError):
+            continue
+        if duration_ms <= 0:
+            continue
+        progress_percent = min(1.0, position_ms / duration_ms)
+        progress = existing.get(media.id)
+        if 0.05 <= progress_percent < 0.90:
+            updated_at = _nuvio_datetime(row.get("last_watched")) or datetime.utcnow()
+            if progress:
+                progress.progress_percent = progress_percent
+                progress.progress_seconds = position_ms // 1000
+                progress.updated_at = updated_at
+            else:
+                progress = PlaybackProgress(
+                    user_id=user_id,
+                    media_id=media.id,
+                    progress_percent=progress_percent,
+                    progress_seconds=position_ms // 1000,
+                    updated_at=updated_at,
+                )
+                db.add(progress)
+                existing[media.id] = progress
+        elif progress:
+            await db.delete(progress)
+            existing.pop(media.id, None)
+    await db.commit()
+
+
+async def run_nuvio_sync(
+    user_id: int,
+    job_id: int,
+    movie_limit: int,
+    show_limit: int,
+    connection_id: int | None = None,
+):
+    async with _sync_semaphore:
+        await _run_nuvio_sync(user_id, job_id, movie_limit, show_limit, connection_id)
+
+
+async def _run_nuvio_sync(
+    user_id: int,
+    job_id: int,
+    movie_limit: int,
+    show_limit: int,
+    connection_id: int | None = None,
+):
+    print(f"Starting Nuvio sync for user {user_id}, job {job_id}")
+    async_session = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+    async with async_session() as db:
+        try:
+            await db.execute(
+                update(SyncJob)
+                .where(SyncJob.id == job_id)
+                .values(status=SyncStatus.running, processed_items=0, total_items=0)
+            )
+            await db.commit()
+
+            settings_result = await db.execute(select(UserSettings).where(UserSettings.user_id == user_id))
+            settings = settings_result.scalar_one_or_none()
+            tmdb_api_key = await _get_effective_tmdb_key(db, settings)
+
+            conn_query = select(MediaServerConnection).where(
+                MediaServerConnection.user_id == user_id,
+                MediaServerConnection.type == "nuvio",
+            )
+            if connection_id:
+                conn_query = conn_query.where(MediaServerConnection.id == connection_id)
+            else:
+                conn_query = conn_query.order_by(MediaServerConnection.id.asc()).limit(1)
+            conn_result = await db.execute(conn_query)
+            conn = conn_result.scalar_one_or_none()
+            if not conn or not tmdb_api_key:
+                raise RuntimeError("Missing Nuvio connection or TMDB API key")
+
+            try:
+                profile_id = int(conn.server_user_id or "")
+            except ValueError:
+                raise RuntimeError("Invalid Nuvio profile index")
+            if profile_id < 1 or profile_id > 6:
+                raise RuntimeError("Invalid Nuvio profile index")
+
+            session, data = await nuvio.pull_sync_data(conn.url, conn.token, profile_id)
+            # Supabase refresh tokens rotate. Persist the replacement before doing
+            # any expensive metadata work so the connection remains recoverable.
+            conn.token = session.refresh_token
+            await db.commit()
+
+            library_records = data["library"] if conn.sync_collection else []
+            watched_records = data["watched"] if conn.sync_watched else []
+            progress_records = data["progress"] if conn.sync_playback else []
+            print(
+                f"Nuvio profile {conn.server_username or f'#{profile_id}'} (index #{profile_id}): "
+                f"pulled {len(data['library'])} library, {len(data['watched'])} watched, "
+                f"and {len(data['progress'])} progress records; enabled for this sync: "
+                f"{len(library_records)} library, {len(watched_records)} watched, "
+                f"{len(progress_records)} progress"
+            )
+
+            all_nuvio_records = [*library_records, *watched_records, *progress_records]
+            tmdb_ids = await _resolve_nuvio_tmdb_ids(
+                all_nuvio_records,
+                db,
+                user_id,
+                tmdb_api_key,
+            )
+            normalized_library = [
+                normalized
+                for record in library_records
+                if (
+                    normalized := _normalize_nuvio_item(
+                        record,
+                        profile_id,
+                        tmdb_id=tmdb_ids.get(str(record.get("content_id") or "")),
+                    )
+                )
+                is not None
+            ]
+            normalized_watched = [
+                normalized
+                for record in watched_records
+                if (
+                    normalized := _normalize_nuvio_item(
+                        record,
+                        profile_id,
+                        watched=True,
+                        tmdb_id=tmdb_ids.get(str(record.get("content_id") or "")),
+                    )
+                )
+                is not None
+            ]
+            normalized_progress = [
+                normalized
+                for record in progress_records
+                if (
+                    normalized := _normalize_nuvio_item(
+                        record,
+                        profile_id,
+                        tmdb_id=tmdb_ids.get(str(record.get("content_id") or "")),
+                    )
+                )
+                is not None
+            ]
+            skipped_nuvio_records = len(all_nuvio_records) - (
+                len(normalized_library) + len(normalized_watched) + len(normalized_progress)
+            )
+
+            if movie_limit:
+                normalized_library = [
+                    *[entry for entry in normalized_library if entry[0] == MediaType.movie][:movie_limit],
+                    *[entry for entry in normalized_library if entry[0] != MediaType.movie],
+                ]
+            if show_limit:
+                normalized_library = [
+                    *[entry for entry in normalized_library if entry[0] != MediaType.series],
+                    *[entry for entry in normalized_library if entry[0] == MediaType.series][:show_limit],
+                ]
+
+            series_tmdb_map = {
+                str(record.get("content_id")): tmdb_id
+                for record in [*library_records, *watched_records, *progress_records]
+                if str(record.get("content_type") or "").lower() == "series"
+                if (tmdb_id := tmdb_ids.get(str(record.get("content_id") or ""))) is not None
+            }
+            if series_tmdb_map:
+                show_map, show_id_to_tmdb = await sync_shows_batch(
+                    series_tmdb_map,
+                    db,
+                    api_key=tmdb_api_key,
+                )
+            else:
+                show_map, show_id_to_tmdb = {}, {}
+
+            all_entries = [*normalized_library, *normalized_watched, *normalized_progress]
+            await db.execute(
+                update(SyncJob).where(SyncJob.id == job_id).values(total_items=len(all_entries))
+            )
+            await db.commit()
+
+            stats = {"movies": 0, "series": 0, "episodes": 0, "skipped": skipped_nuvio_records, "errors": 0}
+            warnings: list[dict] = []
+            new_watched_ids: set[int] = set()
+
+            async def sync_group(
+                entries: list[tuple[MediaType, dict]],
+                media_type: MediaType,
+                *,
+                sync_collection: bool,
+                sync_watched: bool,
+            ) -> None:
+                items = [item for item_type, item in entries if item_type == media_type]
+                if not items:
+                    return
+                group_warnings = await sync_items(
+                    items,
+                    media_type,
+                    CollectionSource.nuvio,
+                    db,
+                    stats,
+                    user_id,
+                    job_id,
+                    show_map if media_type == MediaType.episode else {},
+                    api_key=tmdb_api_key,
+                    show_id_to_tmdb=show_id_to_tmdb if media_type == MediaType.episode else {},
+                    sync_collection=sync_collection,
+                    sync_watched=sync_watched,
+                    sync_ratings=False,
+                    new_watched_ids=new_watched_ids,
+                    connection_id=conn.id,
+                )
+                warnings.extend(group_warnings)
+
+            for media_type in (MediaType.movie, MediaType.series):
+                await sync_group(
+                    normalized_library,
+                    media_type,
+                    sync_collection=True,
+                    sync_watched=False,
+                )
+            for media_type in (MediaType.movie, MediaType.series, MediaType.episode):
+                await sync_group(
+                    normalized_watched,
+                    media_type,
+                    sync_collection=False,
+                    sync_watched=True,
+                )
+            for media_type in (MediaType.movie, MediaType.series, MediaType.episode):
+                await sync_group(
+                    normalized_progress,
+                    media_type,
+                    sync_collection=False,
+                    sync_watched=False,
+                )
+
+            if progress_records:
+                await _apply_nuvio_progress(db, user_id, progress_records, show_map, tmdb_ids)
+
+            await _fan_out_changes_to_other_connections(
+                db,
+                user_id,
+                conn.id,
+                new_watched_ids,
+                {},
+                settings=settings,
+            )
+            warnings = await _stamp_matched_show_warnings(db, user_id, warnings)
+            await db.execute(
+                update(SyncJob)
+                .where(SyncJob.id == job_id)
+                .values(
+                    status=SyncStatus.completed,
+                    stats=stats,
+                    warnings=warnings or None,
+                    updated_at=func.now(),
+                )
+            )
+            await db.commit()
+            asyncio.create_task(pre_cache_all_collected_bg())
+            print(f"Nuvio sync job {job_id} completed. Stats: {stats}")
+        except Exception as exc:
+            print(f"Nuvio sync job {job_id} failed: {exc}")
+            import traceback
+
+            traceback.print_exc()
+            await db.rollback()
+            await db.execute(
+                update(SyncJob)
+                .where(SyncJob.id == job_id)
+                .values(status=SyncStatus.failed, error_message=str(exc)[:900])
+            )
+            await db.commit()
+
+
 class LibrarySelectionBody(BaseModel):
     library_ids: list[str]
 
@@ -1807,6 +2377,9 @@ async def get_connection_libraries(
             ]
             return {"libraries": libraries, "all_selected": len(selected_keys) == 0}
 
+        elif conn.type == "nuvio":
+            return {"libraries": [], "all_selected": True}
+
         else:
             raise HTTPException(status_code=400, detail=f"Unknown connection type: {conn.type}")
     except HTTPException:
@@ -1818,12 +2391,59 @@ async def get_connection_libraries(
 @router.post("/connection/{connection_id}/scan")
 async def trigger_library_scan(
     connection_id: int,
+    background_tasks: BackgroundTasks,
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
     conn = await _get_connection_or_404(db, connection_id, current_user.id)
 
     try:
+        if conn.type == "nuvio":
+            settings_result = await db.execute(
+                select(UserSettings).where(UserSettings.user_id == current_user.id)
+            )
+            settings = settings_result.scalar_one_or_none()
+            if not await _get_effective_tmdb_key(db, settings):
+                raise HTTPException(status_code=400, detail="TMDB API key required")
+            active_result = await db.execute(
+                select(SyncJob)
+                .where(
+                    SyncJob.user_id == current_user.id,
+                    SyncJob.connection_id == conn.id,
+                    SyncJob.status.in_([SyncStatus.pending, SyncStatus.running]),
+                )
+                .limit(1)
+            )
+            active_job = active_result.scalar_one_or_none()
+            if active_job:
+                return {
+                    "status": "started",
+                    "job_id": active_job.id,
+                    "message": "Nuvio sync is already running",
+                }
+            job = SyncJob(
+                user_id=current_user.id,
+                source=CollectionSource.nuvio,
+                status=SyncStatus.pending,
+                connection_id=conn.id,
+                job_type="pull",
+            )
+            db.add(job)
+            await db.commit()
+            await db.refresh(job)
+            background_tasks.add_task(
+                run_nuvio_sync,
+                current_user.id,
+                job.id,
+                0,
+                0,
+                conn.id,
+            )
+            return {
+                "status": "started",
+                "job_id": job.id,
+                "message": "Nuvio library, watch history, and playback progress sync started",
+            }
         if conn.type in ("jellyfin", "emby"):
             client = jellyfin if conn.type == "jellyfin" else emby
             ok = await client.scan_libraries(conn.url, conn.token)
@@ -1888,6 +2508,9 @@ async def save_connection_libraries(
             await db.commit()
             return {"saved": len(library_keys)}
 
+        elif conn.type == "nuvio":
+            return {"saved": 0}
+
         else:
             raise HTTPException(status_code=400, detail=f"Unknown connection type: {conn.type}")
     except HTTPException:
@@ -1912,7 +2535,7 @@ async def sync_connection(
     if not await _get_effective_tmdb_key(db, settings):
         raise HTTPException(status_code=400, detail="TMDB API key required")
 
-    source_map = {"jellyfin": CollectionSource.jellyfin, "emby": CollectionSource.emby, "plex": CollectionSource.plex}
+    source_map = {"jellyfin": CollectionSource.jellyfin, "emby": CollectionSource.emby, "plex": CollectionSource.plex, "nuvio": CollectionSource.nuvio}
     source = source_map.get(conn.type)
     if not source:
         raise HTTPException(status_code=400, detail=f"Unknown connection type: {conn.type}")
@@ -1922,7 +2545,7 @@ async def sync_connection(
     await db.commit()
     await db.refresh(job)
 
-    runner_map = {"jellyfin": run_jellyfin_sync, "emby": run_emby_sync, "plex": run_plex_sync}
+    runner_map = {"jellyfin": run_jellyfin_sync, "emby": run_emby_sync, "plex": run_plex_sync, "nuvio": run_nuvio_sync}
     background_tasks.add_task(runner_map[conn.type], current_user.id, job.id, movie_limit, show_limit, connection_id)
     return {"status": "started", "job_id": job.id, "message": f"{conn.type.capitalize()} sync is running in the background"}
 
@@ -1946,6 +2569,40 @@ async def _run_full_push(user_id: int, connection_id: int, job_id: int) -> None:
             if not conn:
                 await db.execute(update(SyncJob).where(SyncJob.id == job_id).values(status=SyncStatus.failed, error_message="Connection not found"))
                 await db.commit()
+                return
+
+            if conn.type == "nuvio":
+                watched_items = (
+                    await _build_nuvio_watched_items(db, user_id)
+                    if conn.push_watched
+                    else []
+                )
+                total = len(watched_items)
+                await db.execute(
+                    update(SyncJob)
+                    .where(SyncJob.id == job_id)
+                    .values(total_items=total, processed_items=0)
+                )
+                await db.commit()
+                if watched_items:
+                    session = await nuvio.push_watched_items(
+                        conn.url,
+                        conn.token,
+                        _nuvio_profile_id(conn),
+                        watched_items,
+                    )
+                    conn.token = session.refresh_token
+                await db.execute(
+                    update(SyncJob)
+                    .where(SyncJob.id == job_id)
+                    .values(
+                        status=SyncStatus.completed,
+                        processed_items=total,
+                        stats={"succeeded": total, "failed": 0},
+                    )
+                )
+                await db.commit()
+                print(f"Full Nuvio push for connection {connection_id}: {total} watched items")
                 return
 
             conn_source = CollectionSource(conn.type)
@@ -2181,7 +2838,7 @@ async def push_upstream(
     if not conn.push_watched and not conn.push_ratings:
         raise HTTPException(status_code=400, detail="Enable 'Scrob → Server' push flags for this connection first")
 
-    source_map = {"jellyfin": CollectionSource.jellyfin, "emby": CollectionSource.emby, "plex": CollectionSource.plex}
+    source_map = {"jellyfin": CollectionSource.jellyfin, "emby": CollectionSource.emby, "plex": CollectionSource.plex, "nuvio": CollectionSource.nuvio}
     source = source_map.get(conn.type, CollectionSource.jellyfin)
     job = SyncJob(user_id=current_user.id, source=source, status=SyncStatus.pending, connection_id=connection_id, job_type="push")
     db.add(job)

--- a/backend/routers/trakt.py
+++ b/backend/routers/trakt.py
@@ -307,6 +307,7 @@ async def run_trakt_sync(user_id: int, job_id: int):
             stats = {"movies": 0, "episodes": 0, "ratings": 0, "lists": 0, "list_items": 0, "skipped": 0, "errors": 0}
             _new_watched: set[int] = set()
             _new_ratings: dict[int, float] = {}
+            watched_processed = 0
 
             # ── Watched Movies ────────────────────────────────────────────────
             if sync_watched:
@@ -322,42 +323,52 @@ async def run_trakt_sync(user_id: int, job_id: int):
                 )
                 existing_watched: set[int] = {row[0] for row in we_res}
 
-                for item in watched_movies:
+                for movie_index, item in enumerate(watched_movies, start=1):
                     movie_data = item.get("movie", {})
                     tmdb_id = movie_data.get("ids", {}).get("tmdb")
-                    if not tmdb_id:
-                        stats["skipped"] += 1
-                        continue
                     try:
-                        async with db.begin_nested():
-                            media = await _get_or_create_movie_media(db, tmdb_id, movie_data.get("title", ""), api_key)
-                            if not media:
-                                stats["errors"] += 1
-                                continue
-                            if media.id not in existing_watched:
-                                last_watched = item.get("last_watched_at")
-                                watched_at = None
-                                if last_watched:
-                                    from dateutil import parser as dt_parser
-                                    dt = dt_parser.isoparse(last_watched)
-                                    if dt.tzinfo:
-                                        dt = dt.astimezone(timezone.utc).replace(tzinfo=None)
-                                    watched_at = dt
-                                db.add(WatchEvent(
-                                    user_id=user_id,
-                                    media_id=media.id,
-                                    watched_at=watched_at or datetime.utcnow(),
-                                    completed=True,
-                                    play_count=item.get("plays", 1),
-                                ))
-                                existing_watched.add(media.id)
-                                _new_watched.add(media.id)
-                                stats["movies"] += 1
-                            else:
-                                stats["skipped"] += 1
-                    except Exception as exc:
-                        logger.warning("Error processing Trakt movie tmdb=%s: %s", tmdb_id, exc)
-                        stats["errors"] += 1
+                        if not tmdb_id:
+                            stats["skipped"] += 1
+                            continue
+                        try:
+                            async with db.begin_nested():
+                                media = await _get_or_create_movie_media(db, tmdb_id, movie_data.get("title", ""), api_key)
+                                if not media:
+                                    stats["errors"] += 1
+                                    continue
+                                if media.id not in existing_watched:
+                                    last_watched = item.get("last_watched_at")
+                                    watched_at = None
+                                    if last_watched:
+                                        from dateutil import parser as dt_parser
+                                        dt = dt_parser.isoparse(last_watched)
+                                        if dt.tzinfo:
+                                            dt = dt.astimezone(timezone.utc).replace(tzinfo=None)
+                                        watched_at = dt
+                                    db.add(WatchEvent(
+                                        user_id=user_id,
+                                        media_id=media.id,
+                                        watched_at=watched_at or datetime.utcnow(),
+                                        completed=True,
+                                        play_count=item.get("plays", 1),
+                                    ))
+                                    existing_watched.add(media.id)
+                                    _new_watched.add(media.id)
+                                    stats["movies"] += 1
+                                else:
+                                    stats["skipped"] += 1
+                        except Exception as exc:
+                            logger.warning("Error processing Trakt movie tmdb=%s: %s", tmdb_id, exc)
+                            stats["errors"] += 1
+                    finally:
+                        watched_processed = movie_index
+                        if movie_index % 25 == 0 or movie_index == len(watched_movies):
+                            await db.execute(
+                                update(SyncJob)
+                                .where(SyncJob.id == job_id)
+                                .values(processed_items=watched_processed)
+                            )
+                            await db.commit()
 
                 await db.commit()
 
@@ -372,7 +383,8 @@ async def run_trakt_sync(user_id: int, job_id: int):
                     for s in watched_shows
                 )
                 await db.execute(update(SyncJob).where(SyncJob.id == job_id).values(
-                    total_items=len(watched_movies) + total_episodes
+                    total_items=len(watched_movies) + total_episodes,
+                    processed_items=watched_processed,
                 ))
                 await db.commit()
 
@@ -443,9 +455,14 @@ async def run_trakt_sync(user_id: int, job_id: int):
 
                 for i, s in enumerate(watched_shows):
                     await process_show(s)
-                    if (i + 1) % 10 == 0:
+                    watched_processed += sum(
+                        len(season.get("episodes", []))
+                        for season in s.get("seasons", [])
+                        if season.get("number") not in (None, 0)
+                    )
+                    if (i + 1) % 10 == 0 or i + 1 == len(watched_shows):
                         await db.execute(update(SyncJob).where(SyncJob.id == job_id).values(
-                            processed_items=stats["movies"] + stats["episodes"]
+                            processed_items=watched_processed
                         ))
                         await db.commit()
                 await db.commit()
@@ -824,7 +841,7 @@ async def run_trakt_sync(user_id: int, job_id: int):
                 update(SyncJob).where(SyncJob.id == job_id).values(
                     status=SyncStatus.completed,
                     stats=stats,
-                    processed_items=stats["movies"] + stats["episodes"] + stats["ratings"],
+                    processed_items=watched_processed,
                 )
             )
             await db.commit()

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -150,6 +150,7 @@ class MediaServerConnectionBase(BaseModel):
     sync_ratings: bool = True
     sync_playback: bool = True
     push_watched: bool = False
+    push_playback: bool = False
     push_ratings: bool = False
     auto_sync_interval: Optional[float] = None
     watchlist_to_radarr: bool = False
@@ -175,6 +176,7 @@ class MediaServerConnectionUpdate(BaseModel):
     sync_ratings: Optional[bool] = None
     sync_playback: Optional[bool] = None
     push_watched: Optional[bool] = None
+    push_playback: Optional[bool] = None
     push_ratings: Optional[bool] = None
     auto_sync_interval: Optional[float] = None
     watchlist_to_radarr: Optional[bool] = None

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -126,6 +126,18 @@ class UserSettings(BaseModel):
         from_attributes = True
 
 
+class NuvioLoginRequest(BaseModel):
+    email: EmailStr
+    password: str
+    url: str = "https://api.nuvio.tv"
+
+
+class NuvioConnectionTestRequest(BaseModel):
+    url: str
+    token: str
+    profile_id: int
+
+
 class MediaServerConnectionBase(BaseModel):
     type: str
     name: str
@@ -139,7 +151,7 @@ class MediaServerConnectionBase(BaseModel):
     sync_playback: bool = True
     push_watched: bool = False
     push_ratings: bool = False
-    auto_sync_interval: Optional[int] = None
+    auto_sync_interval: Optional[float] = None
     watchlist_to_radarr: bool = False
     watchlist_to_sonarr: bool = False
     watchlist_all_users: bool = False
@@ -164,7 +176,7 @@ class MediaServerConnectionUpdate(BaseModel):
     sync_playback: Optional[bool] = None
     push_watched: Optional[bool] = None
     push_ratings: Optional[bool] = None
-    auto_sync_interval: Optional[int] = None
+    auto_sync_interval: Optional[float] = None
     watchlist_to_radarr: Optional[bool] = None
     watchlist_to_sonarr: Optional[bool] = None
     watchlist_all_users: Optional[bool] = None

--- a/backend/tests/test_nuvio.py
+++ b/backend/tests/test_nuvio.py
@@ -1,0 +1,176 @@
+import json
+import os
+import unittest
+from unittest.mock import patch
+
+import httpx
+
+os.environ.setdefault("SECRET_KEY", "test-secret")
+os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://test:test@localhost/test")
+
+from core import nuvio
+from models.base import MediaType
+from routers.sync import _normalize_nuvio_item
+
+
+_REAL_ASYNC_CLIENT = httpx.AsyncClient
+
+
+class NuvioClientTests(unittest.IsolatedAsyncioTestCase):
+    async def test_pull_sync_data_refreshes_session_and_paginates_library(self) -> None:
+        library_offsets: list[int] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path == "/auth/v1/token":
+                self.assertEqual(request.url.params["grant_type"], "refresh_token")
+                self.assertEqual(json.loads(request.content), {"refresh_token": "old-refresh"})
+                return httpx.Response(
+                    200,
+                    json={
+                        "access_token": "access-token",
+                        "refresh_token": "new-refresh",
+                        "expires_in": 3600,
+                    },
+                )
+            self.assertEqual(request.headers["authorization"], "Bearer access-token")
+            payload = json.loads(request.content or b"{}")
+            if request.url.path.endswith("/sync_pull_profiles"):
+                return httpx.Response(200, json=[{"profile_index": 2, "name": "Main"}])
+            if request.url.path.endswith("/sync_pull_library"):
+                library_offsets.append(payload["p_offset"])
+                item_count = 500 if payload["p_offset"] == 0 else 1
+                return httpx.Response(
+                    200,
+                    json=[
+                        {"content_id": f"tmdb:{index + payload['p_offset']}", "content_type": "movie"}
+                        for index in range(item_count)
+                    ],
+                )
+            if request.url.path.endswith("/sync_pull_watched_items"):
+                return httpx.Response(
+                    200,
+                    json=[{"content_id": "tmdb:550", "content_type": "movie", "watched_at": 1711600000000}],
+                )
+            if request.url.path.endswith("/sync_pull_watch_progress"):
+                return httpx.Response(
+                    200,
+                    json=[{"content_id": "tmdb:550", "content_type": "movie", "position": 1000, "duration": 2000}],
+                )
+            return httpx.Response(404, json={"message": "unexpected request"})
+
+        transport = httpx.MockTransport(handler)
+        with patch.object(
+            nuvio.httpx,
+            "AsyncClient",
+            side_effect=lambda **kwargs: _REAL_ASYNC_CLIENT(transport=transport, **kwargs),
+        ):
+            session, data = await nuvio.pull_sync_data(
+                "https://api.nuvio.tv/",
+                "old-refresh",
+                2,
+            )
+
+        self.assertEqual(session.refresh_token, "new-refresh")
+        self.assertEqual(library_offsets, [0, 500])
+        self.assertEqual(len(data["library"]), 501)
+        self.assertEqual(len(data["watched"]), 1)
+        self.assertEqual(len(data["progress"]), 1)
+
+    async def test_push_watched_items_batches_without_full_replace(self) -> None:
+        batch_sizes: list[int] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path == "/auth/v1/token":
+                return httpx.Response(
+                    200,
+                    json={
+                        "access_token": "access-token",
+                        "refresh_token": "rotated-refresh",
+                        "expires_in": 3600,
+                    },
+                )
+            if request.url.path.endswith("/sync_push_watched_items"):
+                payload = json.loads(request.content)
+                self.assertEqual(payload["p_profile_id"], 1)
+                batch_sizes.append(len(payload["p_items"]))
+                return httpx.Response(204)
+            return httpx.Response(404, json={"message": "unexpected request"})
+
+        transport = httpx.MockTransport(handler)
+        items = [
+            {
+                "content_id": f"tmdb:{index}",
+                "content_type": "movie",
+                "watched_at": 1711600000000,
+            }
+            for index in range(501)
+        ]
+        with patch.object(
+            nuvio.httpx,
+            "AsyncClient",
+            side_effect=lambda **kwargs: _REAL_ASYNC_CLIENT(transport=transport, **kwargs),
+        ):
+            session = await nuvio.push_watched_items(
+                "https://api.nuvio.tv",
+                "old-refresh",
+                1,
+                items,
+            )
+
+        self.assertEqual(session.refresh_token, "rotated-refresh")
+        self.assertEqual(batch_sizes, [500, 1])
+
+
+class NuvioNormalizationTests(unittest.TestCase):
+    def test_episode_history_maps_to_tmdb_series_and_watch_state(self) -> None:
+        normalized = _normalize_nuvio_item(
+            {
+                "content_id": "tmdb:1396",
+                "content_type": "series",
+                "title": "Pilot",
+                "season": 1,
+                "episode": 1,
+                "watched_at": 1711600000000,
+            },
+            profile_id=3,
+            watched=True,
+        )
+
+        self.assertIsNotNone(normalized)
+        media_type, item = normalized
+        self.assertEqual(media_type, MediaType.episode)
+        self.assertEqual(item["Id"], "3:tmdb:1396:s1e1")
+        self.assertEqual(item["SeriesId"], "tmdb:1396")
+        self.assertEqual(item["ProviderIds"], {})
+        self.assertEqual(item["UserData"]["Played"], True)
+        self.assertEqual(item["UserData"]["PlayCount"], 1)
+        self.assertIsNotNone(item["UserData"]["LastPlayedDate"])
+
+    def test_imdb_content_uses_resolved_tmdb_id(self) -> None:
+        normalized = _normalize_nuvio_item(
+            {
+                "content_id": "tt0411008",
+                "content_type": "series",
+                "name": "Lost",
+            },
+            profile_id=1,
+            tmdb_id=4607,
+        )
+
+        self.assertIsNotNone(normalized)
+        media_type, item = normalized
+        self.assertEqual(media_type, MediaType.series)
+        self.assertEqual(item["Id"], "1:tt0411008")
+        self.assertEqual(item["ProviderIds"], {"Tmdb": "4607"})
+
+    def test_unsupported_content_identifier_is_skipped(self) -> None:
+        self.assertIsNone(
+            _normalize_nuvio_item(
+                {"content_id": "imdb:tt0137523", "content_type": "movie"},
+                profile_id=1,
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_nuvio.py
+++ b/backend/tests/test_nuvio.py
@@ -1,4 +1,5 @@
 import json
+from datetime import datetime, timezone
 import os
 import unittest
 from unittest.mock import patch
@@ -10,7 +11,15 @@ os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://test:test@localhost/
 
 from core import nuvio
 from models.base import MediaType
-from routers.sync import _normalize_nuvio_item
+from models.media import Media
+from models.playback_progress import PlaybackProgress
+from models.show import Show
+from routers.sync import (
+    _ensure_nuvio_imdb_ids,
+    _normalize_nuvio_item,
+    _nuvio_progress_item,
+    _nuvio_watched_item,
+)
 
 
 _REAL_ASYNC_CLIENT = httpx.AsyncClient
@@ -120,6 +129,105 @@ class NuvioClientTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(session.refresh_token, "rotated-refresh")
         self.assertEqual(batch_sizes, [500, 1])
 
+    async def test_push_sync_items_uses_watched_and_progress_endpoints(self) -> None:
+        calls: list[tuple[str, int]] = []
+        refresh_count = 0
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal refresh_count
+            if request.url.path == "/auth/v1/token":
+                refresh_count += 1
+                return httpx.Response(
+                    200,
+                    json={
+                        "access_token": "access-token",
+                        "refresh_token": "rotated-refresh",
+                        "expires_in": 3600,
+                    },
+                )
+            payload = json.loads(request.content)
+            self.assertEqual(payload["p_profile_id"], 3)
+            function_name = request.url.path.rsplit("/", 1)[-1]
+            items_key = "p_entries" if function_name == "sync_push_watch_progress" else "p_items"
+            self.assertEqual(set(payload), {"p_profile_id", items_key})
+            calls.append((function_name, len(payload[items_key])))
+            return httpx.Response(204)
+
+        watched_items = [{"content_id": "tmdb:550", "content_type": "movie", "watched_at": 1}]
+        progress_items = [
+            {
+                "content_id": f"tmdb:{index}",
+                "content_type": "movie",
+                "video_id": f"tmdb:{index}",
+                "position": 1000,
+                "duration": 2000,
+                "last_watched": 1,
+            }
+            for index in range(501)
+        ]
+        transport = httpx.MockTransport(handler)
+        with patch.object(
+            nuvio.httpx,
+            "AsyncClient",
+            side_effect=lambda **kwargs: _REAL_ASYNC_CLIENT(transport=transport, **kwargs),
+        ):
+            session = await nuvio.push_sync_items(
+                "https://api.nuvio.tv",
+                "old-refresh",
+                3,
+                watched_items,
+                progress_items,
+            )
+
+        self.assertEqual(session.refresh_token, "rotated-refresh")
+        self.assertEqual(refresh_count, 1)
+        self.assertEqual(
+            calls,
+            [
+                ("sync_push_watched_items", 1),
+                ("sync_push_watch_progress", 500),
+                ("sync_push_watch_progress", 1),
+            ],
+        )
+
+    async def test_missing_imdb_ids_are_resolved_and_cached(self) -> None:
+        movie = Media(
+            id=10,
+            tmdb_id=550,
+            media_type=MediaType.movie,
+            title="Fight Club",
+            tmdb_data={},
+        )
+        episode = Media(
+            id=11,
+            media_type=MediaType.episode,
+            title="It's All Good",
+            show_id=5,
+            season_number=3,
+            episode_number=2,
+        )
+        show = Show(id=5, tmdb_id=125988, title="Silo", tmdb_data={})
+
+        async def external_ids(tmdb_id: int, media_type: str, api_key: str | None = None) -> dict:
+            self.assertEqual(api_key, "tmdb-token")
+            return {
+                "imdb_id": {
+                    ("movie", 550): "tt0137523",
+                    ("tv", 125988): "tt14688458",
+                }[(media_type, tmdb_id)]
+            }
+
+        with patch("routers.sync.tmdb.get_external_ids", side_effect=external_ids) as get_external_ids:
+            await _ensure_nuvio_imdb_ids(
+                [movie, episode],
+                {show.id: show},
+                "tmdb-token",
+            )
+
+        self.assertEqual(get_external_ids.await_count, 2)
+        self.assertEqual(movie.tmdb_data["external_ids"]["imdb_id"], "tt0137523")
+        self.assertEqual(show.tmdb_data["external_ids"]["imdb_id"], "tt14688458")
+
 
 class NuvioNormalizationTests(unittest.TestCase):
     def test_episode_history_maps_to_tmdb_series_and_watch_state(self) -> None:
@@ -170,6 +278,116 @@ class NuvioNormalizationTests(unittest.TestCase):
                 profile_id=1,
             )
         )
+
+    def test_progress_payload_maps_movies_and_episodes(self) -> None:
+        updated_at = datetime(2026, 7, 14, 12, 0, tzinfo=timezone.utc)
+        progress = PlaybackProgress(
+            user_id=1,
+            media_id=10,
+            progress_seconds=1800,
+            progress_percent=0.25,
+            updated_at=updated_at,
+        )
+        movie = Media(
+            id=10,
+            tmdb_id=550,
+            media_type=MediaType.movie,
+            title="Fight Club",
+            runtime=120,
+            tmdb_data={"external_ids": {"imdb_id": "tt0137523"}},
+        )
+        self.assertEqual(
+            _nuvio_progress_item(progress, movie),
+            {
+                "content_id": "tt0137523",
+                "content_type": "movie",
+                "video_id": "tt0137523",
+                "position": 1800000,
+                "duration": 7200000,
+                "last_watched": int(updated_at.timestamp() * 1000),
+            },
+        )
+
+        episode = Media(
+            id=11,
+            media_type=MediaType.episode,
+            title="Pilot",
+            show_id=5,
+            season_number=1,
+            episode_number=1,
+        )
+        show = Show(
+            id=5,
+            tmdb_id=1396,
+            title="Breaking Bad",
+            tmdb_data={"external_ids": {"imdb_id": "tt0903747"}},
+        )
+        self.assertEqual(
+            _nuvio_progress_item(progress, episode, show),
+            {
+                "content_id": "tt0903747",
+                "content_type": "series",
+                "video_id": "tt0903747:1:1",
+                "season": 1,
+                "episode": 1,
+                "position": 1800000,
+                "duration": 7200000,
+                "last_watched": int(updated_at.timestamp() * 1000),
+            },
+        )
+
+    def test_watched_payload_uses_bare_imdb_ids(self) -> None:
+        watched_at = datetime(2026, 7, 14, 12, 0, tzinfo=timezone.utc)
+        movie = Media(
+            id=10,
+            tmdb_id=550,
+            media_type=MediaType.movie,
+            title="Fight Club",
+            tmdb_data={"external_ids": {"imdb_id": "tt0137523"}},
+        )
+        self.assertEqual(
+            _nuvio_watched_item(movie, watched_at),
+            {
+                "content_id": "tt0137523",
+                "content_type": "movie",
+                "title": "Fight Club",
+                "watched_at": int(watched_at.timestamp() * 1000),
+            },
+        )
+
+        episode = Media(
+            id=11,
+            media_type=MediaType.episode,
+            title="It's All Good",
+            show_id=5,
+            season_number=3,
+            episode_number=2,
+        )
+        show = Show(
+            id=5,
+            tmdb_id=125988,
+            title="Silo",
+            tmdb_data={"external_ids": {"imdb_id": "tt14688458"}},
+        )
+        self.assertEqual(
+            _nuvio_watched_item(episode, watched_at, show),
+            {
+                "content_id": "tt14688458",
+                "content_type": "series",
+                "title": "It's All Good",
+                "season": 3,
+                "episode": 2,
+                "watched_at": int(watched_at.timestamp() * 1000),
+            },
+        )
+
+        tmdb_only_movie = Media(
+            id=12,
+            tmdb_id=550,
+            media_type=MediaType.movie,
+            title="Fight Club",
+        )
+        self.assertIsNone(_nuvio_watched_item(tmdb_only_movie, watched_at))
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_trakt.py
+++ b/backend/tests/test_trakt.py
@@ -1,0 +1,48 @@
+import unittest
+from unittest.mock import patch
+
+import httpx
+
+from core import trakt
+
+
+_REAL_ASYNC_CLIENT = httpx.AsyncClient
+
+
+class TraktClientTests(unittest.IsolatedAsyncioTestCase):
+    async def test_get_watched_movies_fetches_every_page(self) -> None:
+        requested_pages: list[int] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            self.assertEqual(request.url.path, "/sync/watched/movies")
+            self.assertEqual(request.url.params["limit"], "100")
+            self.assertEqual(request.headers["authorization"], "Bearer access-token")
+
+            page = int(request.url.params["page"])
+            requested_pages.append(page)
+            page_items = {
+                1: [{"movie": {"ids": {"tmdb": index}}} for index in range(1, 101)],
+                2: [{"movie": {"ids": {"tmdb": index}}} for index in range(101, 201)],
+                3: [{"movie": {"ids": {"tmdb": index}}} for index in range(201, 218)],
+            }[page]
+            return httpx.Response(
+                200,
+                json=page_items,
+                headers={"X-Pagination-Page-Count": "3"},
+            )
+
+        transport = httpx.MockTransport(handler)
+        with patch.object(
+            trakt.httpx,
+            "AsyncClient",
+            side_effect=lambda **kwargs: _REAL_ASYNC_CLIENT(transport=transport, **kwargs),
+        ):
+            movies = await trakt.get_watched_movies("client-id", "access-token")
+
+        self.assertEqual(requested_pages, [1, 2, 3])
+        self.assertEqual(len(movies), 217)
+        self.assertEqual(movies[-1]["movie"]["ids"]["tmdb"], 217)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_trakt.py
+++ b/backend/tests/test_trakt.py
@@ -44,5 +44,49 @@ class TraktClientTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(movies[-1]["movie"]["ids"]["tmdb"], 217)
 
 
+    async def test_get_watched_shows_requests_progress_on_every_page(self) -> None:
+        requested_pages: list[int] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            self.assertEqual(request.url.path, "/sync/watched/shows")
+            self.assertEqual(request.url.params["limit"], "100")
+            self.assertEqual(request.url.params["extended"], "progress")
+            page = int(request.url.params["page"])
+            requested_pages.append(page)
+            if page == 1:
+                return httpx.Response(
+                    200,
+                    json=[
+                        {
+                            "show": {"ids": {"tmdb": 1396}},
+                            "seasons": [
+                                {
+                                    "number": 1,
+                                    "episodes": [
+                                        {
+                                            "number": 1,
+                                            "plays": 1,
+                                            "last_watched_at": "2026-07-15T20:00:00.000Z",
+                                        }
+                                    ],
+                                }
+                            ],
+                        }
+                    ],
+                )
+            return httpx.Response(200, json=[])
+
+        transport = httpx.MockTransport(handler)
+        with patch.object(
+            trakt.httpx,
+            "AsyncClient",
+            side_effect=lambda **kwargs: _REAL_ASYNC_CLIENT(transport=transport, **kwargs),
+        ):
+            shows = await trakt.get_watched_shows("client-id", "access-token")
+
+        self.assertEqual(requested_pages, [1, 2])
+        self.assertEqual(shows[0]["seasons"][0]["episodes"][0]["number"], 1)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/backend/tests/test_trakt.py
+++ b/backend/tests/test_trakt.py
@@ -15,15 +15,15 @@ class TraktClientTests(unittest.IsolatedAsyncioTestCase):
 
         def handler(request: httpx.Request) -> httpx.Response:
             self.assertEqual(request.url.path, "/sync/watched/movies")
-            self.assertEqual(request.url.params["limit"], "100")
+            self.assertEqual(request.url.params["limit"], "250")
             self.assertEqual(request.headers["authorization"], "Bearer access-token")
 
             page = int(request.url.params["page"])
             requested_pages.append(page)
             page_items = {
-                1: [{"movie": {"ids": {"tmdb": index}}} for index in range(1, 101)],
-                2: [{"movie": {"ids": {"tmdb": index}}} for index in range(101, 201)],
-                3: [{"movie": {"ids": {"tmdb": index}}} for index in range(201, 218)],
+                1: [{"movie": {"ids": {"tmdb": index}}} for index in range(1, 251)],
+                2: [{"movie": {"ids": {"tmdb": index}}} for index in range(251, 501)],
+                3: [{"movie": {"ids": {"tmdb": index}}} for index in range(501, 518)],
             }[page]
             return httpx.Response(
                 200,
@@ -40,8 +40,8 @@ class TraktClientTests(unittest.IsolatedAsyncioTestCase):
             movies = await trakt.get_watched_movies("client-id", "access-token")
 
         self.assertEqual(requested_pages, [1, 2, 3])
-        self.assertEqual(len(movies), 217)
-        self.assertEqual(movies[-1]["movie"]["ids"]["tmdb"], 217)
+        self.assertEqual(len(movies), 517)
+        self.assertEqual(movies[-1]["movie"]["ids"]["tmdb"], 517)
 
 
     async def test_get_watched_shows_requests_progress_on_every_page(self) -> None:
@@ -49,7 +49,7 @@ class TraktClientTests(unittest.IsolatedAsyncioTestCase):
 
         def handler(request: httpx.Request) -> httpx.Response:
             self.assertEqual(request.url.path, "/sync/watched/shows")
-            self.assertEqual(request.url.params["limit"], "100")
+            self.assertEqual(request.url.params["limit"], "250")
             self.assertEqual(request.url.params["extended"], "progress")
             page = int(request.url.params["page"])
             requested_pages.append(page)

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -435,6 +435,7 @@ export interface MediaServerConnection {
   sync_ratings: boolean;
   sync_playback: boolean;
   push_watched: boolean;
+  push_playback: boolean;
   push_ratings: boolean;
   auto_sync_interval: number | null;
   created_at: string;
@@ -452,6 +453,7 @@ export interface MediaServerConnectionCreate {
   sync_ratings?: boolean;
   sync_playback?: boolean;
   push_watched?: boolean;
+  push_playback?: boolean;
   push_ratings?: boolean;
   auto_sync_interval?: number | null;
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -424,7 +424,7 @@ export interface UserSettings {
 export interface MediaServerConnection {
   id: number;
   user_id: number;
-  type: "jellyfin" | "emby" | "plex";
+  type: "jellyfin" | "emby" | "plex" | "nuvio";
   name: string;
   url: string;
   token: string;
@@ -441,7 +441,7 @@ export interface MediaServerConnection {
 }
 
 export interface MediaServerConnectionCreate {
-  type: "jellyfin" | "emby" | "plex";
+  type: "jellyfin" | "emby" | "plex" | "nuvio";
   name: string;
   url: string;
   token: string;

--- a/frontend/src/pages/admin.astro
+++ b/frontend/src/pages/admin.astro
@@ -53,7 +53,7 @@ const adminCount = users.filter((u: AdminUser) => u.is_admin).length;
           <div id="tmdb-body" class="border-t border-zinc-800 hidden">
             <div class="px-6 py-6">
               <div class="space-y-2 max-w-md">
-                <label for="tmdb_api_key" class="block text-sm font-medium text-zinc-400">API Key</label>
+                <label for="tmdb_api_key" class="block text-sm font-medium text-zinc-400">Read Access Token</label>
                 <div class="relative group/field">
                   <input
                     type="password"
@@ -68,7 +68,7 @@ const adminCount = users.filter((u: AdminUser) => u.is_admin).length;
                     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 eye-slash-icon hidden"><path stroke-linecap="round" stroke-linejoin="round" d="M3.98 8.223A10.477 10.477 0 001.934 12C3.226 16.338 7.244 19.5 12 19.5c.993 0 1.953-.138 2.863-.395M6.228 6.228A10.45 10.45 0 0112 4.5c4.756 0 8.773 3.162 10.065 7.498a10.523 10.523 0 01-4.293 5.774M6.228 6.228L3 3m3.228 3.228l3.65 3.65m7.894 7.894L21 21m-3.228-3.228l-3.65-3.65m0 0a3 3 0 10-4.243-4.243m4.242 4.242L9.88 9.88" /></svg>
                   </button>
                 </div>
-                <p class="text-xs text-zinc-500">Required for all users who don't set their own key.</p>
+                <p class="text-xs text-zinc-500">Required for all users who don't set their own token.</p>
               </div>
             </div>
           </div>

--- a/frontend/src/pages/admin.astro
+++ b/frontend/src/pages/admin.astro
@@ -433,7 +433,7 @@ const adminCount = users.filter((u: AdminUser) => u.is_admin).length;
         <div class="p-6 flex flex-col sm:flex-row sm:items-center gap-4">
           <div class="flex-1">
             <h3 class="font-semibold text-zinc-100 mb-1">Heal missing metadata</h3>
-            <p class="text-sm text-zinc-400">Re-enrich all items across every user's collection that are missing poster or date metadata. Requires a global TMDB API key to be set.</p>
+            <p class="text-sm text-zinc-400">Re-enrich all items across every user's collection that are missing poster or date metadata. Requires a global TMDB Read Access Token to be set.</p>
           </div>
           <button id="admin-heal-btn"
             class="shrink-0 px-5 py-2.5 bg-blue-600 hover:bg-blue-500 text-white text-sm font-semibold rounded-xl transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed">

--- a/frontend/src/pages/discover.astro
+++ b/frontend/src/pages/discover.astro
@@ -106,8 +106,8 @@ function skeletonWide() {
 
   {!hasTmdbKey && (
     <div class="p-10 bg-zinc-900/50 border border-zinc-800 rounded-2xl text-center mb-10">
-      <h2 class="text-xl font-bold text-zinc-100 mb-2">TMDB API Key Required</h2>
-      <p class="text-zinc-400 mb-5 max-w-md mx-auto">Add your TMDB API key in settings to unlock Discover.</p>
+      <h2 class="text-xl font-bold text-zinc-100 mb-2">TMDB Read Access Token Required</h2>
+      <p class="text-zinc-400 mb-5 max-w-md mx-auto">Add your TMDB Read Access Token in settings to unlock Discover.</p>
       <a href="/settings" class="inline-flex px-6 py-3 bg-blue-600 hover:bg-blue-500 text-white font-bold rounded-xl transition-all">
         Go to Settings
       </a>

--- a/frontend/src/pages/index.astro
+++ b/frontend/src/pages/index.astro
@@ -76,7 +76,7 @@ const discoverBackdropUrl = discoverPick?.backdrop_path
       </div>
       <div class="flex-1">
         <h2 class="text-xl font-bold text-zinc-100 mb-1">Finish setting up your account</h2>
-        <p class="text-zinc-400">To start using Scrob and explore movies and shows, you must add your TMDB API Key.</p>
+        <p class="text-zinc-400">To start using Scrob and explore movies and shows, you must add your TMDB Read Access Token.</p>
       </div>
       <a href="/settings" class="px-6 py-3 bg-blue-600 hover:bg-blue-500 text-zinc-100 font-bold rounded-xl transition-all shadow-lg shadow-blue-600/20 active:scale-95">
         Go to Settings

--- a/frontend/src/pages/movies.astro
+++ b/frontend/src/pages/movies.astro
@@ -84,8 +84,8 @@ const baseUrl = `/movies?${baseParams.toString()}`;
   {!hasTmdbKey ? (
     <div class="p-12 bg-zinc-900/50 border border-zinc-800 rounded-2xl text-center">
       <div class="text-4xl mb-4">🎬</div>
-      <h2 class="text-xl font-bold text-zinc-100 mb-2">TMDB API Key Required</h2>
-      <p class="text-zinc-400 mb-6 max-w-md mx-auto">To explore movies from The Movie Database, you must add your API key in the settings.</p>
+      <h2 class="text-xl font-bold text-zinc-100 mb-2">TMDB Read Access Token Required</h2>
+      <p class="text-zinc-400 mb-6 max-w-md mx-auto">To explore movies from The Movie Database, add your TMDB Read Access Token in settings.</p>
       <a href="/settings" class="inline-flex px-6 py-3 bg-blue-600 hover:bg-blue-500 text-white font-bold rounded-xl transition-all shadow-lg shadow-blue-600/20 active:scale-95">
         Go to Settings
       </a>

--- a/frontend/src/pages/settings.astro
+++ b/frontend/src/pages/settings.astro
@@ -274,6 +274,7 @@ if (me.totp_enabled) {
                         <p class="text-xs font-semibold uppercase tracking-wide text-zinc-500">Scrob → {typeLabel}</p>
                         {[
                           { key: "push_watched", label: "Watched status" },
+                          ...(conn.type === "nuvio" ? [{ key: "push_playback", label: "Playback progress" }] : []),
                           ...(conn.type === "nuvio" ? [] : [{ key: "push_ratings", label: "Ratings" }]),
                           ...(conn.type === "plex" ? [{ key: "plex_push_watchlist", label: "Watchlist" }] : []),
                         ].map(({ key, label }) => (
@@ -283,7 +284,7 @@ if (me.totp_enabled) {
                           </label>
                         ))}
                         <button type="button" data-action="push_upstream" data-conn-id={conn.id} data-conn-name={conn.name}
-                          title={`Push all watched states from Scrob to ${conn.name}`}
+                          title={`Push enabled data from Scrob to ${conn.name}`}
                           class="js-action-btn text-sm bg-zinc-800 hover:bg-zinc-700 text-zinc-300 border border-zinc-700 px-3 py-1.5 rounded-lg transition-colors cursor-pointer"
                         >Push</button>
                       </div>
@@ -442,6 +443,10 @@ if (me.totp_enabled) {
                           <span class="text-sm text-zinc-300 group-hover:text-zinc-100 transition-colors">{label}</span>
                         </label>
                       ))}
+                      <label id="new-push-playback-row" class="hidden new-provider-pref flex items-center gap-3 cursor-pointer group">
+                        <input type="checkbox" id="new-push-playback" class="w-4 h-4 rounded cursor-pointer" disabled />
+                        <span class="text-sm text-zinc-300 group-hover:text-zinc-100 transition-colors">Playback progress</span>
+                      </label>
                     </div>
                     <div class="bg-zinc-950 rounded-xl p-4 space-y-3">
                       <p class="text-xs font-semibold uppercase tracking-wide text-zinc-500">Auto Sync</p>
@@ -2468,6 +2473,7 @@ if (me.totp_enabled) {
             const pushPrefLabels: Record<string, string> = {
               push_watched: 'watched status',
               push_ratings: 'ratings',
+              push_playback: 'playback progress',
             };
             const pushing: string[] = [];
             card?.querySelectorAll('.conn-pref-checkbox').forEach((el: any) => {
@@ -3187,6 +3193,9 @@ if (me.totp_enabled) {
       if (tokenInput) tokenInput.autocomplete = isNuvio ? 'current-password' : 'off';
       const syncRatings = document.getElementById('new-sync-ratings') as HTMLInputElement | null;
       const pushRatings = document.getElementById('new-push-ratings') as HTMLInputElement | null;
+      const pushPlayback = document.getElementById('new-push-playback') as HTMLInputElement | null;
+      pushPlayback?.closest('label')?.classList.toggle('hidden', !isNuvio);
+      if (pushPlayback) pushPlayback.disabled = !isNuvio;
       for (const checkbox of [syncRatings, pushRatings]) {
         checkbox?.closest('label')?.classList.toggle('hidden', isNuvio);
         if (checkbox) checkbox.disabled = isNuvio;
@@ -3299,6 +3308,7 @@ if (me.totp_enabled) {
             sync_ratings: type === 'nuvio' ? false : ((document.getElementById('new-sync-ratings') as HTMLInputElement)?.checked ?? true),
             sync_playback: (document.getElementById('new-sync-playback') as HTMLInputElement)?.checked ?? true,
             push_watched: (document.getElementById('new-push-watched') as HTMLInputElement)?.checked ?? false,
+            push_playback: type === 'nuvio' && ((document.getElementById('new-push-playback') as HTMLInputElement)?.checked ?? false),
             push_ratings: type === 'nuvio' ? false : ((document.getElementById('new-push-ratings') as HTMLInputElement)?.checked ?? false),
             auto_sync_interval: (() => {
               const value = (document.getElementById('new-auto-sync') as HTMLSelectElement)?.value;

--- a/frontend/src/pages/settings.astro
+++ b/frontend/src/pages/settings.astro
@@ -41,9 +41,9 @@ if (me.totp_enabled) {
         </div>
         <form id="settings-form" class="space-y-6">
           <div class="space-y-6 max-w-xl">
-          <!-- TMDB API Key -->
+          <!-- TMDB Read Access Token -->
           <div class="space-y-2">
-            <label for="tmdb_api_key" class="block text-sm font-medium text-zinc-400">TMDB API Key</label>
+            <label for="tmdb_api_key" class="block text-sm font-medium text-zinc-400">TMDB Read Access Token</label>
             <div class="flex gap-2">
               <div class="relative flex-1 group/field">
                 <input
@@ -70,7 +70,7 @@ if (me.totp_enabled) {
               <button
                 type="button"
                 data-action="test_tmdb"
-                title="Test TMDB key"
+                title="Test TMDB token"
                 class="js-action-btn px-3 py-2 bg-zinc-800 hover:bg-zinc-700 border border-zinc-700 text-zinc-300 rounded-lg transition-colors cursor-pointer disabled:opacity-50"
               >
                 <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
@@ -79,11 +79,11 @@ if (me.totp_enabled) {
               </button>
             </div>
             {settings.has_global_tmdb_key && !settings.tmdb_api_key ? (
-              <p class="text-xs text-blue-400">A server-wide TMDB key is configured by your admin. You can leave this blank to use it, or enter your own key to override it.</p>
+              <p class="text-xs text-blue-400">A server-wide TMDB token is configured by your admin. You can leave this blank to use it, or enter your own token to override it.</p>
             ) : settings.has_global_tmdb_key && settings.tmdb_api_key ? (
-              <p class="text-xs text-blue-400">A server-wide TMDB key is configured, but you are using your own key. Clear this field to fall back to the server key.</p>
+              <p class="text-xs text-blue-400">A server-wide TMDB token is configured, but you are using your own token. Clear this field to fall back to the server token.</p>
             ) : (
-              <p class="text-xs text-zinc-500">Required for fetching metadata and posters. Will be validated before saving.</p>
+              <p class="text-xs text-zinc-500">Paste the API Read Access Token (v4) from TMDB Settings → API. Required for metadata and posters; validated before saving.</p>
             )}
           </div>
 
@@ -137,13 +137,13 @@ if (me.totp_enabled) {
 
           <!-- ======== SYNC SECTION ======== -->
           <div class="space-y-3 mt-8">
-            <h2 class="section-headline border-b border-zinc-800 pb-2">Media Server Connections</h2>
+            <h2 class="section-headline border-b border-zinc-800 pb-2">Media &amp; Cloud Connections</h2>
 
             <!-- Connections list (server-side rendered, managed client-side) -->
             <div id="connections-list" class="space-y-3">
             {connections.map((conn) => {
-              const typeColor = conn.type === "jellyfin" ? "bg-purple-500" : conn.type === "emby" ? "bg-green-500" : "bg-yellow-500";
-              const typeLabel = conn.type === "jellyfin" ? "Jellyfin" : conn.type === "emby" ? "Emby" : "Plex";
+              const typeColor = conn.type === "jellyfin" ? "bg-purple-500" : conn.type === "emby" ? "bg-green-500" : conn.type === "plex" ? "bg-yellow-500" : "bg-cyan-500";
+              const typeLabel = conn.type === "jellyfin" ? "Jellyfin" : conn.type === "emby" ? "Emby" : conn.type === "plex" ? "Plex" : "Nuvio";
               return (
               <div class="bg-zinc-900 border border-zinc-800 rounded-2xl overflow-hidden" data-connection-id={conn.id}>
                 <div class="collapsible-header flex items-center justify-between px-6 py-4 hover:bg-zinc-900/40 cursor-pointer transition-colors select-none" data-target={`conn-body-${conn.id}`}>
@@ -188,11 +188,11 @@ if (me.totp_enabled) {
                     <!-- Left: Connection details -->
                     <div class="space-y-4">
                       <div class="space-y-2">
-                        <label class="block text-sm font-medium text-zinc-400">Server URL</label>
-                        <input type="url" class="conn-url-input w-full bg-zinc-950 border border-zinc-800 rounded-lg px-4 py-3 text-zinc-100 focus:outline-none focus:ring-2 focus:ring-blue-500 transition-all" value={conn.url} data-conn-id={conn.id} />
+                        <label class="block text-sm font-medium text-zinc-400">{conn.type === "nuvio" ? "Cloud API URL" : "Server URL"}</label>
+                        <input type="url" class="conn-url-input w-full bg-zinc-950 border border-zinc-800 rounded-lg px-4 py-3 text-zinc-100 focus:outline-none focus:ring-2 focus:ring-blue-500 transition-all disabled:opacity-70" value={conn.url} data-conn-id={conn.id} disabled={conn.type === "nuvio"} />
                       </div>
                       <div class="space-y-2">
-                        <label class="block text-sm font-medium text-zinc-400">{conn.type === "plex" ? "X-Plex-Token" : "API Token"}</label>
+                        <label class="block text-sm font-medium text-zinc-400">{conn.type === "plex" ? "X-Plex-Token" : conn.type === "nuvio" ? "Refresh Token" : "API Token"}</label>
                         <div class="relative">
                           <input type="password" class="conn-token-input w-full bg-zinc-950 border border-zinc-800 rounded-lg pl-4 pr-10 py-3 text-zinc-100 focus:outline-none focus:ring-2 focus:ring-blue-500 transition-all" value={conn.token} data-conn-id={conn.id} />
                           <button type="button" class="password-toggle absolute right-2 top-1/2 -translate-y-1/2 text-zinc-500 hover:text-zinc-300 p-1 cursor-pointer transition-colors" aria-label="Toggle token visibility">
@@ -201,7 +201,14 @@ if (me.totp_enabled) {
                           </button>
                         </div>
                       </div>
-                      {conn.type !== "plex" && (
+                      {conn.type === "nuvio" ? (
+                        <div class="space-y-2">
+                          <label class="block text-sm font-medium text-zinc-400">Nuvio Profile</label>
+                          <select aria-label="Nuvio profile" class="conn-user-id-input w-full bg-zinc-950 border border-zinc-800 rounded-lg px-4 py-3 text-zinc-100 focus:outline-none focus:ring-2 focus:ring-blue-500 transition-all cursor-pointer" data-conn-id={conn.id}>
+                            <option value={conn.server_user_id || ""}>{conn.server_username || `Profile ${conn.server_user_id}`} (#{conn.server_user_id})</option>
+                          </select>
+                        </div>
+                      ) : conn.type !== "plex" && (
                         <div class="space-y-2">
                           <label class="block text-sm font-medium text-zinc-400">User ID</label>
                           <input type="text" class="conn-user-id-input w-full bg-zinc-950 border border-zinc-800 rounded-lg px-4 py-3 text-zinc-100 focus:outline-none focus:ring-2 focus:ring-blue-500 transition-all" value={conn.server_user_id || ""} data-conn-id={conn.id} />
@@ -214,35 +221,39 @@ if (me.totp_enabled) {
                           <input type="text" class="conn-username-input w-full bg-zinc-950 border border-zinc-800 rounded-lg px-4 py-3 text-zinc-100 focus:outline-none focus:ring-2 focus:ring-blue-500 transition-all" value={conn.server_username || ""} data-conn-id={conn.id} />
                         </div>
                       )}
-                      <div class="space-y-2">
-                        <label class="block text-sm font-medium text-zinc-400">Libraries to sync</label>
-                        <div class={`conn-library-picker`} data-conn-id={conn.id} data-conn-type={conn.type}>
-                          <div class="conn-libraries-list space-y-1 text-sm text-zinc-500 italic">Checking connection…</div>
-                          <p class="text-xs text-zinc-400 mt-1">Leave all unchecked to sync every library.</p>
-                          <div class="mt-3">
-                            <button type="button" data-action="scan_libraries" data-conn-id={conn.id} class="js-action-btn text-sm bg-zinc-800 hover:bg-zinc-700 text-zinc-300 border border-zinc-700 px-4 py-2 rounded-lg transition-colors cursor-pointer">Trigger library scan</button>
+                      {conn.type !== "nuvio" && (
+                        <>
+                          <div class="space-y-2">
+                            <label class="block text-sm font-medium text-zinc-400">Libraries to sync</label>
+                            <div class={`conn-library-picker`} data-conn-id={conn.id} data-conn-type={conn.type}>
+                              <div class="conn-libraries-list space-y-1 text-sm text-zinc-500 italic">Checking connection…</div>
+                              <p class="text-xs text-zinc-400 mt-1">Leave all unchecked to sync every library.</p>
+                              <div class="mt-3">
+                                <button type="button" data-action="scan_libraries" data-conn-id={conn.id} class="js-action-btn text-sm bg-zinc-800 hover:bg-zinc-700 text-zinc-300 border border-zinc-700 px-4 py-2 rounded-lg transition-colors cursor-pointer">Trigger library scan</button>
+                              </div>
+                            </div>
                           </div>
-                        </div>
-                      </div>
-                      <div class="space-y-2">
-                        <label class="block text-sm font-medium text-zinc-400">Webhook URL</label>
-                        <div class="flex gap-2">
-                          <input type="text" readonly class="conn-webhook-url flex-1 bg-zinc-950 border border-zinc-800 rounded-lg px-4 py-3 text-zinc-300 font-mono text-xs focus:outline-none cursor-default select-all" value="" data-conn-id={conn.id} data-conn-type={conn.type} />
-                          <button type="button" class="conn-copy-webhook px-3 py-2 bg-zinc-800 hover:bg-zinc-700 border border-zinc-700 text-zinc-300 rounded-lg transition-colors cursor-pointer" data-conn-id={conn.id}>
-                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5"><path stroke-linecap="round" stroke-linejoin="round" d="M15.666 3.888A2.25 2.25 0 0013.5 2.25h-3c-1.03 0-1.9.693-2.166 1.638m7.332 0c.055.194.084.4.084.612v0a.75.75 0 01-.75.75H9a.75.75 0 01-.75-.75v0c0-.212.03-.418.084-.612m7.332 0c.646.049 1.288.11 1.927.184 1.1.128 1.907 1.077 1.907 2.185V19.5a2.25 2.25 0 01-2.25 2.25H6.75A2.25 2.25 0 014.5 19.5V6.257c0-1.108.806-2.057 1.907-2.185a48.208 48.208 0 011.927-.184" /></svg>
-                          </button>
-                        </div>
-                      </div>
+                          <div class="space-y-2">
+                            <label class="block text-sm font-medium text-zinc-400">Webhook URL</label>
+                            <div class="flex gap-2">
+                              <input type="text" readonly class="conn-webhook-url flex-1 bg-zinc-950 border border-zinc-800 rounded-lg px-4 py-3 text-zinc-300 font-mono text-xs focus:outline-none cursor-default select-all" value="" data-conn-id={conn.id} data-conn-type={conn.type} />
+                              <button type="button" class="conn-copy-webhook px-3 py-2 bg-zinc-800 hover:bg-zinc-700 border border-zinc-700 text-zinc-300 rounded-lg transition-colors cursor-pointer" data-conn-id={conn.id}>
+                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5"><path stroke-linecap="round" stroke-linejoin="round" d="M15.666 3.888A2.25 2.25 0 0013.5 2.25h-3c-1.03 0-1.9.693-2.166 1.638m7.332 0c.055.194.084.4.084.612v0a.75.75 0 01-.75.75H9a.75.75 0 01-.75-.75v0c0-.212.03-.418.084-.612m7.332 0c.646.049 1.288.11 1.927.184 1.1.128 1.907 1.077 1.907 2.185V19.5a2.25 2.25 0 01-2.25 2.25H6.75A2.25 2.25 0 014.5 19.5V6.257c0-1.108.806-2.057 1.907-2.185a48.208 48.208 0 011.927-.184" /></svg>
+                              </button>
+                            </div>
+                          </div>
+                        </>
+                      )}
                     </div>
                     <!-- Right: Sync Preferences -->
                     <div class="space-y-4">
                       <div class="bg-zinc-950 rounded-xl p-4 space-y-3">
                         <p class="text-xs font-semibold uppercase tracking-wide text-zinc-500">{typeLabel} → Scrob</p>
                         {[
-                          { key: "sync_collection",   label: "Collection status" },
-                          { key: "sync_watched",      label: "Watched status" },
-                          { key: "sync_ratings",      label: "Ratings" },
-                          { key: "sync_playback",     label: "Playback events" },
+                          { key: "sync_collection", label: "Collection status" },
+                          { key: "sync_watched", label: "Watched status" },
+                          ...(conn.type === "nuvio" ? [] : [{ key: "sync_ratings", label: "Ratings" }]),
+                          { key: "sync_playback", label: conn.type === "nuvio" ? "Playback progress" : "Playback events" },
                           ...(conn.type === "plex" ? [{ key: "plex_sync_watchlist", label: "Watchlist" }] : []),
                         ].map(({ key, label }) => (
                           <label class="flex items-center gap-3 cursor-pointer group">
@@ -253,9 +264,9 @@ if (me.totp_enabled) {
                         <div class="flex items-center gap-3">
                           <button type="button" data-action="sync_connection" data-conn-id={conn.id} data-conn-type={conn.type} data-conn-name={conn.name}
                             disabled={!hasTmdbKey}
-                            title={!hasTmdbKey ? "TMDB API Key is required for sync" : `Pull from ${conn.name}`}
+                            title={!hasTmdbKey ? "TMDB Read Access Token is required for sync" : conn.type === "nuvio" ? "Sync Nuvio library, watch history, and playback progress" : `Pull from ${conn.name}`}
                             class={`js-action-btn text-sm px-3 py-1.5 rounded-lg transition-colors cursor-pointer disabled:opacity-50 ${hasTmdbKey ? "bg-zinc-800 hover:bg-zinc-700 text-zinc-300 border border-zinc-700" : "bg-zinc-800 text-zinc-400 border border-zinc-700 opacity-50"}`}
-                          >Pull</button>
+                          >{conn.type === "nuvio" ? "Sync now" : "Pull"}</button>
                           <span id={`${conn.type}-last-sync`} class="hidden text-xs text-zinc-500"></span>
                         </div>
                       </div>
@@ -263,7 +274,7 @@ if (me.totp_enabled) {
                         <p class="text-xs font-semibold uppercase tracking-wide text-zinc-500">Scrob → {typeLabel}</p>
                         {[
                           { key: "push_watched", label: "Watched status" },
-                          { key: "push_ratings", label: "Ratings" },
+                          ...(conn.type === "nuvio" ? [] : [{ key: "push_ratings", label: "Ratings" }]),
                           ...(conn.type === "plex" ? [{ key: "plex_push_watchlist", label: "Watchlist" }] : []),
                         ].map(({ key, label }) => (
                           <label class="flex items-center gap-3 cursor-pointer group">
@@ -272,7 +283,7 @@ if (me.totp_enabled) {
                           </label>
                         ))}
                         <button type="button" data-action="push_upstream" data-conn-id={conn.id} data-conn-name={conn.name}
-                          title="Push all watched states and ratings from Scrob to this server"
+                          title={`Push all watched states from Scrob to ${conn.name}`}
                           class="js-action-btn text-sm bg-zinc-800 hover:bg-zinc-700 text-zinc-300 border border-zinc-700 px-3 py-1.5 rounded-lg transition-colors cursor-pointer"
                         >Push</button>
                       </div>
@@ -282,8 +293,17 @@ if (me.totp_enabled) {
                           <label class="text-sm text-zinc-300">Pull interval</label>
                           <select class="conn-auto-sync bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2 text-sm text-zinc-100 focus:outline-none focus:ring-2 focus:ring-blue-500 transition-all cursor-pointer" data-conn-id={conn.id}>
                             <option value="" selected={!conn.auto_sync_interval}>Disabled</option>
-                            {[6, 12, 24, 48].map(h => (
-                              <option value={String(h)} selected={conn.auto_sync_interval === h}>Every {h}h</option>
+                            {[
+                              { value: 0.25, label: "Every 15m" },
+                              { value: 0.5, label: "Every 30m" },
+                              { value: 1, label: "Every 1h" },
+                              { value: 3, label: "Every 3h" },
+                              { value: 6, label: "Every 6h" },
+                              { value: 12, label: "Every 12h" },
+                              { value: 24, label: "Every 24h" },
+                              { value: 48, label: "Every 48h" },
+                            ].map(({ value, label }) => (
+                              <option value={String(value)} selected={conn.auto_sync_interval === value}>{label}</option>
                             ))}
                           </select>
                         </div>
@@ -350,19 +370,24 @@ if (me.totp_enabled) {
                       <input type="text" id="new-conn-name" placeholder="e.g. Home Plex" class="w-full bg-zinc-950 border border-zinc-800 rounded-lg px-4 py-3 text-zinc-100 focus:outline-none focus:ring-2 focus:ring-blue-500 transition-all" />
                     </div>
                     <div class="space-y-2">
-                      <label for="new-conn-type" class="block text-sm font-medium text-zinc-400">Server Type</label>
+                      <label for="new-conn-type" class="block text-sm font-medium text-zinc-400">Provider Type</label>
                       <select id="new-conn-type" class="w-full bg-zinc-950 border border-zinc-800 rounded-lg px-4 py-3 text-zinc-100 focus:outline-none focus:ring-2 focus:ring-blue-500 transition-all cursor-pointer">
                         <option value="jellyfin">Jellyfin</option>
                         <option value="emby">Emby</option>
                         <option value="plex">Plex</option>
+                        <option value="nuvio">Nuvio</option>
                       </select>
                     </div>
-                    <div class="space-y-2">
-                      <label for="new-conn-url" class="block text-sm font-medium text-zinc-400">Server URL</label>
-                      <input type="url" id="new-conn-url" placeholder="http://192.168.1.100:8096" class="w-full bg-zinc-950 border border-zinc-800 rounded-lg px-4 py-3 text-zinc-100 focus:outline-none focus:ring-2 focus:ring-blue-500 transition-all" />
+                    <div id="new-conn-url-row" class="space-y-2">
+                      <label id="new-conn-url-label" for="new-conn-url" class="block text-sm font-medium text-zinc-400">Server URL</label>
+                      <input type="url" id="new-conn-url" placeholder="http://192.168.1.100:8096" class="w-full bg-zinc-950 border border-zinc-800 rounded-lg px-4 py-3 text-zinc-100 focus:outline-none focus:ring-2 focus:ring-blue-500 transition-all disabled:opacity-70" />
+                    </div>
+                    <div id="new-nuvio-email-row" class="space-y-2 hidden">
+                      <label for="new-nuvio-email" class="block text-sm font-medium text-zinc-400">Nuvio Email</label>
+                      <input type="email" id="new-nuvio-email" autocomplete="username" class="w-full bg-zinc-950 border border-zinc-800 rounded-lg px-4 py-3 text-zinc-100 focus:outline-none focus:ring-2 focus:ring-blue-500 transition-all" />
                     </div>
                     <div class="space-y-2">
-                      <label for="new-conn-token" class="block text-sm font-medium text-zinc-400">Token</label>
+                      <label id="new-conn-token-label" for="new-conn-token" class="block text-sm font-medium text-zinc-400">Token</label>
                       <div class="relative">
                         <input type="password" id="new-conn-token" class="w-full bg-zinc-950 border border-zinc-800 rounded-lg pl-4 pr-10 py-3 text-zinc-100 focus:outline-none focus:ring-2 focus:ring-blue-500 transition-all" />
                         <button type="button" class="password-toggle absolute right-2 top-1/2 -translate-y-1/2 text-zinc-500 hover:text-zinc-300 p-1 cursor-pointer transition-colors" aria-label="Toggle token visibility">
@@ -374,6 +399,12 @@ if (me.totp_enabled) {
                     <div id="new-conn-user-id-row" class="space-y-2">
                       <label for="new-conn-user-id" class="block text-sm font-medium text-zinc-400">User ID</label>
                       <input type="text" id="new-conn-user-id" placeholder="e.g. 550e8400-e29b-41d4-a716-446655440000" class="w-full bg-zinc-950 border border-zinc-800 rounded-lg px-4 py-3 text-zinc-100 focus:outline-none focus:ring-2 focus:ring-blue-500 transition-all" />
+                    </div>
+                    <div id="new-nuvio-profile-row" class="space-y-2 hidden">
+                      <label for="new-nuvio-profile" class="block text-sm font-medium text-zinc-400">Nuvio Profile</label>
+                      <select id="new-nuvio-profile" class="w-full bg-zinc-950 border border-zinc-800 rounded-lg px-4 py-3 text-zinc-100 focus:outline-none focus:ring-2 focus:ring-blue-500 transition-all cursor-pointer">
+                        <option value="">Sign in to load profiles</option>
+                      </select>
                     </div>
                     <div id="new-conn-username-row" class="space-y-2 hidden">
                       <label for="new-conn-username" class="block text-sm font-medium text-zinc-400">Plex Username</label>
@@ -387,26 +418,26 @@ if (me.totp_enabled) {
                   </div>
                   <div class="space-y-4">
                     <div class="bg-zinc-950 rounded-xl p-4 space-y-3">
-                      <p class="text-xs font-semibold uppercase tracking-wide text-zinc-500">Server → Scrob</p>
+                      <p id="new-pull-heading" class="text-xs font-semibold uppercase tracking-wide text-zinc-500">Server → Scrob</p>
                       {[
                         { id: "new-sync-collection", label: "Collection status", defaultOn: true },
                         { id: "new-sync-watched",    label: "Watched status",    defaultOn: true },
                         { id: "new-sync-ratings",    label: "Ratings",           defaultOn: true },
                         { id: "new-sync-playback",   label: "Playback events",   defaultOn: true },
                       ].map(({ id, label, defaultOn }) => (
-                        <label class="flex items-center gap-3 cursor-pointer group">
+                        <label class="new-provider-pref flex items-center gap-3 cursor-pointer group">
                           <input type="checkbox" id={id} class="w-4 h-4 rounded cursor-pointer" checked={defaultOn} />
-                          <span class="text-sm text-zinc-300 group-hover:text-zinc-100 transition-colors">{label}</span>
+                          <span id={`${id}-label`} class="text-sm text-zinc-300 group-hover:text-zinc-100 transition-colors">{label}</span>
                         </label>
                       ))}
                     </div>
                     <div class="bg-zinc-950 rounded-xl p-4 space-y-3">
-                      <p class="text-xs font-semibold uppercase tracking-wide text-zinc-500">Scrob → Server</p>
+                      <p id="new-push-heading" class="text-xs font-semibold uppercase tracking-wide text-zinc-500">Scrob → Server</p>
                       {[
                         { id: "new-push-watched", label: "Watched status" },
                         { id: "new-push-ratings", label: "Ratings" },
                       ].map(({ id, label }) => (
-                        <label class="flex items-center gap-3 cursor-pointer group">
+                        <label class="new-provider-pref flex items-center gap-3 cursor-pointer group">
                           <input type="checkbox" id={id} class="w-4 h-4 rounded cursor-pointer" />
                           <span class="text-sm text-zinc-300 group-hover:text-zinc-100 transition-colors">{label}</span>
                         </label>
@@ -418,7 +449,16 @@ if (me.totp_enabled) {
                         <label class="text-sm text-zinc-300">Sync interval</label>
                         <select id="new-auto-sync" class="bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2 text-sm text-zinc-100 cursor-pointer">
                           <option value="">Disabled</option>
-                          {[6, 12, 24, 48].map(h => (<option value={String(h)}>Every {h}h</option>))}
+                          {[
+                            { value: 0.25, label: "Every 15m" },
+                            { value: 0.5, label: "Every 30m" },
+                            { value: 1, label: "Every 1h" },
+                            { value: 3, label: "Every 3h" },
+                            { value: 6, label: "Every 6h" },
+                            { value: 12, label: "Every 12h" },
+                            { value: 24, label: "Every 24h" },
+                            { value: 48, label: "Every 48h" },
+                          ].map(({ value, label }) => (<option value={String(value)}>{label}</option>))}
                         </select>
                       </div>
                     </div>
@@ -703,7 +743,7 @@ if (me.totp_enabled) {
                           type="button"
                           data-action="sync_trakt"
                           disabled={!hasTmdbKey}
-                          title={!hasTmdbKey ? "TMDB API Key is required for sync" : "Pull watched history and ratings from Trakt"}
+                          title={!hasTmdbKey ? "TMDB Read Access Token is required for sync" : "Pull watched history and ratings from Trakt"}
                           class={`js-action-btn text-sm px-3 py-1.5 rounded-lg transition-colors cursor-pointer disabled:opacity-50 ${hasTmdbKey ? "bg-red-500/10 hover:bg-red-500/20 text-red-400 border border-red-500/30" : "bg-zinc-800 text-zinc-400 border border-zinc-700 opacity-50"}`}
                         >Pull</button>
                       </div>
@@ -820,7 +860,7 @@ if (me.totp_enabled) {
                           type="button"
                           data-action="sync_simkl"
                           disabled={!hasTmdbKey}
-                          title={!hasTmdbKey ? "TMDB API Key is required for sync" : "Pull watched history and ratings from Simkl"}
+                          title={!hasTmdbKey ? "TMDB Read Access Token is required for sync" : "Pull watched history and ratings from Simkl"}
                           class={`js-action-btn text-sm px-3 py-1.5 rounded-lg transition-colors cursor-pointer disabled:opacity-50 ${hasTmdbKey ? "bg-teal-500/10 hover:bg-teal-500/20 text-teal-400 border border-teal-500/30" : "bg-zinc-800 text-zinc-400 border border-zinc-700 opacity-50"}`}
                         >Pull</button>
                       </div>
@@ -1103,7 +1143,7 @@ if (me.totp_enabled) {
                 id="heal-btn"
                 type="button"
                 disabled={!hasTmdbKey}
-                title={!hasTmdbKey ? "TMDB API Key is required" : ""}
+                title={!hasTmdbKey ? "TMDB Read Access Token is required" : ""}
                 class="ml-4 shrink-0 text-sm px-4 py-2 rounded-lg transition-colors cursor-pointer disabled:opacity-50 bg-blue-600/20 hover:bg-blue-600/30 text-blue-400 border border-blue-500/30"
               >
                 Heal
@@ -2112,6 +2152,24 @@ if (me.totp_enabled) {
       }
       for (const cs of (data.connections ?? [])) {
         setConnStatus(`conn-status-${cs.id}`, cs.connected ? 'connected' : 'disconnected');
+        if (cs.token) {
+          const card = document.querySelector(`[data-connection-id="${cs.id}"]`);
+          const tokenInput = card?.querySelector('.conn-token-input') as HTMLInputElement | null;
+          if (tokenInput) tokenInput.value = cs.token;
+        }
+        if (cs.profiles?.length) {
+          const card = document.querySelector(`[data-connection-id="${cs.id}"]`);
+          const profileSelect = card?.querySelector('.conn-user-id-input') as HTMLSelectElement | null;
+          if (profileSelect) {
+            const selectedProfile = profileSelect.value;
+            profileSelect.innerHTML = cs.profiles.map((profile: any) =>
+              `<option value="${esc(String(profile.profile_index))}">${esc(profile.name || `Profile ${profile.profile_index}`)} (#${esc(String(profile.profile_index))})</option>`
+            ).join('');
+            if ([...profileSelect.options].some(option => option.value === selectedProfile)) {
+              profileSelect.value = selectedProfile;
+            }
+          }
+        }
         if (cs.connected) loadLibraries(String(cs.id));
       }
     } catch {
@@ -2234,19 +2292,39 @@ if (me.totp_enabled) {
             const u = (card?.querySelector('.conn-url-input') as HTMLInputElement)?.value || '';
             const t = (card?.querySelector('.conn-token-input') as HTMLInputElement)?.value || '';
             const ui = (card?.querySelector('.conn-user-id-input') as HTMLInputElement)?.value || '';
-            let testEndpoint: string;
-            if (connType === 'plex') {
-              testEndpoint = `/api/proxy/auth/test-plex?url=${encodeURIComponent(u)}&token=${encodeURIComponent(t)}`;
-            } else if (connType === 'emby') {
-              testEndpoint = `/api/proxy/auth/test-emby?url=${encodeURIComponent(u)}&token=${encodeURIComponent(t)}&user_id=${encodeURIComponent(ui)}`;
+            let testRes: Response;
+            if (connType === 'nuvio') {
+              testRes = await fetch('/api/proxy/auth/test-nuvio', {
+                method: 'POST',
+                headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' },
+                body: JSON.stringify({ url: u, token: t, profile_id: parseInt(ui) }),
+              });
             } else {
-              testEndpoint = `/api/proxy/auth/test-jellyfin?url=${encodeURIComponent(u)}&token=${encodeURIComponent(t)}&user_id=${encodeURIComponent(ui)}`;
+              let testEndpoint: string;
+              if (connType === 'plex') {
+                testEndpoint = `/api/proxy/auth/test-plex?url=${encodeURIComponent(u)}&token=${encodeURIComponent(t)}`;
+              } else if (connType === 'emby') {
+                testEndpoint = `/api/proxy/auth/test-emby?url=${encodeURIComponent(u)}&token=${encodeURIComponent(t)}&user_id=${encodeURIComponent(ui)}`;
+              } else {
+                testEndpoint = `/api/proxy/auth/test-jellyfin?url=${encodeURIComponent(u)}&token=${encodeURIComponent(t)}&user_id=${encodeURIComponent(ui)}`;
+              }
+              testRes = await fetch(testEndpoint, { method: 'POST', headers: { 'Authorization': `Bearer ${token}` } });
             }
-            const testRes = await fetch(testEndpoint, { method: 'POST', headers: { 'Authorization': `Bearer ${token}` } });
             const testData = await testRes.json();
             if (testRes.ok) {
               showMessage(testData.message || 'Connection successful!');
               if (connId) setConnStatus(`conn-status-${connId}`, 'connected');
+              if (connType === 'nuvio' && connId) {
+                const saveTokenRes = await fetch(`/api/proxy/auth/connections/${connId}`, {
+                  method: 'PATCH',
+                  headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' },
+                  body: JSON.stringify({ token: testData.refresh_token }),
+                });
+                if (!saveTokenRes.ok) throw new Error('Nuvio session was validated but could not be saved');
+                const savedConnection = await saveTokenRes.json();
+                const tokenInput = card?.querySelector('.conn-token-input') as HTMLInputElement | null;
+                if (tokenInput) tokenInput.value = savedConnection.token;
+              }
             } else {
               if (connId) setConnStatus(`conn-status-${connId}`, 'disconnected');
               throw new Error(testData.detail || 'Connection test failed');
@@ -2262,7 +2340,7 @@ if (me.totp_enabled) {
               server_username: (card?.querySelector('.conn-username-input') as HTMLInputElement)?.value || null,
               auto_sync_interval: (() => {
                 const v = (card?.querySelector('.conn-auto-sync') as HTMLSelectElement)?.value;
-                return v ? parseInt(v) : null;
+                return v ? parseFloat(v) : null;
               })(),
             };
             card?.querySelectorAll('.conn-pref-checkbox').forEach((cb: any) => {
@@ -2283,6 +2361,9 @@ if (me.totp_enabled) {
               const err = await saveRes.json();
               throw new Error(err.detail || 'Failed to save connection');
             }
+            const savedConnection = await saveRes.json();
+            const savedTokenInput = card?.querySelector('.conn-token-input') as HTMLInputElement | null;
+            if (savedTokenInput && savedConnection.token) savedTokenInput.value = savedConnection.token;
             // Save libraries if they've been loaded
             const libList = card?.querySelector('.conn-libraries-list');
             if (libList && libList.querySelector('.library-checkbox')) {
@@ -3070,17 +3151,83 @@ if (me.totp_enabled) {
       cancelBtn.addEventListener('click', () => addForm.classList.add('hidden'));
     }
 
-    // Show/hide user_id vs username based on new connection type
+    // Provider-specific fields for a new connection
     const typeSelect = document.getElementById('new-conn-type') as HTMLSelectElement | null;
     const userIdRow = document.getElementById('new-conn-user-id-row');
     const usernameRow = document.getElementById('new-conn-username-row');
+    const nuvioEmailRow = document.getElementById('new-nuvio-email-row');
+    const nuvioProfileRow = document.getElementById('new-nuvio-profile-row');
+    const urlInput = document.getElementById('new-conn-url') as HTMLInputElement | null;
+    const urlLabel = document.getElementById('new-conn-url-label');
+    const tokenInput = document.getElementById('new-conn-token') as HTMLInputElement | null;
+    const tokenLabel = document.getElementById('new-conn-token-label');
+    const nuvioProfileSelect = document.getElementById('new-nuvio-profile') as HTMLSelectElement | null;
+    let pendingNuvioRefreshToken = '';
+    let previousType = typeSelect?.value ?? 'jellyfin';
+
     const updateTypeFields = () => {
-      const isPlex = typeSelect?.value === 'plex';
-      userIdRow?.classList.toggle('hidden', isPlex);
+      const type = typeSelect?.value ?? 'jellyfin';
+      const isPlex = type === 'plex';
+      const isNuvio = type === 'nuvio';
+      userIdRow?.classList.toggle('hidden', isPlex || isNuvio);
       usernameRow?.classList.toggle('hidden', !isPlex);
+      nuvioEmailRow?.classList.toggle('hidden', !isNuvio);
+      nuvioProfileRow?.classList.toggle('hidden', !isNuvio);
+      if (urlInput) {
+        if (isNuvio) {
+          urlInput.value = 'https://api.nuvio.tv';
+          urlInput.disabled = true;
+        } else {
+          if (previousType === 'nuvio' && urlInput.value === 'https://api.nuvio.tv') urlInput.value = '';
+          urlInput.disabled = false;
+        }
+      }
+      if (urlLabel) urlLabel.textContent = isNuvio ? 'Cloud API URL' : 'Server URL';
+      if (tokenLabel) tokenLabel.textContent = isNuvio ? 'Nuvio Password' : 'Token';
+      if (tokenInput) tokenInput.autocomplete = isNuvio ? 'current-password' : 'off';
+      const syncRatings = document.getElementById('new-sync-ratings') as HTMLInputElement | null;
+      const pushRatings = document.getElementById('new-push-ratings') as HTMLInputElement | null;
+      for (const checkbox of [syncRatings, pushRatings]) {
+        checkbox?.closest('label')?.classList.toggle('hidden', isNuvio);
+        if (checkbox) checkbox.disabled = isNuvio;
+      }
+      const playbackLabel = document.getElementById('new-sync-playback-label');
+      if (playbackLabel) playbackLabel.textContent = isNuvio ? 'Playback progress' : 'Playback events';
+      const pullHeading = document.getElementById('new-pull-heading');
+      const pushHeading = document.getElementById('new-push-heading');
+      if (pullHeading) pullHeading.textContent = isNuvio ? 'Nuvio → Scrob' : 'Server → Scrob';
+      if (pushHeading) pushHeading.textContent = isNuvio ? 'Scrob → Nuvio' : 'Scrob → Server';
+      if (type !== previousType) pendingNuvioRefreshToken = '';
+      previousType = type;
     };
     typeSelect?.addEventListener('change', updateTypeFields);
     updateTypeFields();
+
+    const authenticateNuvio = async () => {
+      const email = (document.getElementById('new-nuvio-email') as HTMLInputElement | null)?.value.trim() || '';
+      const password = tokenInput?.value || '';
+      const url = urlInput?.value || 'https://api.nuvio.tv';
+      if (!email || !password) throw new Error('Nuvio email and password are required.');
+      const selectedProfile = nuvioProfileSelect?.value || '';
+      const response = await fetch('/api/proxy/auth/nuvio-login', {
+        method: 'POST',
+        headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password, url }),
+      });
+      const data = await response.json();
+      if (!response.ok) throw new Error(data.detail || 'Nuvio sign-in failed');
+      pendingNuvioRefreshToken = data.refresh_token;
+      if (nuvioProfileSelect) {
+        nuvioProfileSelect.innerHTML = (data.profiles || []).map((profile: any) =>
+          `<option value="${esc(String(profile.profile_index))}">${esc(profile.name || `Profile ${profile.profile_index}`)} (#${esc(String(profile.profile_index))})</option>`
+        ).join('');
+        if (selectedProfile && [...nuvioProfileSelect.options].some(option => option.value === selectedProfile)) {
+          nuvioProfileSelect.value = selectedProfile;
+        }
+      }
+      if (!nuvioProfileSelect?.value) throw new Error('No Nuvio profile is available for this account.');
+      return data;
+    };
 
     // Test new connection button
     const testNewBtn = document.getElementById('test-new-connection-btn');
@@ -3094,18 +3241,23 @@ if (me.totp_enabled) {
         const orig = testNewBtn.textContent;
         testNewBtn.textContent = '...';
         try {
-          let ep: string;
-          if (type === 'plex') {
-            ep = `/api/proxy/auth/test-plex?url=${encodeURIComponent(u)}&token=${encodeURIComponent(t)}`;
-          } else if (type === 'emby') {
-            ep = `/api/proxy/auth/test-emby?url=${encodeURIComponent(u)}&token=${encodeURIComponent(t)}&user_id=${encodeURIComponent(ui)}`;
+          if (type === 'nuvio') {
+            await authenticateNuvio();
+            showMessage('Nuvio connection successful. Select the profile to sync.');
           } else {
-            ep = `/api/proxy/auth/test-jellyfin?url=${encodeURIComponent(u)}&token=${encodeURIComponent(t)}&user_id=${encodeURIComponent(ui)}`;
+            let ep: string;
+            if (type === 'plex') {
+              ep = `/api/proxy/auth/test-plex?url=${encodeURIComponent(u)}&token=${encodeURIComponent(t)}`;
+            } else if (type === 'emby') {
+              ep = `/api/proxy/auth/test-emby?url=${encodeURIComponent(u)}&token=${encodeURIComponent(t)}&user_id=${encodeURIComponent(ui)}`;
+            } else {
+              ep = `/api/proxy/auth/test-jellyfin?url=${encodeURIComponent(u)}&token=${encodeURIComponent(t)}&user_id=${encodeURIComponent(ui)}`;
+            }
+            const res = await fetch(ep, { method: 'POST', headers: { 'Authorization': `Bearer ${token}` } });
+            const data = await res.json();
+            if (res.ok) showMessage(data.message || 'Connection successful!');
+            else throw new Error(data.detail || 'Connection test failed');
           }
-          const res = await fetch(ep, { method: 'POST', headers: { 'Authorization': `Bearer ${token}` } });
-          const data = await res.json();
-          if (res.ok) showMessage(data.message || 'Connection successful!');
-          else throw new Error(data.detail || 'Connection test failed');
         } catch (e: any) {
           showMessage(e.message, 'error');
         } finally {
@@ -3122,32 +3274,40 @@ if (me.totp_enabled) {
         const name = (document.getElementById('new-conn-name') as HTMLInputElement)?.value.trim();
         const type = typeSelect?.value ?? 'jellyfin';
         const u = (document.getElementById('new-conn-url') as HTMLInputElement)?.value.trim();
-        const t = (document.getElementById('new-conn-token') as HTMLInputElement)?.value.trim();
-        const ui = (document.getElementById('new-conn-user-id') as HTMLInputElement)?.value.trim() || null;
-        const un = (document.getElementById('new-conn-username') as HTMLInputElement)?.value.trim() || null;
-        if (!name || !u || !t) { showMessage('Name, URL and Token are required.', 'error'); return; }
+        let connectionToken = (document.getElementById('new-conn-token') as HTMLInputElement)?.value.trim();
+        let userId = (document.getElementById('new-conn-user-id') as HTMLInputElement)?.value.trim() || null;
+        const username = (document.getElementById('new-conn-username') as HTMLInputElement)?.value.trim() || null;
+        if (!name || !u || !connectionToken) {
+          showMessage(type === 'nuvio' ? 'Name, Nuvio email and password are required.' : 'Name, URL and Token are required.', 'error');
+          return;
+        }
 
         createBtn.disabled = true;
         const orig = createBtn.textContent;
         createBtn.textContent = 'Adding…';
 
-        const body: Record<string, any> = {
-          name, type, url: u, token: t,
-          sync_collection: (document.getElementById('new-sync-collection') as HTMLInputElement)?.checked ?? true,
-          sync_watched: (document.getElementById('new-sync-watched') as HTMLInputElement)?.checked ?? true,
-          sync_ratings: (document.getElementById('new-sync-ratings') as HTMLInputElement)?.checked ?? true,
-          sync_playback: (document.getElementById('new-sync-playback') as HTMLInputElement)?.checked ?? true,
-          push_watched: (document.getElementById('new-push-watched') as HTMLInputElement)?.checked ?? false,
-          push_ratings: (document.getElementById('new-push-ratings') as HTMLInputElement)?.checked ?? false,
-          auto_sync_interval: (() => {
-            const v = (document.getElementById('new-auto-sync') as HTMLSelectElement)?.value;
-            return v ? parseInt(v) : null;
-          })(),
-        };
-        if (type === 'plex') body.server_username = un;
-        else body.server_user_id = ui;
-
         try {
+          if (type === 'nuvio') {
+            await authenticateNuvio();
+            connectionToken = pendingNuvioRefreshToken;
+            userId = nuvioProfileSelect?.value || null;
+          }
+          const body: Record<string, any> = {
+            name, type, url: u, token: connectionToken,
+            sync_collection: (document.getElementById('new-sync-collection') as HTMLInputElement)?.checked ?? true,
+            sync_watched: (document.getElementById('new-sync-watched') as HTMLInputElement)?.checked ?? true,
+            sync_ratings: type === 'nuvio' ? false : ((document.getElementById('new-sync-ratings') as HTMLInputElement)?.checked ?? true),
+            sync_playback: (document.getElementById('new-sync-playback') as HTMLInputElement)?.checked ?? true,
+            push_watched: (document.getElementById('new-push-watched') as HTMLInputElement)?.checked ?? false,
+            push_ratings: type === 'nuvio' ? false : ((document.getElementById('new-push-ratings') as HTMLInputElement)?.checked ?? false),
+            auto_sync_interval: (() => {
+              const value = (document.getElementById('new-auto-sync') as HTMLSelectElement)?.value;
+              return value ? parseFloat(value) : null;
+            })(),
+          };
+          if (type === 'plex') body.server_username = username;
+          else body.server_user_id = userId;
+
           const res = await fetch('/api/proxy/auth/connections', {
             method: 'POST',
             headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' },
@@ -3730,7 +3890,7 @@ if (me.totp_enabled) {
         return `${Math.floor(diff / 86400)}d ago`;
       }
 
-      for (const source of ['jellyfin', 'emby', 'plex'] as const) {
+      for (const source of ['jellyfin', 'emby', 'plex', 'nuvio'] as const) {
         const el = document.getElementById(`${source}-last-sync`);
         if (!el) continue;
         const job = jobs.find(j => j.source === source && (j.status === 'completed' || j.status === 'failed'));

--- a/frontend/src/pages/shows.astro
+++ b/frontend/src/pages/shows.astro
@@ -89,8 +89,8 @@ const baseUrl = `/shows?${baseParams.toString()}`;
   {!hasTmdbKey ? (
     <div class="p-12 bg-zinc-900/50 border border-zinc-800 rounded-2xl text-center">
       <div class="text-4xl mb-4">📺</div>
-      <h2 class="text-xl font-bold text-zinc-100 mb-2">TMDB API Key Required</h2>
-      <p class="text-zinc-400 mb-6 max-w-md mx-auto">To explore shows from The Movie Database, you must add your API key in the settings.</p>
+      <h2 class="text-xl font-bold text-zinc-100 mb-2">TMDB Read Access Token Required</h2>
+      <p class="text-zinc-400 mb-6 max-w-md mx-auto">To explore shows from The Movie Database, add your TMDB Read Access Token in settings.</p>
       <a href="/settings" class="inline-flex px-6 py-3 bg-blue-600 hover:bg-blue-500 text-white font-bold rounded-xl transition-all shadow-lg shadow-blue-600/20 active:scale-95">
         Go to Settings
       </a>


### PR DESCRIPTION
## Summary

Adds Nuvio Cloud as a first-class Scrob connection provider with profile-aware library, watched-history, and playback-progress synchronization.

- authenticate with Nuvio email/password without persisting the password
- persist and rotate the Nuvio refresh token
- load named Nuvio profiles and synchronize each profile independently
- pull library items, watched history, and Continue Watching progress
- push watched/unwatched state and playback progress back to Nuvio
- normalize inbound IMDb identifiers through TMDB
- resolve outbound TMDB identifiers to Nuvio-compatible bare IMDb IDs
- support manual Sync now, explicit Push, and scheduled Auto Pull
- support 15m, 30m, 1h, 3h, 6h, 12h, 24h, and 48h pull intervals
- include directly collected cloud series in My Shows
- document setup, synchronization directions, scheduling, and limitations

Nuvio API documentation: https://nuvio.tv/docs

## Authentication and profiles

Scrob exchanges the Nuvio email/password for a Supabase refresh token. The password is never persisted. Refresh-token rotation is handled during connection validation, status checks, pulls, and pushes.

Profiles are loaded after authentication and displayed by name and index, for example:

```text
Main (#1)
Kids (#2)
```

Each Scrob connection targets one Nuvio profile. Multiple connections can be added for multiple profiles.

## Pull synchronization

A Nuvio pull imports:

- library movies and series
- watched movies and episodes
- watch timestamps
- playback position and duration
- Continue Watching progress

The same pull runner is used by Sync now, connection scans, and scheduled Auto Pull jobs. Nuvio synchronization is polling-based; it does not use Scrob's media-server webhook URLs.

## Media matching

Nuvio returns bare IMDb content identifiers such as `tt0411008`. Scrob resolves them through TMDB's external-ID endpoint and stores TMDB IDs for internal matching.

```text
Nuvio IMDb ID
-> TMDB movie or series ID
-> Scrob Media / Show
```

For outbound writes, Scrob performs the reverse mapping and sends bare IMDb identifiers (`tt...`), as expected by Nuvio. Resolved IMDb IDs are cached in existing TMDB metadata. Unsupported or ambiguous identifiers are skipped rather than attached to the wrong title.

## Outbound synchronization

Scrob can push:

- watched state through `sync_push_watched_items`
- unwatched state through `sync_delete_watched_items`
- playback position and duration through `sync_push_watch_progress`

Watched and progress writes use Nuvio's non-destructive batch upserts. Items absent from Scrob are not removed from Nuvio. Manual watched/unwatched changes use the same bare IMDb identifier mapping as full pushes, preventing duplicate `tmdb:*` cloud records.

Ratings and library membership are currently pull-only.

## Series collections

The My Shows query now supports both collection models:

- directly collected series, used by cloud/watchlist providers such as Nuvio
- series inferred from collected episodes, used by media-server libraries

Nuvio synchronization creates Show metadata for every series in the Nuvio library, including series without watched or in-progress episodes.

## Scheduled synchronization

Connection intervals now support:

- 15 minutes
- 30 minutes
- 1 hour
- 3 hours
- 6 hours
- 12 hours
- 24 hours
- 48 hours

The database interval column is migrated from integer hours to floating-point hours:

```text
0.25 = 15 minutes
0.5  = 30 minutes
```

## Database migrations

The PR adds:

- `s3t4u5v6w7x8_add_nuvio_provider.py`
- `t4u5v6w7x8y9_allow_subhour_sync_intervals.py`
- `u5v6w7x8y9z0_add_push_playback.py`

Alembic has a single head:

```text
u5v6w7x8y9z0 (head)
```

## Additional fixes

### Clear Collection

Imports SQLAlchemy's `delete()` in the existing Clear Collection endpoint, fixing the runtime `NameError`. Fixes #62.

### Trakt watched-history pagination and progress

Trakt now paginates `/sync/watched/movies` and `/sync/watched/shows`. Watched shows explicitly request `extended=progress`, because Trakt's new default response no longer includes the nested `seasons[].episodes[]` data required by the importer. Scrob requests Trakt's documented maximum page size of 250. Pagination follows `X-Pagination-Page-Count`, which Trakt calculates from the effective server-side limit, and never assumes the requested limit was applied. Heavier `extended=progress` responses therefore remain correct when Trakt reduces the page size; if pagination headers are absent, Scrob continues until an empty page. Running jobs persist progress during the import instead of remaining at zero until completion. Fixes the zero-episode regression reported in #61.

### TMDB setting label

Clarifies in both user and admin settings that Scrob expects a TMDB **Read Access Token**, not the shorter API key.

## Verification

Automated tests:

```text
python -m unittest tests.test_trakt tests.test_nuvio -v

Ran 11 tests
OK
```

Covered behavior includes:

- refresh-token rotation
- paginated Nuvio library pulls
- watched-history and playback-progress retrieval
- watched and progress push endpoints
- non-destructive watched batching
- movie and episode payload generation
- bare IMDb outbound identifiers
- missing IMDb resolution and caching
- episode normalization
- unsupported identifier handling
- multi-page Trakt watched-history retrieval
- Trakt `extended=progress` episode payload retrieval
- pagination fallback when Trakt omits pagination headers

Additional checks:

```text
backend compileall: passed
frontend npm run build: passed
alembic heads: u5v6w7x8y9z0
Docker image build: passed
Docker scrob service: healthy
Docker PostgreSQL service: healthy
```

Live Nuvio validation:

```text
Full push job: completed
Watched items pushed: 971
Playback progress items pushed: 1
Failed items: 0
Cloud watched records using tmdb:* after push: 0
Cloud progress records using tmdb:* after push: 0
```

Validated in the Nuvio application with a watched movie, a watched series episode, and an in-progress series episode.

Live Trakt validation against the post-change API:

```text
Watched movies fetched: 817 across 4 pages (requested/effective limit: 250)
Watched shows fetched: 138 across 2 pages (requested limit: 250, effective limit: 100)
Nested watched episodes with default response: 0
Nested watched episodes with extended=progress: 5,363
Import job processed: 6,180 / 6,180
Episodes imported: 5,245
Errors: 0
```