### PR TITLE
fix(sync): synchronize season ratings across providers

### DIFF
--- a/backend/core/plex.py
+++ b/backend/core/plex.py
@@ -215,6 +215,13 @@ async def get_shows(url: str, token: str, section_id: str) -> List[Dict]:
     data = await _get(f"{url.rstrip('/')}/library/sections/{section_id}/all", token, params=params)
     return data.get("MediaContainer", {}).get("Metadata", [])
 
+async def get_seasons(url: str, token: str, section_id: str) -> List[Dict]:
+    """Fetch season metadata, including user ratings, from a TV library."""
+    params = {"type": 3, "includeGuids": 1}
+    data = await _get(f"{url.rstrip('/')}/library/sections/{section_id}/all", token, params=params)
+    return data.get("MediaContainer", {}).get("Metadata", [])
+
+
 async def get_episodes(url: str, token: str, section_id: str) -> List[Dict]:
     params = {"type": 4, "includeGuids": 1}
     data = await _get(f"{url.rstrip('/')}/library/sections/{section_id}/all", token, params=params)
@@ -356,6 +363,48 @@ async def resolve_tmdb_ratingkey(token: str, tmdb_id: int, media_type: str) -> s
             data = res.json()
         items = data.get("MediaContainer", {}).get("Metadata", [])
         return items[0]["ratingKey"] if items else None
+    except Exception:
+        return None
+
+
+async def resolve_season_rating_key(
+    url: str,
+    token: str,
+    show_tmdb_id: int,
+    season_number: int,
+) -> str | None:
+    """Resolve a local Plex season ratingKey from a TMDB show ID and season number."""
+    try:
+        data = await _get(
+            f"{url.rstrip('/')}/library/sections/all",
+            token,
+            params={"type": 2, "guid": f"tmdb://{show_tmdb_id}", "includeGuids": 1},
+        )
+        shows = data.get("MediaContainer", {}).get("Metadata", [])
+        show = next(
+            (
+                item
+                for item in shows
+                if extract_tmdb_id(get_guids(item)) == show_tmdb_id
+            ),
+            None,
+        )
+        if not show or not show.get("ratingKey"):
+            return None
+        children = await _get(
+            f"{url.rstrip('/')}/library/metadata/{show['ratingKey']}/children",
+            token,
+        )
+        seasons = children.get("MediaContainer", {}).get("Metadata", [])
+        match = next(
+            (
+                item
+                for item in seasons
+                if item.get("type") == "season" and item.get("index") == season_number
+            ),
+            None,
+        )
+        return str(match["ratingKey"]) if match and match.get("ratingKey") else None
     except Exception:
         return None
 

--- a/backend/core/trakt.py
+++ b/backend/core/trakt.py
@@ -183,22 +183,22 @@ async def get_watched_shows(client_id: str, access_token: str) -> list[dict]:
 
 
 async def get_ratings(client_id: str, access_token: str) -> dict:
-    """Fetch all user ratings.
+    """Fetch every page of movie, show, and season ratings."""
 
-    Returns: {movies: [{rated_at, rating, movie: {ids: {tmdb}}}],
-              shows: [{rated_at, rating, show: {ids: {tmdb}}}]}
-    """
-    async def _fetch(path: str) -> list:
+    async def _fetch(path: str) -> list[dict]:
         async with httpx.AsyncClient(timeout=60.0) as client:
-            resp = await client.get(f"{TRAKT_BASE}{path}", headers=_headers(client_id, access_token))
-            resp.raise_for_status()
-            return resp.json()
+            return await _get_all_pages(
+                client,
+                path,
+                _headers(client_id, access_token),
+            )
 
-    movies, shows = await asyncio.gather(
+    movies, shows, seasons = await asyncio.gather(
         _fetch("/sync/ratings/movies"),
         _fetch("/sync/ratings/shows"),
+        _fetch("/sync/ratings/seasons"),
     )
-    return {"movies": movies, "shows": shows}
+    return {"movies": movies, "shows": shows, "seasons": seasons}
 
 
 # ── Outbound Push ─────────────────────────────────────────────────────────────
@@ -246,21 +246,61 @@ async def set_ratings_batch(
     access_token: str,
     movie_ratings: list[tuple[int, float]],
     show_ratings: list[tuple[int, float]],
+    season_ratings: list[tuple[int, float]] | None = None,
 ) -> None:
-    """Set ratings for multiple movies and/or shows in a single API call.
+    """Set movie, show, and season ratings in a single API call.
 
-    movie_ratings / show_ratings: list of (tmdb_id, rating)
+    Each tuple contains the TMDB identifier for that media object and its rating.
+    A season TMDB identifier is distinct from its parent show's TMDB identifier.
     """
-    if not movie_ratings and not show_ratings:
+    season_ratings = season_ratings or []
+    if not movie_ratings and not show_ratings and not season_ratings:
         return
     body: dict = {}
     if movie_ratings:
-        body["movies"] = [{"rating": max(1, min(10, round(r))), "ids": {"tmdb": tid}} for tid, r in movie_ratings]
+        body["movies"] = [
+            {"rating": max(1, min(10, round(rating))), "ids": {"tmdb": tmdb_id}}
+            for tmdb_id, rating in movie_ratings
+        ]
     if show_ratings:
-        body["shows"] = [{"rating": max(1, min(10, round(r))), "ids": {"tmdb": tid}} for tid, r in show_ratings]
+        body["shows"] = [
+            {"rating": max(1, min(10, round(rating))), "ids": {"tmdb": tmdb_id}}
+            for tmdb_id, rating in show_ratings
+        ]
+    if season_ratings:
+        body["seasons"] = [
+            {"rating": max(1, min(10, round(rating))), "ids": {"tmdb": tmdb_id}}
+            for tmdb_id, rating in season_ratings
+        ]
     async with httpx.AsyncClient(timeout=TIMEOUT) as client:
         resp = await client.post(
             f"{TRAKT_BASE}/sync/ratings",
+            json=body,
+            headers=_headers(client_id, access_token),
+        )
+        resp.raise_for_status()
+
+
+async def remove_ratings_batch(
+    client_id: str,
+    access_token: str,
+    movie_tmdb_ids: list[int],
+    show_tmdb_ids: list[int],
+    season_tmdb_ids: list[int],
+) -> None:
+    """Remove movie, show, and season ratings in one API call."""
+    if not movie_tmdb_ids and not show_tmdb_ids and not season_tmdb_ids:
+        return
+    body: dict = {}
+    if movie_tmdb_ids:
+        body["movies"] = [{"ids": {"tmdb": tmdb_id}} for tmdb_id in movie_tmdb_ids]
+    if show_tmdb_ids:
+        body["shows"] = [{"ids": {"tmdb": tmdb_id}} for tmdb_id in show_tmdb_ids]
+    if season_tmdb_ids:
+        body["seasons"] = [{"ids": {"tmdb": tmdb_id}} for tmdb_id in season_tmdb_ids]
+    async with httpx.AsyncClient(timeout=TIMEOUT) as client:
+        resp = await client.post(
+            f"{TRAKT_BASE}/sync/ratings/remove",
             json=body,
             headers=_headers(client_id, access_token),
         )
@@ -471,6 +511,38 @@ async def set_show_rating(
             headers=_headers(client_id, access_token),
         )
         resp.raise_for_status()
+
+async def set_season_rating(
+    client_id: str,
+    access_token: str,
+    season_tmdb_id: int,
+    rating: float,
+) -> None:
+    """Rate a season on Trakt using its TMDB season identifier."""
+    trakt_rating = max(1, min(10, round(rating)))
+    async with httpx.AsyncClient(timeout=TIMEOUT) as client:
+        resp = await client.post(
+            f"{TRAKT_BASE}/sync/ratings",
+            json={"seasons": [{"rating": trakt_rating, "ids": {"tmdb": season_tmdb_id}}]},
+            headers=_headers(client_id, access_token),
+        )
+        resp.raise_for_status()
+
+
+async def remove_season_rating(
+    client_id: str,
+    access_token: str,
+    season_tmdb_id: int,
+) -> None:
+    """Remove a season rating from Trakt."""
+    async with httpx.AsyncClient(timeout=TIMEOUT) as client:
+        resp = await client.post(
+            f"{TRAKT_BASE}/sync/ratings/remove",
+            json={"seasons": [{"ids": {"tmdb": season_tmdb_id}}]},
+            headers=_headers(client_id, access_token),
+        )
+        resp.raise_for_status()
+
 
 
 async def remove_show_rating(client_id: str, access_token: str, tmdb_id: int) -> None:

--- a/backend/models/ratings.py
+++ b/backend/models/ratings.py
@@ -7,6 +7,10 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from .base import Base
 
 
+RatingKey = tuple[int, int | None]
+RatingChanges = dict[RatingKey, float]
+
+
 class Rating(Base):
     __tablename__ = "ratings"
 

--- a/backend/routers/mdblist.py
+++ b/backend/routers/mdblist.py
@@ -19,7 +19,7 @@ from models.base import CollectionSource, MediaType
 from models.events import WatchEvent
 from models.lists import List as ListModel, ListItem
 from models.media import Media
-from models.ratings import Rating
+from models.ratings import Rating, RatingChanges
 from models.show import Show
 from models.sync import SyncJob, SyncStatus
 from models.users import User, UserSettings
@@ -55,7 +55,7 @@ def _iso_utc(value: datetime | None) -> str:
         value = value.replace(tzinfo=timezone.utc)
     else:
         value = value.astimezone(timezone.utc)
-    return value.isoformat().replace("+00:00", "Z")
+    return value.replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
 def _integer(value: Any) -> int | None:
@@ -138,6 +138,16 @@ def _episode_identity(entry: dict[str, Any]) -> tuple[int | None, int | None, in
     return show_tmdb_id, _integer(season), _integer(episode_number), title
 
 
+def _season_identity(
+    entry: dict[str, Any],
+) -> tuple[dict[str, Any], int | None]:
+    season = _entry_data("seasons", entry)
+    show_data = entry.get("show") or season.get("show") or {}
+    show_data = show_data if isinstance(show_data, dict) else {}
+    number = season.get("number", entry.get("number"))
+    return show_data, _integer(number)
+
+
 async def _get_or_create_series_media(
     db: AsyncSession,
     tmdb_id: int,
@@ -214,9 +224,28 @@ def _payload_item(
     watched_at: datetime | None = None,
     rating: float | None = None,
     rated_at: datetime | None = None,
+    season_number: int | None = None,
 ) -> tuple[str, dict[str, Any]] | None:
     if not media.tmdb_id:
         return None
+
+    if season_number is not None:
+        if media.media_type != MediaType.series:
+            return None
+        season: dict[str, Any] = {"number": season_number}
+        if rating is not None:
+            season["rating"] = float(rating)
+            season["rated_at"] = _iso_utc(rated_at or datetime.now(timezone.utc))
+        return (
+            "shows",
+            {
+                "ids": {"tmdb": media.tmdb_id},
+                "seasons": [season],
+            },
+        )
+
+    item: dict[str, Any] = {"ids": {"tmdb": media.tmdb_id}}
+
     if media.media_type == MediaType.movie:
         kind = "movies"
     elif media.media_type == MediaType.series:
@@ -226,13 +255,32 @@ def _payload_item(
     else:
         return None
 
-    item: dict[str, Any] = {"ids": {"tmdb": media.tmdb_id}}
     if watched_at is not None:
         item["watched_at"] = _iso_utc(watched_at)
     if rating is not None:
         item["rating"] = float(rating)
         item["rated_at"] = _iso_utc(rated_at or datetime.now(timezone.utc))
     return kind, item
+
+
+def _rating_removal_item(
+    media: Media,
+    season_number: int | None = None,
+) -> tuple[str, dict[str, Any]] | None:
+    """Build an MDBList season removal without clearing its show rating."""
+    if not media.tmdb_id:
+        return None
+    if season_number is not None:
+        if media.media_type != MediaType.series:
+            return None
+        return (
+            "shows",
+            {
+                "ids": {"tmdb": media.tmdb_id},
+                "seasons": [{"number": season_number}],
+            },
+        )
+    return _payload_item(media)
 
 
 async def _effective_tmdb_key(db: AsyncSession, settings: UserSettings) -> str | None:
@@ -301,14 +349,15 @@ async def _import_ratings(
     api_key: str | None,
     external_cache: dict[tuple[str, str], int | None],
     stats: dict[str, int],
-) -> dict[int, float]:
-    ratings_result = await db.execute(
-        select(Rating).where(Rating.user_id == user_id, Rating.season_number.is_(None))
-    )
-    existing = {rating.media_id: rating for rating in ratings_result.scalars().all()}
-    changed: dict[int, float] = {}
+) -> RatingChanges:
+    ratings_result = await db.execute(select(Rating).where(Rating.user_id == user_id))
+    existing = {
+        (rating.media_id, rating.season_number): rating
+        for rating in ratings_result.scalars().all()
+    }
+    changed: RatingChanges = {}
 
-    for kind in ("movies", "shows", "episodes"):
+    for kind in ("movies", "shows", "seasons", "episodes"):
         for entry in payload.get(kind, []):
             rating_value = entry.get("rating")
             try:
@@ -318,33 +367,63 @@ async def _import_ratings(
                 continue
             try:
                 async with db.begin_nested():
-                    media = await _resolve_media(db, kind, entry, api_key, external_cache)
+                    season_number: int | None = None
+                    if kind == "seasons":
+                        show_data, season_number = _season_identity(entry)
+                        show_tmdb_id = await _resolve_external_tmdb_id(
+                            show_data,
+                            "tv",
+                            api_key,
+                            external_cache,
+                        )
+                        media = (
+                            await _get_or_create_series_media(
+                                db,
+                                show_tmdb_id,
+                                str(show_data.get("title") or ""),
+                                api_key,
+                            )
+                            if show_tmdb_id and season_number is not None
+                            else None
+                        )
+                    else:
+                        media = await _resolve_media(
+                            db,
+                            kind,
+                            entry,
+                            api_key,
+                            external_cache,
+                        )
                     if not media:
                         stats["skipped"] += 1
                         continue
-                    current = existing.get(media.id)
+
+                    key = (media.id, season_number)
+                    current = existing.get(key)
+                    rated_at = _utc_naive(entry.get("rated_at"))
                     if current and current.rating == rating:
+                        current.rated_at = rated_at
                         stats["skipped"] += 1
                         continue
                     if current:
                         current.rating = rating
-                        current.rated_at = _utc_naive(entry.get("rated_at"))
+                        current.rated_at = rated_at
                     else:
                         current = Rating(
                             user_id=user_id,
                             media_id=media.id,
+                            season_number=season_number,
                             rating=rating,
-                            rated_at=_utc_naive(entry.get("rated_at")),
+                            rated_at=rated_at,
                         )
                         db.add(current)
-                        existing[media.id] = current
-                    changed[media.id] = rating
+                        existing[key] = current
+                    changed[key] = rating
                     stats["ratings"] += 1
             except Exception as exc:
                 logger.warning("Error importing MDBList %s rating: %s", kind, exc)
                 stats["errors"] += 1
 
-    stats["skipped"] += len(payload.get("seasons", []))
     return changed
 
 
@@ -461,7 +540,7 @@ async def run_mdblist_sync(user_id: int, job_id: int) -> None:
                 "errors": 0,
             }
             new_watched: set[int] = set()
-            new_ratings: dict[int, float] = {}
+            new_ratings: RatingChanges = {}
             external_cache: dict[tuple[str, str], int | None] = {}
 
             if "watched" in snapshots:
@@ -540,7 +619,7 @@ async def run_mdblist_push(user_id: int, job_id: int) -> None:
                 raise RuntimeError("MDBList API key is not configured")
 
             watched_rows: list[tuple[int, datetime]] = []
-            rating_rows: list[tuple[int, float, datetime | None]] = []
+            rating_rows: list[tuple[int, int | None, float, datetime | None]] = []
             watchlist_ids: set[int] = set()
 
             if settings.mdblist_push_watched:
@@ -552,15 +631,14 @@ async def run_mdblist_push(user_id: int, job_id: int) -> None:
                 watched_rows = list(watched_result.all())
             if settings.mdblist_push_ratings:
                 ratings_result = await db.execute(
-                    select(Rating.media_id, Rating.rating, Rating.rated_at).where(
+                    select(Rating.media_id, Rating.season_number, Rating.rating, Rating.rated_at).where(
                         Rating.user_id == user_id,
                         Rating.rating.isnot(None),
-                        Rating.season_number.is_(None),
                     )
                 )
                 rating_rows = [
-                    (media_id, float(rating), rated_at)
-                    for media_id, rating, rated_at in ratings_result.all()
+                    (media_id, season_number, float(rating), rated_at)
+                    for media_id, season_number, rating, rated_at in ratings_result.all()
                 ]
             if settings.mdblist_push_watchlist:
                 watchlist_result = await db.execute(
@@ -587,9 +665,18 @@ async def run_mdblist_push(user_id: int, job_id: int) -> None:
                 item = _payload_item(media, watched_at=watched_at) if media else None
                 if item:
                     watched_payload[item[0]].append(item[1])
-            for media_id, rating, rated_at in rating_rows:
+            for media_id, season_number, rating, rated_at in rating_rows:
                 media = media_by_id.get(media_id)
-                item = _payload_item(media, rating=rating, rated_at=rated_at) if media else None
+                item = (
+                    _payload_item(
+                        media,
+                        rating=rating,
+                        rated_at=rated_at,
+                        season_number=season_number,
+                    )
+                    if media
+                    else None
+                )
                 if item:
                     ratings_payload[item[0]].append(item[1])
             for media_id in watchlist_ids:

--- a/backend/routers/mdblist.py
+++ b/backend/routers/mdblist.py
@@ -218,6 +218,34 @@ def _empty_payload() -> dict[str, list[dict[str, Any]]]:
     return {"movies": [], "shows": [], "seasons": [], "episodes": []}
 
 
+def _merge_show_entries(shows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Combine payload entries that share a show tmdb id.
+
+    _payload_item() builds one entry per season rating, so a batch touching
+    several seasons of the same show would otherwise produce multiple
+    entries with identical ids.tmdb — MDBList's API expects one show object
+    per tmdb id with all of its rated seasons nested underneath.
+    """
+    merged: dict[int, dict[str, Any]] = {}
+    result: list[dict[str, Any]] = []
+    for item in shows:
+        tmdb_id = (item.get("ids") or {}).get("tmdb")
+        if tmdb_id is None:
+            result.append(item)
+            continue
+        existing = merged.get(tmdb_id)
+        if existing is None:
+            existing = {"ids": item["ids"]}
+            merged[tmdb_id] = existing
+            result.append(existing)
+        for key, value in item.items():
+            if key == "seasons":
+                existing.setdefault("seasons", []).extend(value)
+            elif key != "ids":
+                existing[key] = value
+    return result
+
+
 def _payload_item(
     media: Media,
     *,
@@ -701,6 +729,7 @@ async def run_mdblist_push(user_id: int, job_id: int) -> None:
                     settings.mdblist_api_key, watched_payload
                 )
             if settings.mdblist_push_ratings:
+                ratings_payload["shows"] = _merge_show_entries(ratings_payload["shows"])
                 results["ratings"] = await mdblist_client.push_ratings(
                     settings.mdblist_api_key, ratings_payload
                 )

--- a/backend/routers/ratings.py
+++ b/backend/routers/ratings.py
@@ -9,16 +9,10 @@ from sqlalchemy import select, desc, delete
 from db import get_db
 from models.media import Media
 from models.ratings import Rating
-from models.collection import Collection, CollectionFile
-from models.base import CollectionSource, MediaType
+from models.base import MediaType
 from models.users import UserSettings
-from models.connections import MediaServerConnection
 from dependencies import get_current_user
 from models.users import User
-import core.plex as plex_client
-import core.jellyfin as jellyfin_client
-import core.emby as emby_client
-import core.trakt as trakt_client
 from core.enrichment import enrich_media
 
 router = APIRouter()
@@ -127,62 +121,20 @@ async def submit_rating(
     await db.commit()
     await db.refresh(rating)
 
-    # Fan-out rating push to all connections with push_ratings enabled
-    import asyncio
-    push_tasks = []
-    conns_result = await db.execute(
-        select(MediaServerConnection).where(
-            MediaServerConnection.user_id == current_user.id,
-            MediaServerConnection.push_ratings == True,
-        )
+    settings_result = await db.execute(
+        select(UserSettings).where(UserSettings.user_id == current_user.id)
     )
-    push_connections = conns_result.scalars().all()
-    if push_connections:
-        files_result = await db.execute(
-            select(CollectionFile)
-            .join(Collection, Collection.id == CollectionFile.collection_id)
-            .where(Collection.user_id == current_user.id, Collection.media_id == media.id)
-        )
-        coll_files = files_result.scalars().all()
-        conn_by_type: dict[str, list] = {}
-        for conn in push_connections:
-            conn_by_type.setdefault(conn.type, []).append(conn)
-        for coll_file in coll_files:
-            if not coll_file.source_id:
-                continue
-            source_type = coll_file.source.value if hasattr(coll_file.source, "value") else str(coll_file.source)
-            for conn in conn_by_type.get(source_type, []):
-                if coll_file.source == CollectionSource.plex:
-                    push_tasks.append(plex_client.set_rating(conn.url, conn.token, coll_file.source_id, body.rating))
-                elif coll_file.source == CollectionSource.jellyfin:
-                    push_tasks.append(jellyfin_client.set_rating(conn.url, conn.token, conn.server_user_id, coll_file.source_id, body.rating))
-                elif coll_file.source == CollectionSource.emby:
-                    push_tasks.append(emby_client.set_rating(conn.url, conn.token, conn.server_user_id, coll_file.source_id, body.rating))
-
-    settings_result = await db.execute(select(UserSettings).where(UserSettings.user_id == current_user.id))
     settings = settings_result.scalar_one_or_none()
-    if settings and settings.trakt_push_ratings and settings.trakt_access_token and settings.trakt_client_id and media.tmdb_id:
-        if media_type == MediaType.movie:
-            push_tasks.append(trakt_client.set_movie_rating(settings.trakt_client_id, settings.trakt_access_token, media.tmdb_id, body.rating))
-        elif media_type == MediaType.series:
-            push_tasks.append(trakt_client.set_show_rating(settings.trakt_client_id, settings.trakt_access_token, media.tmdb_id, body.rating))
-    if settings and settings.simkl_push_ratings and settings.simkl_access_token and settings.simkl_client_id and media.tmdb_id:
-        from core import simkl as simkl_client
-        if media_type == MediaType.movie:
-            push_tasks.append(simkl_client.set_movie_rating(settings.simkl_client_id, settings.simkl_access_token, media.tmdb_id, body.rating))
-        elif media_type == MediaType.series:
-            push_tasks.append(simkl_client.set_show_rating(settings.simkl_client_id, settings.simkl_access_token, media.tmdb_id, body.rating))
-    if settings and settings.mdblist_push_ratings and settings.mdblist_api_key:
-        from core import mdblist as mdblist_client
-        from routers.mdblist import _empty_payload, _payload_item
+    from routers.sync import _fan_out_changes_to_other_connections
 
-        payload = _empty_payload()
-        item = _payload_item(media, rating=body.rating)
-        if item:
-            payload[item[0]].append(item[1])
-            push_tasks.append(mdblist_client.push_ratings(settings.mdblist_api_key, payload))
-    if push_tasks:
-        await asyncio.gather(*push_tasks, return_exceptions=True)
+    await _fan_out_changes_to_other_connections(
+        db,
+        current_user.id,
+        None,
+        set(),
+        {(media.id, effective_season): body.rating},
+        settings=settings,
+    )
 
     return format_rating(rating, media)
 
@@ -253,60 +205,20 @@ async def delete_rating(
     await db.delete(rating)
     await db.commit()
 
-    import asyncio
-    push_tasks = []
-    conns_result = await db.execute(
-        select(MediaServerConnection).where(
-            MediaServerConnection.user_id == current_user.id,
-            MediaServerConnection.push_ratings == True,
-        )
+    settings_result = await db.execute(
+        select(UserSettings).where(UserSettings.user_id == current_user.id)
     )
-    push_connections = conns_result.scalars().all()
-    if push_connections:
-        files_result = await db.execute(
-            select(CollectionFile)
-            .join(Collection, Collection.id == CollectionFile.collection_id)
-            .where(Collection.user_id == current_user.id, Collection.media_id == media.id)
-        )
-        coll_files = files_result.scalars().all()
-        conn_by_type: dict[str, list] = {}
-        for conn in push_connections:
-            conn_by_type.setdefault(conn.type, []).append(conn)
-        for coll_file in coll_files:
-            if not coll_file.source_id:
-                continue
-            source_type = coll_file.source.value if hasattr(coll_file.source, "value") else str(coll_file.source)
-            for conn in conn_by_type.get(source_type, []):
-                if coll_file.source == CollectionSource.plex:
-                    push_tasks.append(plex_client.set_rating(conn.url, conn.token, coll_file.source_id, 0))
-                elif coll_file.source == CollectionSource.jellyfin:
-                    push_tasks.append(jellyfin_client.set_rating(conn.url, conn.token, conn.server_user_id, coll_file.source_id, 0))
-                elif coll_file.source == CollectionSource.emby:
-                    push_tasks.append(emby_client.set_rating(conn.url, conn.token, conn.server_user_id, coll_file.source_id, 0))
-
-    settings_result = await db.execute(select(UserSettings).where(UserSettings.user_id == current_user.id))
     settings = settings_result.scalar_one_or_none()
-    if settings and settings.trakt_push_ratings and settings.trakt_access_token and settings.trakt_client_id and media.tmdb_id:
-        if mt == MediaType.movie:
-            push_tasks.append(trakt_client.remove_movie_rating(settings.trakt_client_id, settings.trakt_access_token, media.tmdb_id))
-        elif mt == MediaType.series:
-            push_tasks.append(trakt_client.remove_show_rating(settings.trakt_client_id, settings.trakt_access_token, media.tmdb_id))
-    if settings and settings.simkl_push_ratings and settings.simkl_access_token and settings.simkl_client_id and media.tmdb_id:
-        from core import simkl as simkl_client
-        if mt == MediaType.movie:
-            push_tasks.append(simkl_client.remove_movie_rating(settings.simkl_client_id, settings.simkl_access_token, media.tmdb_id))
-        elif mt == MediaType.series:
-            push_tasks.append(simkl_client.remove_show_rating(settings.simkl_client_id, settings.simkl_access_token, media.tmdb_id))
-    if settings and settings.mdblist_push_ratings and settings.mdblist_api_key:
-        from core import mdblist as mdblist_client
-        from routers.mdblist import _empty_payload, _payload_item
+    from routers.sync import _fan_out_changes_to_other_connections
 
-        payload = _empty_payload()
-        item = _payload_item(media)
-        if item:
-            payload[item[0]].append(item[1])
-            push_tasks.append(mdblist_client.remove_ratings(settings.mdblist_api_key, payload))
-    if push_tasks:
-        await asyncio.gather(*push_tasks, return_exceptions=True)
+    await _fan_out_changes_to_other_connections(
+        db,
+        current_user.id,
+        None,
+        set(),
+        {},
+        settings=settings,
+        removed_ratings={(media.id, effective_season)},
+    )
 
     return {"status": "deleted"}

--- a/backend/routers/simkl.py
+++ b/backend/routers/simkl.py
@@ -24,7 +24,7 @@ from models.base import CollectionSource, MediaType
 from models.events import WatchEvent
 from models.lists import List as ListModel, ListItem
 from models.media import Media
-from models.ratings import Rating
+from models.ratings import Rating, RatingChanges
 from models.show import Show
 from models.sync import SyncJob, SyncStatus
 from models.users import User, UserSettings
@@ -277,7 +277,7 @@ async def run_simkl_sync(user_id: int, job_id: int) -> None:
 
             stats: dict[str, int] = {"movies": 0, "episodes": 0, "ratings": 0, "lists": 0, "list_items": 0, "skipped": 0, "errors": 0}
             _new_watched: set[int] = set()
-            _new_ratings: dict[int, float] = {}
+            _new_ratings: RatingChanges = {}
 
             print("  Fetching all items from Simkl…")
             all_items = await simkl_client.get_all_items(client_id, access_token)
@@ -419,7 +419,7 @@ async def run_simkl_sync(user_id: int, job_id: int) -> None:
                             if media.id not in existing_rated:
                                 db.add(Rating(user_id=user_id, media_id=media.id, rating=float(rating_val)))
                                 existing_rated.add(media.id)
-                                _new_ratings[media.id] = float(rating_val)
+                                _new_ratings[(media.id, None)] = float(rating_val)
                                 stats["ratings"] += 1
                     except Exception as exc:
                         logger.warning("Error processing Simkl movie rating tmdb=%s: %s", tmdb_id, exc)
@@ -448,7 +448,7 @@ async def run_simkl_sync(user_id: int, job_id: int) -> None:
                             if media.id not in existing_rated:
                                 db.add(Rating(user_id=user_id, media_id=media.id, rating=float(rating_val)))
                                 existing_rated.add(media.id)
-                                _new_ratings[media.id] = float(rating_val)
+                                _new_ratings[(media.id, None)] = float(rating_val)
                                 stats["ratings"] += 1
                     except Exception as exc:
                         logger.warning("Error processing Simkl show rating tmdb=%s: %s", tmdb_id, exc)
@@ -542,7 +542,15 @@ async def run_simkl_sync(user_id: int, job_id: int) -> None:
                 f"Skipped: {stats['skipped']}. Errors: {stats['errors']}."
             )
             from routers.sync import _fan_out_changes_to_other_connections
-            await _fan_out_changes_to_other_connections(db, user_id, None, _new_watched, _new_ratings, settings=settings)
+            await _fan_out_changes_to_other_connections(
+                db,
+                user_id,
+                None,
+                _new_watched,
+                _new_ratings,
+                settings=settings,
+                exclude_cloud_source=CollectionSource.simkl,
+            )
             await db.execute(
                 update(SyncJob).where(SyncJob.id == job_id).values(
                     status=SyncStatus.completed,

--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -870,7 +870,7 @@ async def _fan_out_changes_to_other_connections(
 
     if (push_mdblist_watched or push_mdblist_ratings) and all_changed_ids:
         from core import mdblist as mdblist_client
-        from routers.mdblist import _empty_payload, _payload_item, _rating_removal_item
+        from routers.mdblist import _empty_payload, _merge_show_entries, _payload_item, _rating_removal_item
 
         mdblist_media_by_id = media_by_id
 
@@ -918,6 +918,7 @@ async def _fan_out_changes_to_other_connections(
                 )
                 if item:
                     ratings_payload[item[0]].append(item[1])
+            ratings_payload["shows"] = _merge_show_entries(ratings_payload["shows"])
             push_tasks.append(mdblist_client.push_ratings(settings.mdblist_api_key, ratings_payload))
 
         if push_mdblist_ratings and removed_ratings:
@@ -931,6 +932,7 @@ async def _fan_out_changes_to_other_connections(
                 )
                 if item:
                     removed_payload[item[0]].append(item[1])
+            removed_payload["shows"] = _merge_show_entries(removed_payload["shows"])
             push_tasks.append(
                 mdblist_client.remove_ratings(
                     settings.mdblist_api_key,

--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -17,7 +17,7 @@ from models.users import User, UserSettings
 from models.connections import MediaServerConnection
 from models.sync import SyncJob, SyncStatus
 from models.events import WatchEvent
-from models.ratings import Rating
+from models.ratings import Rating, RatingChanges, RatingKey
 from models.playback_progress import PlaybackProgress
 from models.library_selections import JellyfinLibrarySelection, EmbyLibrarySelection, PlexLibrarySelection
 from models.season_override import ShowSeasonOverride
@@ -83,6 +83,73 @@ async def _latest_watched_at(db: AsyncSession, user_id: int, media_ids: list) ->
         for media_id, watched_at in result.all():
             watched_at_by_media.setdefault(media_id, watched_at)
     return watched_at_by_media
+
+
+async def _resolve_tmdb_season_ids(
+    media_by_id: dict[int, Media],
+    rating_keys: set[RatingKey],
+    api_key: str | None,
+) -> dict[RatingKey, int]:
+    """Resolve TMDB season resource IDs for season rating operations."""
+    season_keys = {
+        key
+        for key in rating_keys
+        if key[1] is not None
+        and (media := media_by_id.get(key[0]))
+        and media.media_type == MediaType.series
+        and media.tmdb_id
+    }
+    if not season_keys:
+        return {}
+
+    resolved: dict[RatingKey, int] = {}
+    semaphore = asyncio.Semaphore(TMDB_CONCURRENCY)
+
+    async def resolve(key: RatingKey) -> None:
+        media = media_by_id[key[0]]
+        async with semaphore:
+            try:
+                season = await tmdb.get_season(
+                    media.tmdb_id,
+                    key[1],
+                    api_key=api_key,
+                )
+            except Exception as exc:
+                logger.warning(
+                    "Could not resolve TMDB season ID for show=%s season=%s: %s",
+                    media.tmdb_id,
+                    key[1],
+                    exc,
+                )
+                return
+        season_tmdb_id = season.get("id")
+        if season_tmdb_id:
+            resolved[key] = int(season_tmdb_id)
+
+    await asyncio.gather(*(resolve(key) for key in season_keys))
+    return resolved
+
+
+async def _get_or_create_series_rating_media(
+    db: AsyncSession,
+    tmdb_id: int,
+    title: str,
+    api_key: str | None,
+) -> Media:
+    result = await db.execute(
+        select(Media).where(
+            Media.tmdb_id == tmdb_id,
+            Media.media_type == MediaType.series,
+        )
+    )
+    media = result.scalars().first()
+    if media:
+        return media
+    media = Media(tmdb_id=tmdb_id, media_type=MediaType.series, title=title)
+    db.add(media)
+    await db.flush()
+    await enrich_media(media, api_key=api_key)
+    return media
 
 
 def extract_watch_state(item: dict, source: CollectionSource) -> dict:
@@ -555,19 +622,31 @@ async def _fan_out_changes_to_other_connections(
     user_id: int,
     exclude_connection_id: int | None,
     new_watched_ids: set[int],
-    new_ratings: dict[int, float],
+    new_ratings: RatingChanges,
     settings: "UserSettings | None" = None,
     exclude_cloud_source: CollectionSource | None = None,
+    removed_ratings: set[RatingKey] | None = None,
 ) -> None:
     """Push an inbound sync delta to every enabled media server and cloud target.
 
     ``exclude_connection_id`` prevents media-server echo. ``exclude_cloud_source``
     prevents a cloud pull from writing the same delta back to its source.
     """
-    if not new_watched_ids and not new_ratings:
+    removed_ratings = removed_ratings or set()
+    if not new_watched_ids and not new_ratings and not removed_ratings:
         return
 
-    all_changed_ids = set(new_watched_ids) | set(new_ratings.keys())
+    all_changed_ids = (
+        set(new_watched_ids)
+        | {media_id for media_id, _ in new_ratings}
+        | {media_id for media_id, _ in removed_ratings}
+    )
+    media_items = await _select_in_chunks(
+        db,
+        lambda chunk: select(Media).where(Media.id.in_(chunk)),
+        list(all_changed_ids),
+    )
+    media_by_id: dict[int, Media] = {media.id: media for media in media_items}
 
     # ── Media server fan-out ─────────────────────────────────────────────────
     conns_filter = [MediaServerConnection.user_id == user_id]
@@ -580,6 +659,8 @@ async def _fan_out_changes_to_other_connections(
     push_candidates = [c for c in other_conns if c.push_watched or c.push_ratings]
 
     push_tasks = []
+    server_rating_changes = {key: 0.0 for key in removed_ratings}
+    server_rating_changes.update(new_ratings)
 
     if push_candidates:
         # Chunk the IN clause to stay under asyncpg's 32767-parameter limit.
@@ -648,7 +729,33 @@ async def _fan_out_changes_to_other_connections(
                         elif conn.type == "emby":
                             push_tasks.append(_guarded(emby.mark_watched(conn.url, conn.token, conn.server_user_id, sid)))
             if conn.push_ratings:
-                for mid, rating in new_ratings.items():
+                for (mid, season_number), rating in server_rating_changes.items():
+                    media = media_by_id.get(mid)
+                    if season_number is not None:
+                        if conn.type == "plex" and media and media.tmdb_id:
+                            async def _set_plex_season_rating(
+                                target_conn: MediaServerConnection = conn,
+                                target_media: Media = media,
+                                target_season: int = season_number,
+                                target_rating: float = rating,
+                            ) -> bool:
+                                rating_key = await plex.resolve_season_rating_key(
+                                    target_conn.url,
+                                    target_conn.token,
+                                    target_media.tmdb_id,
+                                    target_season,
+                                )
+                                if not rating_key:
+                                    return False
+                                return await plex.set_rating(
+                                    target_conn.url,
+                                    target_conn.token,
+                                    rating_key,
+                                    target_rating,
+                                )
+
+                            push_tasks.append(_guarded(_set_plex_season_rating()))
+                        continue
                     for sid in source_ids_map.get((conn_source, mid), []):
                         if conn.type == "plex":
                             push_tasks.append(_guarded(plex.set_rating(conn.url, conn.token, sid, rating)))
@@ -657,17 +764,13 @@ async def _fan_out_changes_to_other_connections(
                         elif conn.type == "emby":
                             push_tasks.append(_guarded(emby.set_rating(conn.url, conn.token, conn.server_user_id, sid, rating)))
 
+    season_tmdb_ids: dict[RatingKey, int] = {}
     # ── Trakt fan-out ────────────────────────────────────────────────────────
     push_trakt_watched = settings and exclude_cloud_source != CollectionSource.trakt and settings.trakt_push_watched and settings.trakt_access_token and settings.trakt_client_id
     push_trakt_ratings = settings and exclude_cloud_source != CollectionSource.trakt and settings.trakt_push_ratings and settings.trakt_access_token and settings.trakt_client_id
 
     if (push_trakt_watched or push_trakt_ratings) and all_changed_ids:
-        media_items = await _select_in_chunks(
-            db,
-            lambda chunk: select(Media).where(Media.id.in_(chunk)),
-            list(all_changed_ids),
-        )
-        media_by_id: dict[int, Media] = {m.id: m for m in media_items}
+        media_items = list(media_by_id.values())
 
         # Load shows for episode tmdb_id lookups
         show_ids = {m.show_id for m in media_items if m.show_id}
@@ -702,21 +805,64 @@ async def _fan_out_changes_to_other_connections(
 
         trakt_movie_ratings: list[tuple[int, float]] = []
         trakt_show_ratings: list[tuple[int, float]] = []
+        trakt_season_ratings: list[tuple[int, float]] = []
         if push_trakt_ratings:
-            for mid, rating in new_ratings.items():
+            all_rating_keys = set(new_ratings) | removed_ratings
+            season_tmdb_ids = await _resolve_tmdb_season_ids(
+                media_by_id,
+                all_rating_keys,
+                await _get_effective_tmdb_key(db, settings),
+            )
+            for key, rating in new_ratings.items():
+                mid, season_number = key
                 media = media_by_id.get(mid)
                 if not media or not media.tmdb_id:
                     continue
-                if media.media_type == MediaType.movie:
+                if season_number is not None:
+                    if season_tmdb_id := season_tmdb_ids.get(key):
+                        trakt_season_ratings.append((season_tmdb_id, rating))
+                elif media.media_type == MediaType.movie:
                     trakt_movie_ratings.append((media.tmdb_id, rating))
-                elif media.media_type in (MediaType.series, MediaType.episode):
+                elif media.media_type == MediaType.series:
                     trakt_show_ratings.append((media.tmdb_id, rating))
 
-        if trakt_movie_ratings or trakt_show_ratings:
-            push_tasks.append(trakt_client.set_ratings_batch(
-                settings.trakt_client_id, settings.trakt_access_token,
-                trakt_movie_ratings, trakt_show_ratings,
-            ))
+        if trakt_movie_ratings or trakt_show_ratings or trakt_season_ratings:
+            push_tasks.append(
+                trakt_client.set_ratings_batch(
+                    settings.trakt_client_id,
+                    settings.trakt_access_token,
+                    trakt_movie_ratings,
+                    trakt_show_ratings,
+                    trakt_season_ratings,
+                )
+            )
+
+        if push_trakt_ratings:
+            removed_trakt_movies: list[int] = []
+            removed_trakt_shows: list[int] = []
+            removed_trakt_seasons: list[int] = []
+            for key in removed_ratings:
+                media_id, season_number = key
+                media = media_by_id.get(media_id)
+                if not media or not media.tmdb_id:
+                    continue
+                if season_number is not None:
+                    if season_tmdb_id := season_tmdb_ids.get(key):
+                        removed_trakt_seasons.append(season_tmdb_id)
+                elif media.media_type == MediaType.movie:
+                    removed_trakt_movies.append(media.tmdb_id)
+                elif media.media_type == MediaType.series:
+                    removed_trakt_shows.append(media.tmdb_id)
+            if removed_trakt_movies or removed_trakt_shows or removed_trakt_seasons:
+                push_tasks.append(
+                    trakt_client.remove_ratings_batch(
+                        settings.trakt_client_id,
+                        settings.trakt_access_token,
+                        removed_trakt_movies,
+                        removed_trakt_shows,
+                        removed_trakt_seasons,
+                    )
+                )
 
     # ── MDBList fan-out ──────────────────────────────────────────────────────
     push_mdblist_watched = settings and exclude_cloud_source != CollectionSource.mdblist and settings.mdblist_push_watched and settings.mdblist_api_key
@@ -724,14 +870,9 @@ async def _fan_out_changes_to_other_connections(
 
     if (push_mdblist_watched or push_mdblist_ratings) and all_changed_ids:
         from core import mdblist as mdblist_client
-        from routers.mdblist import _empty_payload, _payload_item
+        from routers.mdblist import _empty_payload, _payload_item, _rating_removal_item
 
-        mdblist_media = await _select_in_chunks(
-            db,
-            lambda chunk: select(Media).where(Media.id.in_(chunk)),
-            list(all_changed_ids),
-        )
-        mdblist_media_by_id = {media.id: media for media in mdblist_media}
+        mdblist_media_by_id = media_by_id
 
         if push_mdblist_watched:
             watched_at_by_media = await _latest_watched_at(db, user_id, list(new_watched_ids))
@@ -744,22 +885,34 @@ async def _fan_out_changes_to_other_connections(
                     watched_payload[item[0]].append(item[1])
             push_tasks.append(mdblist_client.push_watched(settings.mdblist_api_key, watched_payload))
 
-        if push_mdblist_ratings:
-            rated_media_ids = list(new_ratings.keys())
-            rated_at_by_media: dict[int, datetime] = {}
+        if push_mdblist_ratings and new_ratings:
+            rated_media_ids = list({media_id for media_id, _ in new_ratings})
+            rated_at_by_key: dict[RatingKey, datetime] = {}
             for i in range(0, len(rated_media_ids), _MAX_IN_PARAMS):
                 chunk = rated_media_ids[i : i + _MAX_IN_PARAMS]
                 rated_at_result = await db.execute(
-                    select(Rating.media_id, Rating.rated_at).where(
-                        Rating.user_id == user_id, Rating.media_id.in_(chunk)
+                    select(Rating.media_id, Rating.season_number, Rating.rated_at).where(
+                        Rating.user_id == user_id,
+                        Rating.media_id.in_(chunk),
                     )
                 )
-                rated_at_by_media.update(dict(rated_at_result.all()))
+                rated_at_by_key.update(
+                    {
+                        (media_id, season_number): rated_at
+                        for media_id, season_number, rated_at in rated_at_result.all()
+                    }
+                )
             ratings_payload = _empty_payload()
-            for media_id, rating in new_ratings.items():
+            for key, rating in new_ratings.items():
+                media_id, season_number = key
                 media = mdblist_media_by_id.get(media_id)
                 item = (
-                    _payload_item(media, rating=rating, rated_at=rated_at_by_media.get(media_id))
+                    _payload_item(
+                        media,
+                        rating=rating,
+                        rated_at=rated_at_by_key.get(key),
+                        season_number=season_number,
+                    )
                     if media
                     else None
                 )
@@ -767,10 +920,88 @@ async def _fan_out_changes_to_other_connections(
                     ratings_payload[item[0]].append(item[1])
             push_tasks.append(mdblist_client.push_ratings(settings.mdblist_api_key, ratings_payload))
 
+        if push_mdblist_ratings and removed_ratings:
+            removed_payload = _empty_payload()
+            for media_id, season_number in removed_ratings:
+                media = mdblist_media_by_id.get(media_id)
+                item = (
+                    _rating_removal_item(media, season_number)
+                    if media
+                    else None
+                )
+                if item:
+                    removed_payload[item[0]].append(item[1])
+            push_tasks.append(
+                mdblist_client.remove_ratings(
+                    settings.mdblist_api_key,
+                    removed_payload,
+                )
+            )
+
+    # ── Simkl fan-out ────────────────────────────────────────────────────────
+    push_simkl_ratings = (
+        settings
+        and exclude_cloud_source != CollectionSource.simkl
+        and settings.simkl_push_ratings
+        and settings.simkl_access_token
+        and settings.simkl_client_id
+    )
+    if push_simkl_ratings:
+        from core import simkl as simkl_client
+
+        for key, rating in new_ratings.items():
+            media_id, season_number = key
+            if season_number is not None:
+                continue
+            media = media_by_id.get(media_id)
+            if not media or not media.tmdb_id:
+                continue
+            if media.media_type == MediaType.movie:
+                push_tasks.append(
+                    simkl_client.set_movie_rating(
+                        settings.simkl_client_id,
+                        settings.simkl_access_token,
+                        media.tmdb_id,
+                        rating,
+                    )
+                )
+            elif media.media_type == MediaType.series:
+                push_tasks.append(
+                    simkl_client.set_show_rating(
+                        settings.simkl_client_id,
+                        settings.simkl_access_token,
+                        media.tmdb_id,
+                        rating,
+                    )
+                )
+        for media_id, season_number in removed_ratings:
+            if season_number is not None:
+                continue
+            media = media_by_id.get(media_id)
+            if not media or not media.tmdb_id:
+                continue
+            if media.media_type == MediaType.movie:
+                push_tasks.append(
+                    simkl_client.remove_movie_rating(
+                        settings.simkl_client_id,
+                        settings.simkl_access_token,
+                        media.tmdb_id,
+                    )
+                )
+            elif media.media_type == MediaType.series:
+                push_tasks.append(
+                    simkl_client.remove_show_rating(
+                        settings.simkl_client_id,
+                        settings.simkl_access_token,
+                        media.tmdb_id,
+                    )
+                )
+
     if push_tasks:
         target_count = len(push_candidates)
         target_count += 1 if (push_trakt_watched or push_trakt_ratings) else 0
         target_count += 1 if (push_mdblist_watched or push_mdblist_ratings) else 0
+        target_count += 1 if push_simkl_ratings else 0
         print(f"  Fanning out {len(push_tasks)} changes to {target_count} other connection(s)...")
         results = await asyncio.gather(*push_tasks, return_exceptions=True)
         failed = sum(1 for r in results if isinstance(r, Exception))
@@ -795,7 +1026,7 @@ async def sync_items(
     sync_watched: bool = True,
     sync_ratings: bool = True,
     new_watched_ids: set[int] | None = None,  # accumulated across calls; mutated in-place
-    new_ratings: dict[int, float] | None = None,  # accumulated across calls; mutated in-place
+    new_ratings: RatingChanges | None = None,  # accumulated across calls; mutated in-place
     connection_id: int | None = None,
 ) -> list[dict]:  # returns warnings
     print(f"  Syncing {len(items)} {media_type.value}s from {source.value}...")
@@ -1208,7 +1439,7 @@ async def sync_items(
                             db.add(new_r)
                             existing_ratings[media_id_for_watch] = new_r
                         if new_ratings is not None:
-                            new_ratings[media_id_for_watch] = watch_state["user_rating"]
+                            new_ratings[(media_id_for_watch, None)] = watch_state["user_rating"]
 
             # Savepoint committed — update pre-loaded caches so duplicates within the
             # same sync batch reuse the newly created media instead of creating another.
@@ -1331,7 +1562,7 @@ async def _run_jellyfin_sync(user_id: int, job_id: int, movie_limit: int, show_l
             all_warnings: list[dict] = []
             total_discovered = 0
             _new_watched: set[int] = set()
-            _new_ratings: dict[int, float] = {}
+            _new_ratings: RatingChanges = {}
 
             for lib in libraries:
                 lib_type = (lib.get("CollectionType") or "").lower()
@@ -1518,7 +1749,7 @@ async def _run_emby_sync(user_id: int, job_id: int, movie_limit: int, show_limit
             all_warnings: list[dict] = []
             total_discovered = 0
             _new_watched: set[int] = set()
-            _new_ratings: dict[int, float] = {}
+            _new_ratings: RatingChanges = {}
 
             for lib in libraries:
                 lib_type = (lib.get("CollectionType") or "").lower()
@@ -1772,11 +2003,18 @@ async def _run_plex_sync(user_id: int, job_id: int, movie_limit: int, show_limit
                 libraries = [lib for lib in libraries if lib.get("key") in selected_keys]
 
             print(f"  Found {len(libraries)} libraries to sync")
-            stats = {"movies": 0, "episodes": 0, "skipped": 0, "errors": 0}
+            stats = {"movies": 0, "episodes": 0, "ratings": 0, "skipped": 0, "errors": 0}
             all_warnings: list[dict] = []
             total_discovered = 0
             _new_watched: set[int] = set()
-            _new_ratings: dict[int, float] = {}
+            _new_ratings: RatingChanges = {}
+            ratings_result = await db.execute(
+                select(Rating).where(Rating.user_id == user_id)
+            )
+            existing_ratings = {
+                (rating.media_id, rating.season_number): rating
+                for rating in ratings_result.scalars().all()
+            }
 
             for lib in libraries:
                 lib_type = lib.get("type")
@@ -1890,6 +2128,63 @@ async def _run_plex_sync(user_id: int, job_id: int, movie_limit: int, show_limit
                         series_tmdb_map, db, api_key=tmdb_api_key
                     )
                     print(f"    Mapped {len(show_map)}/{len(series_tmdb_map)} shows.")
+
+                    if conn.sync_ratings:
+                        seasons = await plex.get_seasons(p_url, p_token, lib_key)
+                        show_titles = {
+                            str(show.get("ratingKey")): str(show.get("title") or "")
+                            for show in shows
+                        }
+                        rated_seasons = [
+                            season
+                            for season in seasons
+                            if season.get("userRating") is not None
+                        ]
+                        total_discovered += len(rated_seasons)
+                        for season in rated_seasons:
+                            parent_key = str(season.get("parentRatingKey") or "")
+                            show_id = show_map.get(parent_key)
+                            show_tmdb_id = show_id_to_tmdb.get(show_id) if show_id else None
+                            season_number = season.get("index")
+                            if show_tmdb_id is None or season_number is None:
+                                stats["skipped"] += 1
+                                continue
+                            try:
+                                async with db.begin_nested():
+                                    media = await _get_or_create_series_rating_media(
+                                        db,
+                                        show_tmdb_id,
+                                        show_titles.get(parent_key, ""),
+                                        tmdb_api_key,
+                                    )
+                                    key = (media.id, int(season_number))
+                                    rating_value = float(season["userRating"])
+                                    current = existing_ratings.get(key)
+                                    if current and current.rating == rating_value:
+                                        stats["skipped"] += 1
+                                        continue
+                                    if current:
+                                        current.rating = rating_value
+                                        current.rated_at = datetime.utcnow()
+                                    else:
+                                        current = Rating(
+                                            user_id=user_id,
+                                            media_id=media.id,
+                                            season_number=int(season_number),
+                                            rating=rating_value,
+                                        )
+                                        db.add(current)
+                                        existing_ratings[key] = current
+                                    _new_ratings[key] = rating_value
+                                    stats["ratings"] += 1
+                            except Exception as exc:
+                                logger.warning(
+                                    "Error importing Plex season rating show=%s season=%s: %s",
+                                    show_tmdb_id,
+                                    season_number,
+                                    exc,
+                                )
+                                stats["errors"] += 1
 
                     unmatched_shows = [s for s in shows if str(s.get("ratingKey")) not in show_map]
                     for s in unmatched_shows:
@@ -2874,7 +3169,7 @@ async def _run_full_push(user_id: int, connection_id: int, job_id: int) -> None:
 
             conn_source = CollectionSource(conn.type)
             watched_ids: set[int] = set()
-            ratings_map: dict[int, float] = {}
+            ratings_map: RatingChanges = {}
 
             if conn.push_watched:
                 watched_result = await db.execute(
@@ -2884,14 +3179,17 @@ async def _run_full_push(user_id: int, connection_id: int, job_id: int) -> None:
 
             if conn.push_ratings:
                 ratings_result = await db.execute(
-                    select(Rating.media_id, Rating.rating).where(
+                    select(Rating.media_id, Rating.season_number, Rating.rating).where(
                         Rating.user_id == user_id,
                         Rating.rating.isnot(None),
                     )
                 )
-                ratings_map = {row[0]: row[1] for row in ratings_result.all()}
+                ratings_map = {
+                    (media_id, season_number): float(rating)
+                    for media_id, season_number, rating in ratings_result.all()
+                }
 
-            all_media_ids = watched_ids | set(ratings_map.keys())
+            all_media_ids = watched_ids | {media_id for media_id, _ in ratings_map}
             if not all_media_ids:
                 await db.execute(update(SyncJob).where(SyncJob.id == job_id).values(status=SyncStatus.completed, total_items=0, processed_items=0))
                 await db.commit()
@@ -2916,19 +3214,25 @@ async def _run_full_push(user_id: int, connection_id: int, job_id: int) -> None:
                 for source_id, media_id in files_chunk.all():
                     source_ids_map.setdefault(media_id, []).append(source_id)
 
-            # Slow path: items not in source_ids_map need a live TMDB-based lookup on the server
-            missing_ids = all_media_ids - set(source_ids_map.keys())
+            # Slow path: unknown items and Plex season ratings need media metadata.
+            missing_ids = all_media_ids - set(source_ids_map)
+            season_rating_ids = {
+                media_id
+                for media_id, season_number in ratings_map
+                if season_number is not None
+            }
+            lookup_media_ids = missing_ids | season_rating_ids
             media_info: dict[int, Media] = {}
             show_tmdb_map: dict[int, int] = {}  # show.id → show.tmdb_id
 
-            if missing_ids:
+            if lookup_media_ids:
                 media_rows_list = await _select_in_chunks(
                     db,
                     lambda chunk: select(Media).where(Media.id.in_(chunk)),
-                    list(missing_ids),
+                    list(lookup_media_ids),
                 )
-                for m in media_rows_list:
-                    media_info[m.id] = m
+                for media in media_rows_list:
+                    media_info[media.id] = media
 
                 show_ids_needed = {m.show_id for m in media_info.values() if m.show_id is not None}
                 if show_ids_needed:
@@ -2948,12 +3252,14 @@ async def _run_full_push(user_id: int, connection_id: int, job_id: int) -> None:
                         push_items.append(("watched", sid))
 
             if conn.push_ratings:
-                for mid, rating in ratings_map.items():
+                for (mid, season_number), rating in ratings_map.items():
+                    if season_number is not None:
+                        continue
                     for sid in source_ids_map.get(mid, []):
                         push_items.append(("rating", sid, rating))
 
-            # Items that need live lookup: defer as coroutines resolved during push
-            lookup_items: list[tuple] = []  # (action, media_id, [rating])
+            # Items that need live lookup: defer as coroutines resolved during push.
+            lookup_items: list[tuple] = []
 
             if missing_ids:
                 if conn.push_watched:
@@ -2961,9 +3267,14 @@ async def _run_full_push(user_id: int, connection_id: int, job_id: int) -> None:
                         if mid in media_info:
                             lookup_items.append(("watched", mid))
                 if conn.push_ratings:
-                    for mid in set(ratings_map.keys()) & missing_ids:
-                        if mid in media_info:
-                            lookup_items.append(("rating", mid, ratings_map[mid]))
+                    for key, rating in ratings_map.items():
+                        mid, season_number = key
+                        if season_number is None and mid in missing_ids and mid in media_info:
+                            lookup_items.append(("rating", mid, rating))
+            if conn.type == "plex" and conn.push_ratings:
+                for (mid, season_number), rating in ratings_map.items():
+                    if season_number is not None and mid in media_info:
+                        lookup_items.append(("season_rating", mid, season_number, rating))
 
             total = len(push_items) + len(lookup_items)
             if total == 0:
@@ -3038,6 +3349,25 @@ async def _run_full_push(user_id: int, connection_id: int, job_id: int) -> None:
                 async with sem:
                     try:
                         mid = item[1]
+                        if item[0] == "season_rating":
+                            media = media_info.get(mid)
+                            if not media or not media.tmdb_id:
+                                return False
+                            sid = await plex.resolve_season_rating_key(
+                                conn.url,
+                                conn.token,
+                                media.tmdb_id,
+                                item[2],
+                            )
+                            if not sid:
+                                return False
+                            return await plex.set_rating(
+                                conn.url,
+                                conn.token,
+                                sid,
+                                item[3],
+                                client=client,
+                            )
                         sid = await _find_source_id(mid)
                         if not sid:
                             return False

--- a/backend/routers/trakt.py
+++ b/backend/routers/trakt.py
@@ -23,7 +23,7 @@ from models.base import CollectionSource, MediaType
 from models.events import WatchEvent
 from models.lists import List as ListModel, ListItem
 from models.media import Media
-from models.ratings import Rating
+from models.ratings import Rating, RatingChanges
 from models.show import Show
 from models.sync import SyncJob, SyncStatus
 from models.users import User, UserSettings
@@ -197,6 +197,72 @@ async def _get_or_create_movie_media(db: AsyncSession, tmdb_id: int, title: str,
     return media
 
 
+async def _get_or_create_series_media(
+    db: AsyncSession,
+    tmdb_id: int,
+    title: str,
+    api_key: str | None,
+) -> Media | None:
+    result = await db.execute(
+        select(Media).where(
+            Media.tmdb_id == tmdb_id,
+            Media.media_type == MediaType.series,
+        )
+    )
+    media = result.scalars().first()
+    if media:
+        return media
+    media = Media(tmdb_id=tmdb_id, media_type=MediaType.series, title=title)
+    db.add(media)
+    await db.flush()
+    await enrich_media(media, api_key=api_key)
+    return media
+
+
+def _trakt_rated_at(value: str | None) -> datetime:
+    if not value:
+        return datetime.utcnow()
+    from dateutil import parser as dt_parser
+
+    parsed = dt_parser.isoparse(value)
+    if parsed.tzinfo:
+        parsed = parsed.astimezone(timezone.utc).replace(tzinfo=None)
+    return parsed
+
+
+def _apply_imported_rating(
+    db: AsyncSession,
+    user_id: int,
+    media: Media,
+    season_number: int | None,
+    item: dict,
+    existing: dict[tuple[int, int | None], Rating],
+    changed: RatingChanges,
+) -> bool:
+    rating_value = float(item["rating"])
+    rated_at = _trakt_rated_at(item.get("rated_at"))
+    key = (media.id, season_number)
+    current = existing.get(key)
+    if current and current.rating == rating_value:
+        current.rated_at = rated_at
+        return False
+    if current:
+        current.rating = rating_value
+        current.rated_at = rated_at
+    else:
+        current = Rating(
+            user_id=user_id,
+            media_id=media.id,
+            season_number=season_number,
+            rating=rating_value,
+            rated_at=rated_at,
+        )
+        db.add(current)
+        existing[key] = current
+    changed[key] = rating_value
+    return True
+
+
 async def _get_or_create_episode_media(
     db: AsyncSession,
     show_id: int,
@@ -306,7 +372,7 @@ async def run_trakt_sync(user_id: int, job_id: int):
 
             stats = {"movies": 0, "episodes": 0, "ratings": 0, "lists": 0, "list_items": 0, "skipped": 0, "errors": 0}
             _new_watched: set[int] = set()
-            _new_ratings: dict[int, float] = {}
+            _new_ratings: RatingChanges = {}
             watched_processed = 0
 
             # ── Watched Movies ────────────────────────────────────────────────
@@ -469,70 +535,72 @@ async def run_trakt_sync(user_id: int, job_id: int):
 
             # ── Ratings ───────────────────────────────────────────────────────
             if sync_ratings:
-                print(f"  Fetching ratings from Trakt...")
+                print("  Fetching ratings from Trakt...")
                 ratings_data = await trakt_client.get_ratings(client_id, access_token)
 
-                # Pre-load existing ratings
-                rat_res = await db.execute(
-                    select(Rating.media_id).where(Rating.user_id == user_id)
+                ratings_result = await db.execute(
+                    select(Rating).where(Rating.user_id == user_id)
                 )
-                existing_rated: set[int] = {row[0] for row in rat_res}
+                existing_ratings = {
+                    (rating.media_id, rating.season_number): rating
+                    for rating in ratings_result.scalars().all()
+                }
 
-                # Movies
-                for item in ratings_data.get("movies", []):
-                    movie_data = item.get("movie", {})
-                    tmdb_id = movie_data.get("ids", {}).get("tmdb")
-                    if not tmdb_id:
-                        continue
-                    try:
-                        async with db.begin_nested():
-                            media = await _get_or_create_movie_media(db, tmdb_id, movie_data.get("title", ""), api_key)
-                            if not media:
-                                continue
-                            if media.id not in existing_rated:
-                                db.add(Rating(
-                                    user_id=user_id,
-                                    media_id=media.id,
-                                    rating=float(item.get("rating", 0)),
-                                ))
-                                existing_rated.add(media.id)
-                                _new_ratings[media.id] = float(item.get("rating", 0))
-                                stats["ratings"] += 1
-                    except Exception as exc:
-                        logger.warning("Error processing Trakt movie rating tmdb=%s: %s", tmdb_id, exc)
-                        stats["errors"] += 1
+                for kind in ("movies", "shows", "seasons"):
+                    for item in ratings_data.get(kind, []):
+                        try:
+                            async with db.begin_nested():
+                                season_number: int | None = None
+                                if kind == "movies":
+                                    movie_data = item.get("movie", {})
+                                    tmdb_id = movie_data.get("ids", {}).get("tmdb")
+                                    media = (
+                                        await _get_or_create_movie_media(
+                                            db,
+                                            tmdb_id,
+                                            movie_data.get("title", ""),
+                                            api_key,
+                                        )
+                                        if tmdb_id
+                                        else None
+                                    )
+                                else:
+                                    show_data = item.get("show", {})
+                                    tmdb_id = show_data.get("ids", {}).get("tmdb")
+                                    if kind == "seasons":
+                                        season_number = item.get("season", {}).get("number")
+                                    media = (
+                                        await _get_or_create_series_media(
+                                            db,
+                                            tmdb_id,
+                                            show_data.get("title", ""),
+                                            api_key,
+                                        )
+                                        if tmdb_id and (kind != "seasons" or season_number is not None)
+                                        else None
+                                    )
 
-                # Shows
-                for item in ratings_data.get("shows", []):
-                    show_data = item.get("show", {})
-                    tmdb_id = show_data.get("ids", {}).get("tmdb")
-                    if not tmdb_id:
-                        continue
-                    try:
-                        async with db.begin_nested():
-                            result = await db.execute(
-                                select(Media).where(Media.tmdb_id == tmdb_id, Media.media_type == MediaType.series)
-                            )
-                            media = result.scalar_one_or_none()
-                            if not media:
-                                from core import tmdb
-                                d = await tmdb.get_show(tmdb_id, api_key=api_key)
-                                media = Media(tmdb_id=tmdb_id, media_type=MediaType.series, title=d.get("name") or show_data.get("title", ""))
-                                db.add(media)
-                                await db.flush()
-                                await enrich_media(media, api_key=api_key)
-                            if media.id not in existing_rated:
-                                db.add(Rating(
-                                    user_id=user_id,
-                                    media_id=media.id,
-                                    rating=float(item.get("rating", 0)),
-                                ))
-                                existing_rated.add(media.id)
-                                _new_ratings[media.id] = float(item.get("rating", 0))
-                                stats["ratings"] += 1
-                    except Exception as exc:
-                        logger.warning("Error processing Trakt show rating tmdb=%s: %s", tmdb_id, exc)
-                        stats["errors"] += 1
+                                if not media:
+                                    stats["skipped"] += 1
+                                    continue
+                                if _apply_imported_rating(
+                                    db,
+                                    user_id,
+                                    media,
+                                    season_number,
+                                    item,
+                                    existing_ratings,
+                                    _new_ratings,
+                                ):
+                                    stats["ratings"] += 1
+                                else:
+                                    stats["skipped"] += 1
+                        except (KeyError, TypeError, ValueError) as exc:
+                            logger.warning("Invalid Trakt %s rating: %s", kind, exc)
+                            stats["errors"] += 1
+                        except Exception as exc:
+                            logger.warning("Error processing Trakt %s rating: %s", kind, exc)
+                            stats["errors"] += 1
 
                 await db.commit()
 
@@ -904,7 +972,7 @@ async def _run_trakt_push(user_id: int, job_id: int) -> None:
 
             all_media_ids: set[int] = set()
             watched_ids: set[int] = set()
-            ratings_map: dict[int, float] = {}
+            ratings_map: RatingChanges = {}
 
             if settings.trakt_push_watched:
                 watched_result = await db.execute(
@@ -915,13 +983,16 @@ async def _run_trakt_push(user_id: int, job_id: int) -> None:
 
             if settings.trakt_push_ratings:
                 ratings_result = await db.execute(
-                    select(Rating.media_id, Rating.rating).where(
+                    select(Rating.media_id, Rating.season_number, Rating.rating).where(
                         Rating.user_id == user_id,
                         Rating.rating.isnot(None),
                     )
                 )
-                ratings_map = {row[0]: row[1] for row in ratings_result.all()}
-                all_media_ids |= set(ratings_map.keys())
+                ratings_map = {
+                    (media_id, season_number): float(rating)
+                    for media_id, season_number, rating in ratings_result.all()
+                }
+                all_media_ids |= {media_id for media_id, _ in ratings_map}
 
             if not all_media_ids:
                 await db.execute(update(SyncJob).where(SyncJob.id == job_id).values(status=SyncStatus.completed, stats={"succeeded": 0, "failed": 0}, processed_items=0, total_items=0))
@@ -955,13 +1026,31 @@ async def _run_trakt_push(user_id: int, job_id: int) -> None:
                             push_tasks.append(trakt_client.add_episode_to_history(settings.trakt_client_id, settings.trakt_access_token, show.tmdb_id, media.season_number, media.episode_number))
 
             if settings.trakt_push_ratings:
-                for mid, rating in ratings_map.items():
+                from routers.sync import _get_effective_tmdb_key, _resolve_tmdb_season_ids
+
+                season_tmdb_ids = await _resolve_tmdb_season_ids(
+                    media_by_id,
+                    set(ratings_map),
+                    await _get_effective_tmdb_key(db, settings),
+                )
+                for key, rating in ratings_map.items():
+                    mid, season_number = key
                     media = media_by_id.get(mid)
                     if not media or not media.tmdb_id:
                         continue
-                    if media.media_type == MediaType.movie:
+                    if season_number is not None:
+                        if season_tmdb_id := season_tmdb_ids.get(key):
+                            push_tasks.append(
+                                trakt_client.set_season_rating(
+                                    settings.trakt_client_id,
+                                    settings.trakt_access_token,
+                                    season_tmdb_id,
+                                    rating,
+                                )
+                            )
+                    elif media.media_type == MediaType.movie:
                         push_tasks.append(trakt_client.set_movie_rating(settings.trakt_client_id, settings.trakt_access_token, media.tmdb_id, rating))
-                    elif media.media_type in (MediaType.series, MediaType.episode):
+                    elif media.media_type == MediaType.series:
                         push_tasks.append(trakt_client.set_show_rating(settings.trakt_client_id, settings.trakt_access_token, media.tmdb_id, rating))
 
             total = len(push_tasks)

--- a/backend/tests/test_mdblist.py
+++ b/backend/tests/test_mdblist.py
@@ -13,7 +13,13 @@ os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://test:test@localhost/
 from core import mdblist
 from models.base import MediaType
 from models.media import Media
-from routers.mdblist import _episode_identity, _payload_item, _resolve_external_tmdb_id
+from routers.mdblist import (
+    _episode_identity,
+    _payload_item,
+    _rating_removal_item,
+    _resolve_external_tmdb_id,
+    _season_identity,
+)
 from routers.lists import _push_list_item_to_mdblist
 
 
@@ -212,6 +218,68 @@ class MDBListNormalizationTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(kind, "movies")
         self.assertEqual(item["rating"], 8.0)
         self.assertEqual(item["rated_at"], "2026-07-17T12:00:00Z")
+
+    def test_season_identity_uses_parent_show_and_season_number(self) -> None:
+        entry = {
+            "rated_at": "2026-07-18T00:00:00Z",
+            "rating": 8,
+            "season": {"number": 1, "ids": {"tmdb": 3572}},
+            "show": {"title": "Breaking Bad", "ids": {"tmdb": 1396}},
+        }
+
+        show, season_number = _season_identity(entry)
+
+        self.assertEqual(show["ids"]["tmdb"], 1396)
+        self.assertEqual(season_number, 1)
+
+    def test_payload_item_nests_season_under_parent_show(self) -> None:
+        media = Media(
+            id=1,
+            tmdb_id=1396,
+            media_type=MediaType.series,
+            title="Breaking Bad",
+        )
+
+        kind, item = _payload_item(
+            media,
+            season_number=1,
+            rating=8.0,
+            rated_at=datetime(2026, 7, 18, 0, 0, 0, 123456),
+        )
+
+        self.assertEqual(kind, "shows")
+        self.assertEqual(
+            item,
+            {
+                "ids": {"tmdb": 1396},
+                "seasons": [
+                    {
+                        "number": 1,
+                        "rating": 8.0,
+                        "rated_at": "2026-07-18T00:00:00Z",
+                    }
+                ],
+            },
+        )
+
+    def test_rating_removal_nests_season_under_parent_show(self) -> None:
+        media = Media(
+            id=1,
+            tmdb_id=1396,
+            media_type=MediaType.series,
+            title="Breaking Bad",
+        )
+
+        kind, item = _rating_removal_item(media, season_number=1)
+
+        self.assertEqual(kind, "shows")
+        self.assertEqual(
+            item,
+            {
+                "ids": {"tmdb": 1396},
+                "seasons": [{"number": 1}],
+            },
+        )
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_mdblist.py
+++ b/backend/tests/test_mdblist.py
@@ -15,6 +15,7 @@ from models.base import MediaType
 from models.media import Media
 from routers.mdblist import (
     _episode_identity,
+    _merge_show_entries,
     _payload_item,
     _rating_removal_item,
     _resolve_external_tmdb_id,
@@ -277,6 +278,71 @@ class MDBListNormalizationTests(unittest.IsolatedAsyncioTestCase):
             item,
             {
                 "ids": {"tmdb": 1396},
+                "seasons": [{"number": 1}],
+            },
+        )
+
+    def test_merge_show_entries_combines_multiple_seasons_of_same_show(self) -> None:
+        """Regression test: two season ratings for one show must round-trip
+        as a single show object with both seasons nested, not two separate
+        entries sharing the same ids.tmdb."""
+        _, season_one = _payload_item(
+            Media(id=1, tmdb_id=1396, media_type=MediaType.series, title="Breaking Bad"),
+            season_number=1,
+            rating=8.0,
+            rated_at=datetime(2026, 7, 18, 0, 0, 0),
+        )
+        _, season_two = _payload_item(
+            Media(id=1, tmdb_id=1396, media_type=MediaType.series, title="Breaking Bad"),
+            season_number=2,
+            rating=9.0,
+            rated_at=datetime(2026, 7, 18, 0, 0, 0),
+        )
+
+        merged = _merge_show_entries([season_one, season_two])
+
+        self.assertEqual(len(merged), 1)
+        self.assertEqual(merged[0]["ids"], {"tmdb": 1396})
+        self.assertEqual(
+            merged[0]["seasons"],
+            [
+                {"number": 1, "rating": 8.0, "rated_at": "2026-07-18T00:00:00Z"},
+                {"number": 2, "rating": 9.0, "rated_at": "2026-07-18T00:00:00Z"},
+            ],
+        )
+
+    def test_merge_show_entries_keeps_different_shows_separate(self) -> None:
+        _, breaking_bad = _payload_item(
+            Media(id=1, tmdb_id=1396, media_type=MediaType.series, title="Breaking Bad"),
+            season_number=1,
+            rating=8.0,
+        )
+        _, the_wire = _payload_item(
+            Media(id=2, tmdb_id=1438, media_type=MediaType.series, title="The Wire"),
+            season_number=1,
+            rating=10.0,
+        )
+
+        merged = _merge_show_entries([breaking_bad, the_wire])
+
+        self.assertEqual(len(merged), 2)
+        self.assertEqual({item["ids"]["tmdb"] for item in merged}, {1396, 1438})
+
+    def test_merge_show_entries_combines_show_rating_with_season_removal(self) -> None:
+        """A show-level rating and a season removal for the same show must
+        merge into one object rather than clobbering each other."""
+        show_item = {"ids": {"tmdb": 1396}, "rating": 9.0, "rated_at": "2026-07-18T00:00:00Z"}
+        season_removal = {"ids": {"tmdb": 1396}, "seasons": [{"number": 1}]}
+
+        merged = _merge_show_entries([show_item, season_removal])
+
+        self.assertEqual(len(merged), 1)
+        self.assertEqual(
+            merged[0],
+            {
+                "ids": {"tmdb": 1396},
+                "rating": 9.0,
+                "rated_at": "2026-07-18T00:00:00Z",
                 "seasons": [{"number": 1}],
             },
         )

--- a/backend/tests/test_plex.py
+++ b/backend/tests/test_plex.py
@@ -1,0 +1,91 @@
+import unittest
+from unittest.mock import patch
+
+import httpx
+
+from core import plex
+
+
+_REAL_ASYNC_CLIENT = httpx.AsyncClient
+
+
+class PlexSeasonRatingTests(unittest.IsolatedAsyncioTestCase):
+    async def test_resolve_season_rating_key_uses_parent_show_tmdb_id(self) -> None:
+        requested_paths: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            requested_paths.append(request.url.path)
+            if request.url.path == "/library/sections/all":
+                self.assertEqual(request.url.params["type"], "2")
+                self.assertEqual(request.url.params["guid"], "tmdb://1396")
+                return httpx.Response(
+                    200,
+                    json={
+                        "MediaContainer": {
+                            "Metadata": [
+                                {
+                                    "ratingKey": "100",
+                                    "Guid": [{"id": "tmdb://1396"}],
+                                }
+                            ]
+                        }
+                    },
+                )
+            if request.url.path == "/library/metadata/100/children":
+                return httpx.Response(
+                    200,
+                    json={
+                        "MediaContainer": {
+                            "Metadata": [
+                                {"ratingKey": "101", "index": 0, "type": "season"},
+                                {"ratingKey": "102", "index": 1, "type": "season"},
+                                {"ratingKey": "103", "index": 2, "type": "season"},
+                            ]
+                        }
+                    },
+                )
+            self.fail(f"Unexpected Plex path: {request.url.path}")
+
+        transport = httpx.MockTransport(handler)
+        with patch.object(
+            plex.httpx,
+            "AsyncClient",
+            side_effect=lambda **kwargs: _REAL_ASYNC_CLIENT(transport=transport, **kwargs),
+        ):
+            rating_key = await plex.resolve_season_rating_key(
+                "http://plex.local",
+                "token",
+                1396,
+                2,
+            )
+
+        self.assertEqual(rating_key, "103")
+        self.assertEqual(
+            requested_paths,
+            ["/library/sections/all", "/library/metadata/100/children"],
+        )
+
+    async def test_zero_rating_clears_plex_season_rating(self) -> None:
+        request_data: dict[str, str] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            request_data["path"] = request.url.path
+            request_data["rating"] = request.url.params["rating"]
+            return httpx.Response(200, json={})
+
+        transport = httpx.MockTransport(handler)
+        async with _REAL_ASYNC_CLIENT(transport=transport) as client:
+            result = await plex.set_rating(
+                "http://plex.local",
+                "token",
+                "103",
+                0,
+                client=client,
+            )
+
+        self.assertTrue(result)
+        self.assertEqual(request_data, {"path": "/library/metadata/103/userRating", "rating": "0"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_season_ratings.py
+++ b/backend/tests/test_season_ratings.py
@@ -1,0 +1,284 @@
+import os
+import unittest
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+os.environ.setdefault("SECRET_KEY", "test-secret")
+os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://test:test@localhost/test")
+
+from models.base import MediaType
+from models.media import Media
+from routers.mdblist import _import_ratings
+from routers.trakt import _apply_imported_rating
+from routers.sync import _fan_out_changes_to_other_connections
+
+
+def _scalar_result(items: list) -> MagicMock:
+    result = MagicMock()
+    result.scalars.return_value.all.return_value = items
+    return result
+
+
+def _rows_result(items: list[tuple]) -> MagicMock:
+    result = MagicMock()
+    result.all.return_value = items
+    return result
+
+
+def _settings() -> SimpleNamespace:
+    return SimpleNamespace(
+        tmdb_api_key="tmdb-key",
+        trakt_push_watched=False,
+        trakt_push_ratings=True,
+        trakt_access_token="trakt-token",
+        trakt_client_id="trakt-client",
+        mdblist_push_watched=False,
+        mdblist_push_ratings=True,
+        mdblist_api_key="mdblist-key",
+        simkl_push_ratings=False,
+        simkl_access_token=None,
+        simkl_client_id=None,
+    )
+
+
+def _plex_connection() -> SimpleNamespace:
+    return SimpleNamespace(
+        id=7,
+        type="plex",
+        url="http://plex.local",
+        token="plex-token",
+        server_user_id=None,
+        push_watched=False,
+        push_ratings=True,
+    )
+
+
+class SeasonRatingFanoutTests(unittest.IsolatedAsyncioTestCase):
+    async def test_season_rating_fans_out_with_provider_specific_identity(self) -> None:
+        media = Media(
+            id=1,
+            tmdb_id=1396,
+            media_type=MediaType.series,
+            title="Breaking Bad",
+        )
+        db = SimpleNamespace(
+            execute=AsyncMock(
+                side_effect=[
+                    _scalar_result([media]),
+                    _scalar_result([_plex_connection()]),
+                    _rows_result([]),
+                    _rows_result([(1, 1, datetime(2026, 7, 18, 0, 0, 0))]),
+                ]
+            ),
+            commit=AsyncMock(),
+        )
+
+        with (
+            patch("routers.sync._resolve_tmdb_season_ids", AsyncMock(return_value={(1, 1): 3572})),
+            patch("routers.sync.plex.resolve_season_rating_key", AsyncMock(return_value="103")) as resolve_plex,
+            patch("routers.sync.plex.set_rating", AsyncMock(return_value=True)) as set_plex,
+            patch("routers.sync.trakt_client.set_ratings_batch", AsyncMock()) as set_trakt,
+            patch("core.mdblist.push_ratings", AsyncMock(return_value={})) as push_mdblist,
+        ):
+            await _fan_out_changes_to_other_connections(
+                db,
+                user_id=3,
+                exclude_connection_id=None,
+                new_watched_ids=set(),
+                new_ratings={(1, 1): 8.0},
+                settings=_settings(),
+            )
+
+        resolve_plex.assert_awaited_once_with(
+            "http://plex.local",
+            "plex-token",
+            1396,
+            1,
+        )
+        set_plex.assert_awaited_once_with(
+            "http://plex.local",
+            "plex-token",
+            "103",
+            8.0,
+        )
+        set_trakt.assert_awaited_once_with(
+            "trakt-client",
+            "trakt-token",
+            [],
+            [],
+            [(3572, 8.0)],
+        )
+        payload = push_mdblist.await_args.args[1]
+        self.assertEqual(
+            payload["shows"],
+            [
+                {
+                    "ids": {"tmdb": 1396},
+                    "seasons": [
+                        {
+                            "number": 1,
+                            "rating": 8.0,
+                            "rated_at": "2026-07-18T00:00:00Z",
+                        }
+                    ],
+                }
+            ],
+        )
+
+    async def test_season_rating_removal_fans_out_without_touching_show_rating(self) -> None:
+        media = Media(
+            id=1,
+            tmdb_id=1396,
+            media_type=MediaType.series,
+            title="Breaking Bad",
+        )
+        db = SimpleNamespace(
+            execute=AsyncMock(
+                side_effect=[
+                    _scalar_result([media]),
+                    _scalar_result([_plex_connection()]),
+                    _rows_result([]),
+                ]
+            ),
+            commit=AsyncMock(),
+        )
+
+        with (
+            patch("routers.sync._resolve_tmdb_season_ids", AsyncMock(return_value={(1, 1): 3572})),
+            patch("routers.sync.plex.resolve_season_rating_key", AsyncMock(return_value="103")),
+            patch("routers.sync.plex.set_rating", AsyncMock(return_value=True)) as set_plex,
+            patch("routers.sync.trakt_client.remove_ratings_batch", AsyncMock()) as remove_trakt,
+            patch("core.mdblist.remove_ratings", AsyncMock(return_value={})) as remove_mdblist,
+        ):
+            await _fan_out_changes_to_other_connections(
+                db,
+                user_id=3,
+                exclude_connection_id=None,
+                new_watched_ids=set(),
+                new_ratings={},
+                settings=_settings(),
+                removed_ratings={(1, 1)},
+            )
+
+        set_plex.assert_awaited_once_with(
+            "http://plex.local",
+            "plex-token",
+            "103",
+            0.0,
+        )
+        remove_trakt.assert_awaited_once_with(
+            "trakt-client",
+            "trakt-token",
+            [],
+            [],
+            [3572],
+        )
+        payload = remove_mdblist.await_args.args[1]
+        self.assertEqual(
+            payload["shows"],
+            [{"ids": {"tmdb": 1396}, "seasons": [{"number": 1}]}],
+        )
+
+
+class SeasonRatingImportTests(unittest.IsolatedAsyncioTestCase):
+    async def test_mdblist_import_persists_season_rating_separately(self) -> None:
+        media = Media(
+            id=1,
+            tmdb_id=1396,
+            media_type=MediaType.series,
+            title="Breaking Bad",
+        )
+        transaction = MagicMock()
+        transaction.__aenter__ = AsyncMock(return_value=None)
+        transaction.__aexit__ = AsyncMock(return_value=False)
+        db = SimpleNamespace(
+            execute=AsyncMock(return_value=_scalar_result([])),
+            begin_nested=MagicMock(return_value=transaction),
+            add=MagicMock(),
+        )
+        stats = {"ratings": 0, "skipped": 0, "errors": 0}
+        payload = {
+            "seasons": [
+                {
+                    "rating": 8,
+                    "rated_at": "2026-07-18T00:00:00Z",
+                    "season": {
+                        "number": 1,
+                        "ids": {"tmdb": 3572},
+                        "show": {
+                            "title": "Breaking Bad",
+                            "ids": {"tmdb": 1396},
+                        },
+                    },
+                }
+            ]
+        }
+
+        with (
+            patch(
+                "routers.mdblist._resolve_external_tmdb_id",
+                AsyncMock(return_value=1396),
+            ),
+            patch(
+                "routers.mdblist._get_or_create_series_media",
+                AsyncMock(return_value=media),
+            ),
+        ):
+            changed = await _import_ratings(
+                db,
+                user_id=3,
+                payload=payload,
+                api_key="tmdb-key",
+                external_cache={},
+                stats=stats,
+            )
+
+        self.assertEqual(changed, {(1, 1): 8.0})
+        self.assertEqual(stats["ratings"], 1)
+        imported = db.add.call_args.args[0]
+        self.assertEqual(imported.media_id, 1)
+        self.assertEqual(imported.season_number, 1)
+        self.assertEqual(imported.rating, 8.0)
+
+    def test_trakt_import_keeps_show_and_season_ratings_distinct(self) -> None:
+        media = Media(
+            id=1,
+            tmdb_id=1396,
+            media_type=MediaType.series,
+            title="Breaking Bad",
+        )
+        db = SimpleNamespace(add=MagicMock())
+        existing = {}
+        changed = {}
+
+        self.assertTrue(
+            _apply_imported_rating(
+                db,
+                user_id=3,
+                media=media,
+                season_number=None,
+                item={"rating": 9, "rated_at": "2026-07-18T00:00:00Z"},
+                existing=existing,
+                changed=changed,
+            )
+        )
+        self.assertTrue(
+            _apply_imported_rating(
+                db,
+                user_id=3,
+                media=media,
+                season_number=1,
+                item={"rating": 8, "rated_at": "2026-07-18T00:00:00Z"},
+                existing=existing,
+                changed=changed,
+            )
+        )
+
+        self.assertEqual(changed, {(1, None): 9.0, (1, 1): 8.0})
+        self.assertEqual(existing[(1, None)].season_number, None)
+        self.assertEqual(existing[(1, 1)].season_number, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_season_ratings.py
+++ b/backend/tests/test_season_ratings.py
@@ -180,6 +180,110 @@ class SeasonRatingFanoutTests(unittest.IsolatedAsyncioTestCase):
             [{"ids": {"tmdb": 1396}, "seasons": [{"number": 1}]}],
         )
 
+    async def test_two_season_ratings_of_same_show_merge_into_one_mdblist_entry(self) -> None:
+        """Regression test: rating two seasons of the same show in one sync
+        must fan out to MDBList as a single show object with both seasons
+        nested, not two entries sharing the same ids.tmdb (which would let
+        one silently clobber the other)."""
+        media = Media(
+            id=1,
+            tmdb_id=1396,
+            media_type=MediaType.series,
+            title="Breaking Bad",
+        )
+        db = SimpleNamespace(
+            execute=AsyncMock(
+                side_effect=[
+                    _scalar_result([media]),
+                    _scalar_result([_plex_connection()]),
+                    _rows_result([]),
+                    _rows_result(
+                        [
+                            (1, 1, datetime(2026, 7, 18, 0, 0, 0)),
+                            (1, 2, datetime(2026, 7, 18, 0, 0, 0)),
+                        ]
+                    ),
+                ]
+            ),
+            commit=AsyncMock(),
+        )
+
+        with (
+            patch(
+                "routers.sync._resolve_tmdb_season_ids",
+                AsyncMock(return_value={(1, 1): 3572, (1, 2): 3573}),
+            ),
+            patch("routers.sync.plex.resolve_season_rating_key", AsyncMock(return_value="103")),
+            patch("routers.sync.plex.set_rating", AsyncMock(return_value=True)),
+            patch("routers.sync.trakt_client.set_ratings_batch", AsyncMock()),
+            patch("core.mdblist.push_ratings", AsyncMock(return_value={})) as push_mdblist,
+        ):
+            await _fan_out_changes_to_other_connections(
+                db,
+                user_id=3,
+                exclude_connection_id=None,
+                new_watched_ids=set(),
+                new_ratings={(1, 1): 8.0, (1, 2): 9.0},
+                settings=_settings(),
+            )
+
+        payload = push_mdblist.await_args.args[1]
+        self.assertEqual(len(payload["shows"]), 1)
+        self.assertEqual(payload["shows"][0]["ids"], {"tmdb": 1396})
+        self.assertEqual(
+            sorted(payload["shows"][0]["seasons"], key=lambda s: s["number"]),
+            [
+                {"number": 1, "rating": 8.0, "rated_at": "2026-07-18T00:00:00Z"},
+                {"number": 2, "rating": 9.0, "rated_at": "2026-07-18T00:00:00Z"},
+            ],
+        )
+
+    async def test_two_season_removals_of_same_show_merge_into_one_mdblist_entry(self) -> None:
+        media = Media(
+            id=1,
+            tmdb_id=1396,
+            media_type=MediaType.series,
+            title="Breaking Bad",
+        )
+        db = SimpleNamespace(
+            execute=AsyncMock(
+                side_effect=[
+                    _scalar_result([media]),
+                    _scalar_result([_plex_connection()]),
+                    _rows_result([]),
+                ]
+            ),
+            commit=AsyncMock(),
+        )
+
+        with (
+            patch(
+                "routers.sync._resolve_tmdb_season_ids",
+                AsyncMock(return_value={(1, 1): 3572, (1, 2): 3573}),
+            ),
+            patch("routers.sync.plex.resolve_season_rating_key", AsyncMock(return_value="103")),
+            patch("routers.sync.plex.set_rating", AsyncMock(return_value=True)),
+            patch("routers.sync.trakt_client.remove_ratings_batch", AsyncMock()),
+            patch("core.mdblist.remove_ratings", AsyncMock(return_value={})) as remove_mdblist,
+        ):
+            await _fan_out_changes_to_other_connections(
+                db,
+                user_id=3,
+                exclude_connection_id=None,
+                new_watched_ids=set(),
+                new_ratings={},
+                settings=_settings(),
+                removed_ratings={(1, 1), (1, 2)},
+            )
+
+        payload = remove_mdblist.await_args.args[1]
+        self.assertEqual(len(payload["shows"]), 1)
+        self.assertEqual(payload["shows"][0]["ids"], {"tmdb": 1396})
+        self.assertEqual(
+            sorted(payload["shows"][0]["seasons"], key=lambda s: s["number"]),
+            [{"number": 1}, {"number": 2}],
+        )
+
 
 class SeasonRatingImportTests(unittest.IsolatedAsyncioTestCase):
     async def test_mdblist_import_persists_season_rating_separately(self) -> None:

--- a/backend/tests/test_trakt.py
+++ b/backend/tests/test_trakt.py
@@ -1,3 +1,4 @@
+import json
 import unittest
 from unittest.mock import patch
 
@@ -117,6 +118,88 @@ class TraktClientTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(request_count, 1)
         self.assertEqual(len(movies), 1)
 
+
+    async def test_get_ratings_fetches_movies_shows_and_seasons(self) -> None:
+        requested: list[tuple[str, int]] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            kind = request.url.path.rsplit("/", 1)[-1]
+            page = int(request.url.params["page"])
+            requested.append((kind, page))
+            payload = {
+                "movies": {"movie": {"ids": {"tmdb": 550}}},
+                "shows": {"show": {"ids": {"tmdb": 1396}}},
+                "seasons": {
+                    "show": {"ids": {"tmdb": 1396}},
+                    "season": {"number": page, "ids": {"tmdb": 3572 + page - 1}},
+                },
+            }
+            return httpx.Response(
+                200,
+                json=[payload[kind]],
+                headers={"X-Pagination-Page-Count": "2"},
+            )
+
+        transport = httpx.MockTransport(handler)
+        with patch.object(
+            trakt.httpx,
+            "AsyncClient",
+            side_effect=lambda **kwargs: _REAL_ASYNC_CLIENT(transport=transport, **kwargs),
+        ):
+            ratings = await trakt.get_ratings("client-id", "access-token")
+
+        self.assertCountEqual(
+            requested,
+            [
+                ("movies", 1),
+                ("movies", 2),
+                ("shows", 1),
+                ("shows", 2),
+                ("seasons", 1),
+                ("seasons", 2),
+            ],
+        )
+        self.assertEqual(len(ratings["seasons"]), 2)
+        self.assertEqual(ratings["seasons"][1]["season"]["number"], 2)
+
+    async def test_rating_batches_preserve_season_tmdb_ids(self) -> None:
+        requests: list[tuple[str, dict]] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            requests.append((request.url.path, json.loads(request.content)))
+            return httpx.Response(200, json={"added": {}, "deleted": {}})
+
+        transport = httpx.MockTransport(handler)
+        with patch.object(
+            trakt.httpx,
+            "AsyncClient",
+            side_effect=lambda **kwargs: _REAL_ASYNC_CLIENT(transport=transport, **kwargs),
+        ):
+            await trakt.set_ratings_batch(
+                "client-id",
+                "access-token",
+                [(550, 8.4)],
+                [(1396, 9.0)],
+                [(3572, 7.6)],
+            )
+            await trakt.remove_ratings_batch(
+                "client-id",
+                "access-token",
+                [550],
+                [1396],
+                [3572],
+            )
+
+        self.assertEqual(requests[0][0], "/sync/ratings")
+        self.assertEqual(
+            requests[0][1]["seasons"],
+            [{"rating": 8, "ids": {"tmdb": 3572}}],
+        )
+        self.assertEqual(requests[1][0], "/sync/ratings/remove")
+        self.assertEqual(
+            requests[1][1]["seasons"],
+            [{"ids": {"tmdb": 3572}}],
+        )
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Closes #73.

- preserve season ratings as `(media_id, season_number)` throughout imports, direct actions, full pushes, and provider fan-out
- import, update, and remove Trakt season ratings using TMDB season identifiers and paginated rating snapshots
- import and push MDBList season ratings using its nested show/season contract, with second-precision timestamps required by the live API
- import Plex `userRating` values from seasons and resolve local season `ratingKey` values for push/removal
- keep show-level and season-level ratings independent; providers without season-rating support do not receive a misleading show rating
- centralize manual rating fan-out so add/update/removal behavior matches background synchronization

## Validation

- `python -m compileall -q core models routers tests`
- `python -m unittest discover -s tests -v` — 33 tests passed
- live Scrob API smoke test: added a season rating, observed it on both Trakt and MDBList, removed it, and confirmed it was absent from both providers
- rebuilt the local Docker image and confirmed `scrob` and `scrob-db` were healthy
- removed smoke-test data and restored the temporary provider setting
