### PR TITLE
docs(config): correct registration default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,7 @@ POSTGRES_PORT=5432
 # Generate with: openssl rand -hex 32
 SECRET_KEY=changethisinproduction
 
-ENABLE_REGISTRATIONS=true
+ENABLE_REGISTRATIONS=false
 REGISTRATION_MAX_ALLOWED_USERS=5
 
 # Require email validation for new users — if true, users will receive an email with a validation link before they can log in

--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ Database migrations run automatically on startup - no manual steps required.
 |---|---|---|
 | `SECRET_KEY` | - | **Required.** JWT signing key. Generate with `openssl rand -hex 32`. |
 | `DATABASE_URL` | - | **Required** (standard image). PostgreSQL connection string (`postgresql+asyncpg://...`). Optional on the omnibus image — if omitted, the embedded database is used. |
-| `ENABLE_REGISTRATIONS` | `true` | Allow new users to register. The first user can always register regardless of this setting. |
+| `ENABLE_REGISTRATIONS` | `false` | Allow new users to register. The first user can always register regardless of this setting. |
 | `REGISTRATION_MAX_ALLOWED_USERS` | `0` | Maximum number of registered users. `0` = unlimited. |
 | `TZ` | `UTC` | Container timezone (e.g. `Europe/Lisbon`). |
 | `PUID` | `1000` | User ID to run the process as. |

--- a/docker-compose.omnibus.yml
+++ b/docker-compose.omnibus.yml
@@ -11,8 +11,8 @@ services:
       SECRET_KEY: changeme
 
       # ── Registrations ────────────────────────────────────────────────────────
-      # Registrations are open by default. Disable after initial setup if desired.
-      # ENABLE_REGISTRATIONS: "false"
+      # Registrations are disabled by default. Set to true to allow additional users.
+      # ENABLE_REGISTRATIONS: "true"
       # REGISTRATION_MAX_ALLOWED_USERS: "0"  # 0 = unlimited
 
       # ── OIDC (optional) ─────────────────────────────────────────────────────

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -33,8 +33,8 @@ services:
       SECRET_KEY: changeme
 
       # ── Registrations ────────────────────────────────────────────────────────
-      # Registrations are open by default. Disable after initial setup if desired.
-      # ENABLE_REGISTRATIONS: "false"
+      # Registrations are disabled by default. Set to true to allow additional users.
+      # ENABLE_REGISTRATIONS: "true"
       # REGISTRATION_MAX_ALLOWED_USERS: "0"  # 0 = unlimited
 
       # ── OIDC (optional) ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- correct the documented `ENABLE_REGISTRATIONS` default from `true` to `false`, matching `backend/core/config.py`
- keep the first-user registration exception documented
- make `.env.example` preserve the secure disabled default
- update standard and omnibus Compose examples to show `true` as an explicit opt-in for additional users

## Validation

- searched all `ENABLE_REGISTRATIONS` and registration-default references and confirmed they now agree with the runtime configuration
- documentation/configuration-example changes only; no runtime code changed
