### PR TITLE
feat(sync): add per-show TMDB and TVDB episode order

### DIFF
--- a/backend/core/episode_order.py
+++ b/backend/core/episode_order.py
@@ -1,0 +1,230 @@
+import asyncio
+import re
+import unicodedata
+from datetime import date
+
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from core import tmdb, tvdb
+from models.episode_order import EpisodeOrderMapping, UserShowEpisodeOrder
+
+
+_VALID_ORDERS = {"tmdb", "tvdb"}
+
+
+def _normalise_title(value: str | None) -> str:
+    text = unicodedata.normalize("NFKD", value or "").encode("ascii", "ignore").decode()
+    return re.sub(r"[^a-z0-9]+", "", text.lower())
+
+
+def _date_distance(left: str | None, right: str | None) -> int | None:
+    if not left or not right:
+        return None
+    try:
+        return abs((date.fromisoformat(left) - date.fromisoformat(right)).days)
+    except ValueError:
+        return None
+
+
+async def get_episode_order(
+    db: AsyncSession,
+    user_id: int,
+    series_tmdb_id: int,
+) -> UserShowEpisodeOrder | None:
+    result = await db.execute(
+        select(UserShowEpisodeOrder).where(
+            UserShowEpisodeOrder.user_id == user_id,
+            UserShowEpisodeOrder.series_tmdb_id == series_tmdb_id,
+        )
+    )
+    return result.scalar_one_or_none()
+
+
+async def get_mappings_for_tvdb_season(
+    db: AsyncSession,
+    series_tmdb_id: int,
+    tvdb_season_number: int,
+) -> list[EpisodeOrderMapping]:
+    result = await db.execute(
+        select(EpisodeOrderMapping)
+        .where(
+            EpisodeOrderMapping.series_tmdb_id == series_tmdb_id,
+            EpisodeOrderMapping.tvdb_season_number == tvdb_season_number,
+        )
+        .order_by(EpisodeOrderMapping.tvdb_episode_number)
+    )
+    return list(result.scalars().all())
+
+
+async def get_mapping_by_tvdb_position(
+    db: AsyncSession,
+    series_tmdb_id: int,
+    tvdb_season_number: int,
+    tvdb_episode_number: int,
+) -> EpisodeOrderMapping | None:
+    result = await db.execute(
+        select(EpisodeOrderMapping).where(
+            EpisodeOrderMapping.series_tmdb_id == series_tmdb_id,
+            EpisodeOrderMapping.tvdb_season_number == tvdb_season_number,
+            EpisodeOrderMapping.tvdb_episode_number == tvdb_episode_number,
+        )
+    )
+    return result.scalar_one_or_none()
+
+
+async def ensure_episode_order_mapping(
+    db: AsyncSession,
+    series_tmdb_id: int,
+    tmdb_api_key: str,
+    tvdb_api_key: str,
+    *,
+    force: bool = False,
+) -> dict:
+    existing_result = await db.execute(
+        select(EpisodeOrderMapping).where(
+            EpisodeOrderMapping.series_tmdb_id == series_tmdb_id
+        )
+    )
+    existing = list(existing_result.scalars().all())
+    show_data = await tmdb.get_show(series_tmdb_id, api_key=tmdb_api_key)
+    tvdb_id = (show_data.get("external_ids") or {}).get("tvdb_id")
+    if not tvdb_id:
+        raise ValueError("TMDB does not expose a TVDB identifier for this show")
+    tvdb_id = int(tvdb_id)
+
+    if existing and not force:
+        return {
+            "tvdb_id": tvdb_id,
+            "matched": len(existing),
+            "tmdb_episodes": len(existing),
+            "unmatched": 0,
+        }
+
+    tmdb_season_numbers = sorted(
+        {
+            int(season["season_number"])
+            for season in show_data.get("seasons") or []
+            if season.get("season_number") is not None
+        }
+    )
+    tvdb_series = await tvdb.get_series(tvdb_id, tvdb_api_key)
+    tvdb_season_numbers = sorted(
+        {
+            int(season.get("number"))
+            for season in tvdb_series.get("seasons") or []
+            if season.get("number") is not None
+            and (season.get("type") or {}).get("type") in (None, "official")
+        }
+    )
+    if not tvdb_season_numbers:
+        tvdb_season_numbers = sorted(
+            {
+                int(episode.get("seasonNumber"))
+                for episode in tvdb_series.get("episodes") or []
+                if episode.get("seasonNumber") is not None
+            }
+        )
+
+    tmdb_seasons, tvdb_seasons = await asyncio.gather(
+        asyncio.gather(
+            *(tmdb.get_season(series_tmdb_id, number, api_key=tmdb_api_key) for number in tmdb_season_numbers)
+        ),
+        asyncio.gather(
+            *(tvdb.get_series_episodes(tvdb_id, number, tvdb_api_key) for number in tvdb_season_numbers)
+        ),
+    )
+
+    tmdb_episodes = [
+        episode
+        for season in tmdb_seasons
+        for episode in season.get("episodes") or []
+        if episode.get("season_number") is not None and episode.get("episode_number") is not None
+    ]
+    tvdb_episodes = [episode for season in tvdb_seasons for episode in season]
+    tvdb_by_id = {
+        int(episode["id"]): episode
+        for episode in tvdb_episodes
+        if episode.get("id") is not None
+    }
+
+    semaphore = asyncio.Semaphore(5)
+
+    async def load_external_ids(episode: dict) -> tuple[dict, dict]:
+        async with semaphore:
+            ids = await tmdb.get_episode_external_ids(
+                series_tmdb_id,
+                int(episode["season_number"]),
+                int(episode["episode_number"]),
+                api_key=tmdb_api_key,
+            )
+        return episode, ids
+
+    external_rows = await asyncio.gather(
+        *(load_external_ids(episode) for episode in tmdb_episodes)
+    )
+
+    used_tvdb_ids: set[int] = set()
+    mappings: list[EpisodeOrderMapping] = []
+    unmatched: list[dict] = []
+
+    for episode, external_ids in external_rows:
+        external_tvdb_id = external_ids.get("tvdb_id")
+        match = tvdb_by_id.get(int(external_tvdb_id)) if external_tvdb_id else None
+        method = "external_id"
+        if match is None:
+            title = _normalise_title(episode.get("name"))
+            candidates = [
+                candidate
+                for candidate in tvdb_episodes
+                if candidate.get("id") not in used_tvdb_ids
+                and title
+                and _normalise_title(candidate.get("name")) == title
+                and (_date_distance(episode.get("air_date"), candidate.get("aired")) or 0) <= 1
+            ]
+            if len(candidates) == 1:
+                match = candidates[0]
+                method = "title_date"
+
+        if match is None or match.get("seasonNumber") is None or match.get("number") is None:
+            unmatched.append(episode)
+            continue
+
+        mapped_tvdb_id = int(match["id"])
+        used_tvdb_ids.add(mapped_tvdb_id)
+        mappings.append(
+            EpisodeOrderMapping(
+                series_tmdb_id=series_tmdb_id,
+                tmdb_season_number=int(episode["season_number"]),
+                tmdb_episode_number=int(episode["episode_number"]),
+                tmdb_episode_id=int(episode["id"]),
+                tvdb_id=mapped_tvdb_id,
+                tvdb_season_number=int(match["seasonNumber"]),
+                tvdb_episode_number=int(match["number"]),
+                match_method=method,
+            )
+        )
+
+    if not mappings:
+        raise ValueError("No TMDB episodes could be matched to TVDB")
+
+    await db.execute(
+        delete(EpisodeOrderMapping).where(
+            EpisodeOrderMapping.series_tmdb_id == series_tmdb_id
+        )
+    )
+    db.add_all(mappings)
+    await db.flush()
+
+    return {
+        "tvdb_id": tvdb_id,
+        "matched": len(mappings),
+        "tmdb_episodes": len(tmdb_episodes),
+        "unmatched": len(unmatched),
+    }
+
+
+def validate_episode_order(value: str) -> str:
+    if value not in _VALID_ORDERS:
+        raise ValueError(f"Unsupported episode order: {value}")
+    return value

--- a/backend/core/tmdb.py
+++ b/backend/core/tmdb.py
@@ -95,6 +95,18 @@ async def get_episode(tmdb_id: int, season_number: int, episode_number: int, api
     )
 
 
+async def get_episode_external_ids(
+    tmdb_id: int,
+    season_number: int,
+    episode_number: int,
+    api_key: str = None,
+) -> dict:
+    return await _get(
+        f"{TMDB_BASE}/tv/{tmdb_id}/season/{season_number}/episode/{episode_number}/external_ids",
+        headers=get_headers(api_key),
+    )
+
+
 async def get_trending_movies(time_window: str = "day", page: int = 1, api_key: str = None) -> dict:
     return await _get(f"{TMDB_BASE}/trending/movie/{time_window}", headers=get_headers(api_key), params={"page": page})
 

--- a/backend/core/tvdb.py
+++ b/backend/core/tvdb.py
@@ -134,6 +134,42 @@ async def get_series(tvdb_id: int, api_key: str) -> dict:
     return data.get("data") or {}
 
 
+async def get_season(season_id: int, api_key: str) -> dict:
+    """Fetch extended season metadata, including translated names and overviews."""
+    data = await _get(
+        f"/seasons/{season_id}/extended",
+        api_key,
+        params={"meta": "translations"},
+    )
+    return data.get("data") or {}
+
+
+def format_season(raw: dict, language: str | None = None) -> dict:
+    """Normalise extended TVDB season metadata."""
+    translations = raw.get("translations") or {}
+
+    def _pick(key: str, field: str) -> str | None:
+        entries = translations.get(key) or []
+        fallback = None
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            if language and entry.get("language") == language:
+                return entry.get(field) or None
+            if entry.get("language") == "eng":
+                fallback = entry.get(field) or None
+        return fallback
+
+    return {
+        "season_number": raw.get("number"),
+        "name": _pick("nameTranslations", "name") or raw.get("name"),
+        "overview": _pick("overviewTranslations", "overview") or raw.get("overview"),
+        "poster_path": _image_url(raw.get("image")),
+        "air_date": raw.get("premiereDate"),
+        "id": raw.get("id"),
+    }
+
+
 async def get_series_episodes(tvdb_id: int, season_number: int, api_key: str, language: str | None = None) -> list[dict]:
     """Fetch episodes for a specific season (season_type=official)."""
     episodes = []

--- a/backend/migrations/versions/y9z0a1b2c3d4_add_episode_orders.py
+++ b/backend/migrations/versions/y9z0a1b2c3d4_add_episode_orders.py
@@ -1,0 +1,104 @@
+"""add per-show episode orders
+
+Revision ID: y9z0a1b2c3d4
+Revises: x8y9z0a1b2c3
+Create Date: 2026-07-19
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "y9z0a1b2c3d4"
+down_revision = "x8y9z0a1b2c3"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "user_show_episode_orders",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("series_tmdb_id", sa.Integer(), nullable=False),
+        sa.Column("episode_order", sa.String(length=20), nullable=False),
+        sa.Column("tvdb_id", sa.Integer(), nullable=True),
+        sa.Column("updated_at", sa.DateTime(), server_default=sa.text("now()"), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("user_id", "series_tmdb_id", name="uq_user_show_episode_order"),
+    )
+    op.create_index(
+        op.f("ix_user_show_episode_orders_user_id"),
+        "user_show_episode_orders",
+        ["user_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_user_show_episode_orders_series_tmdb_id"),
+        "user_show_episode_orders",
+        ["series_tmdb_id"],
+        unique=False,
+    )
+
+    op.create_table(
+        "episode_order_mappings",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("series_tmdb_id", sa.Integer(), nullable=False),
+        sa.Column("tmdb_season_number", sa.Integer(), nullable=False),
+        sa.Column("tmdb_episode_number", sa.Integer(), nullable=False),
+        sa.Column("tmdb_episode_id", sa.Integer(), nullable=False),
+        sa.Column("tvdb_id", sa.Integer(), nullable=False),
+        sa.Column("tvdb_season_number", sa.Integer(), nullable=False),
+        sa.Column("tvdb_episode_number", sa.Integer(), nullable=False),
+        sa.Column("match_method", sa.String(length=20), nullable=False),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.text("now()"), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "series_tmdb_id",
+            "tmdb_season_number",
+            "tmdb_episode_number",
+            name="uq_episode_order_mapping_tmdb",
+        ),
+        sa.UniqueConstraint(
+            "series_tmdb_id",
+            "tvdb_id",
+            name="uq_episode_order_mapping_tvdb_id",
+        ),
+    )
+    op.create_index(
+        op.f("ix_episode_order_mappings_series_tmdb_id"),
+        "episode_order_mappings",
+        ["series_tmdb_id"],
+        unique=False,
+    )
+    op.create_index(
+        "idx_episode_order_mapping_tvdb_position",
+        "episode_order_mappings",
+        ["series_tmdb_id", "tvdb_season_number", "tvdb_episode_number"],
+        unique=False,
+    )
+
+    op.add_column("ratings", sa.Column("episode_order", sa.String(length=20), nullable=True))
+    op.drop_index("uq_rating_user_media_season", table_name="ratings")
+    op.execute(
+        "CREATE UNIQUE INDEX uq_rating_user_media_season_order "
+        "ON ratings (user_id, media_id, COALESCE(season_number, -1), "
+        "COALESCE(episode_order, 'tmdb'))"
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("uq_rating_user_media_season_order", table_name="ratings")
+    op.execute("DELETE FROM ratings WHERE episode_order IS NOT NULL")
+    op.execute(
+        "CREATE UNIQUE INDEX uq_rating_user_media_season "
+        "ON ratings (user_id, media_id, COALESCE(season_number, -1))"
+    )
+    op.drop_column("ratings", "episode_order")
+    op.drop_index("idx_episode_order_mapping_tvdb_position", table_name="episode_order_mappings")
+    op.drop_index(op.f("ix_episode_order_mappings_series_tmdb_id"), table_name="episode_order_mappings")
+    op.drop_table("episode_order_mappings")
+    op.drop_index(op.f("ix_user_show_episode_orders_series_tmdb_id"), table_name="user_show_episode_orders")
+    op.drop_index(op.f("ix_user_show_episode_orders_user_id"), table_name="user_show_episode_orders")
+    op.drop_table("user_show_episode_orders")

--- a/backend/migrations/versions/y9z0a1b2c3d4_add_episode_orders.py
+++ b/backend/migrations/versions/y9z0a1b2c3d4_add_episode_orders.py
@@ -81,20 +81,23 @@ def upgrade() -> None:
 
     op.add_column("ratings", sa.Column("episode_order", sa.String(length=20), nullable=True))
     op.drop_index("uq_rating_user_media_season", table_name="ratings")
-    op.execute(
-        "CREATE UNIQUE INDEX uq_rating_user_media_season_order "
-        "ON ratings (user_id, media_id, COALESCE(season_number, -1), "
-        "COALESCE(episode_order, 'tmdb'))"
-    )
+    with op.get_context().autocommit_block():
+        op.execute(
+            "CREATE UNIQUE INDEX CONCURRENTLY uq_rating_user_media_season_order "
+            "ON ratings (user_id, media_id, COALESCE(season_number, -1), "
+            "COALESCE(episode_order, 'tmdb'))"
+        )
 
 
 def downgrade() -> None:
-    op.drop_index("uq_rating_user_media_season_order", table_name="ratings")
+    with op.get_context().autocommit_block():
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS uq_rating_user_media_season_order")
     op.execute("DELETE FROM ratings WHERE episode_order IS NOT NULL")
-    op.execute(
-        "CREATE UNIQUE INDEX uq_rating_user_media_season "
-        "ON ratings (user_id, media_id, COALESCE(season_number, -1))"
-    )
+    with op.get_context().autocommit_block():
+        op.execute(
+            "CREATE UNIQUE INDEX CONCURRENTLY uq_rating_user_media_season "
+            "ON ratings (user_id, media_id, COALESCE(season_number, -1))"
+        )
     op.drop_column("ratings", "episode_order")
     op.drop_index("idx_episode_order_mapping_tvdb_position", table_name="episode_order_mappings")
     op.drop_index(op.f("ix_episode_order_mappings_series_tmdb_id"), table_name="episode_order_mappings")

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -24,6 +24,7 @@ from .media_request import MediaRequest
 from .image_cache import ImageCache
 from .media_translation import MediaTranslation
 from .show_translation import ShowTranslation
+from .episode_order import EpisodeOrderMapping, UserShowEpisodeOrder
 
 __all__ = [
     "Base",
@@ -52,4 +53,5 @@ __all__ = [
     "ImageCache",
     "MediaTranslation",
     "ShowTranslation",
+    "EpisodeOrderMapping", "UserShowEpisodeOrder",
 ]

--- a/backend/models/episode_order.py
+++ b/backend/models/episode_order.py
@@ -1,0 +1,68 @@
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Index, Integer, String, UniqueConstraint, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from .base import Base
+
+
+class UserShowEpisodeOrder(Base):
+    __tablename__ = "user_show_episode_orders"
+    __table_args__ = (
+        UniqueConstraint("user_id", "series_tmdb_id", name="uq_user_show_episode_order"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    user_id: Mapped[int] = mapped_column(
+        Integer,
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    series_tmdb_id: Mapped[int] = mapped_column(Integer, nullable=False, index=True)
+    episode_order: Mapped[str] = mapped_column(String(20), nullable=False, default="tmdb")
+    tvdb_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime,
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+
+class EpisodeOrderMapping(Base):
+    __tablename__ = "episode_order_mappings"
+    __table_args__ = (
+        UniqueConstraint(
+            "series_tmdb_id",
+            "tmdb_season_number",
+            "tmdb_episode_number",
+            name="uq_episode_order_mapping_tmdb",
+        ),
+        UniqueConstraint(
+            "series_tmdb_id",
+            "tvdb_id",
+            name="uq_episode_order_mapping_tvdb_id",
+        ),
+        Index(
+            "idx_episode_order_mapping_tvdb_position",
+            "series_tmdb_id",
+            "tvdb_season_number",
+            "tvdb_episode_number",
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    series_tmdb_id: Mapped[int] = mapped_column(Integer, nullable=False, index=True)
+    tmdb_season_number: Mapped[int] = mapped_column(Integer, nullable=False)
+    tmdb_episode_number: Mapped[int] = mapped_column(Integer, nullable=False)
+    tmdb_episode_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    tvdb_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    tvdb_season_number: Mapped[int] = mapped_column(Integer, nullable=False)
+    tvdb_episode_number: Mapped[int] = mapped_column(Integer, nullable=False)
+    match_method: Mapped[str] = mapped_column(String(20), nullable=False, default="external_id")
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime,
+        server_default=func.now(),
+        nullable=False,
+    )

--- a/backend/models/ratings.py
+++ b/backend/models/ratings.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Optional
 
-from sqlalchemy import DateTime, Float, ForeignKey, Integer, Text, func
+from sqlalchemy import DateTime, Float, ForeignKey, Integer, String, Text, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from .base import Base
@@ -18,6 +18,7 @@ class Rating(Base):
     user_id       : Mapped[int]             = mapped_column(ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
     media_id      : Mapped[int]             = mapped_column(ForeignKey("media.id", ondelete="CASCADE"), nullable=False)
     season_number : Mapped[Optional[int]]   = mapped_column(Integer, nullable=True)
+    episode_order : Mapped[Optional[str]]   = mapped_column(String(20), nullable=True)
     rating        : Mapped[Optional[float]] = mapped_column(Float)
     review        : Mapped[Optional[str]]   = mapped_column(Text)
     rated_at      : Mapped[datetime]        = mapped_column(DateTime, server_default=func.now(), nullable=False)

--- a/backend/routers/history.py
+++ b/backend/routers/history.py
@@ -15,6 +15,7 @@ from models.collection import Collection, CollectionFile
 from models.base import MediaType, CollectionSource
 from models.users import UserSettings
 from models.connections import MediaServerConnection
+from models.episode_order import EpisodeOrderMapping
 from routers.media import enrich_with_state, get_user_tmdb_key, check_tmdb_key
 from core.translations import get_user_metadata_language, get_media_translations, apply_media_translations
 
@@ -627,6 +628,7 @@ async def unhide_next_up_show(
 class SeasonWatchRequest(BaseModel):
     series_tmdb_id: int
     season_number: int
+    episode_order: str | None = None
 
 
 class ShowWatchRequest(BaseModel):
@@ -874,46 +876,79 @@ async def mark_season_watched(
         db.add(show)
         await db.flush()
 
-    # 2. Fetch season episodes from TMDB to ensure we know about all of them
+    target_positions: set[tuple[int, int]] | None = None
+    canonical_seasons = [body.season_number]
+    if body.episode_order == "tvdb":
+        mapping_result = await db.execute(
+            select(EpisodeOrderMapping).where(
+                EpisodeOrderMapping.series_tmdb_id == body.series_tmdb_id,
+                EpisodeOrderMapping.tvdb_season_number == body.season_number,
+            )
+        )
+        mappings = list(mapping_result.scalars().all())
+        if not mappings:
+            raise HTTPException(status_code=400, detail="TVDB episode mapping is not available")
+        target_positions = {
+            (mapping.tmdb_season_number, mapping.tmdb_episode_number)
+            for mapping in mappings
+        }
+        canonical_seasons = sorted({season for season, _ in target_positions})
+
     try:
-        season_data = await tmdb.get_season(body.series_tmdb_id, body.season_number, api_key=api_key)
+        season_payloads = await asyncio.gather(
+            *(
+                tmdb.get_season(
+                    body.series_tmdb_id,
+                    canonical_season,
+                    api_key=api_key,
+                )
+                for canonical_season in canonical_seasons
+            )
+        )
     except Exception as e:
         raise HTTPException(status_code=404, detail=f"Season not found: {e}")
 
-    # 3. Ensure Media rows exist for all aired episodes in this season
     now = datetime.utcnow()
     today = now.date()
-    
-    # Get existing episodes for this season
     existing_q = await db.execute(
         select(Media).where(
             Media.show_id == show.id,
             Media.media_type == MediaType.episode,
-            Media.season_number == body.season_number
+            Media.season_number.in_(canonical_seasons),
         )
     )
-    existing_map = {m.episode_number: m for m in existing_q.scalars().all()}
-    
+    existing_map = {
+        (media.season_number, media.episode_number): media
+        for media in existing_q.scalars().all()
+    }
+
     all_season_episodes = []
-    for ep in season_data.get("episodes", []):
-        air_date_str = ep.get("air_date")
-        if not air_date_str: continue
-        try:
-            air_date = datetime.strptime(air_date_str, "%Y-%m-%d").date()
-            if air_date > today: continue # Skip unaired
-        except Exception: continue
-        
-        ep_num = ep["episode_number"]
-        if ep_num in existing_map:
-            all_season_episodes.append(existing_map[ep_num])
-        else:
+    for canonical_season, season_data in zip(canonical_seasons, season_payloads):
+        for ep in season_data.get("episodes", []):
+            position = (canonical_season, ep["episode_number"])
+            if target_positions is not None and position not in target_positions:
+                continue
+            air_date_str = ep.get("air_date")
+            if not air_date_str:
+                continue
+            try:
+                air_date = datetime.strptime(air_date_str, "%Y-%m-%d").date()
+                if air_date > today:
+                    continue
+            except Exception:
+                continue
+
+            existing = existing_map.get(position)
+            if existing:
+                all_season_episodes.append(existing)
+                continue
             new_ep = Media(
                 show_id=show.id,
                 tmdb_id=ep["id"],
                 media_type=MediaType.episode,
-                title=ep.get("name") or f"Episode {ep_num}",
-                season_number=body.season_number,
-                episode_number=ep_num,
+                title=ep.get("name") or f"Episode {ep['episode_number']}",
+                season_number=canonical_season,
+                episode_number=ep["episode_number"],
                 poster_path=tmdb.poster_url(ep.get("still_path"), size="w500"),
                 release_date=air_date_str,
                 tmdb_rating=ep.get("vote_average"),
@@ -965,6 +1000,7 @@ async def mark_season_watched(
 async def unwatch_season(
     series_tmdb_id: int = Query(...),
     season_number: int = Query(...),
+    episode_order: str | None = Query(None),
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
@@ -974,14 +1010,32 @@ async def unwatch_season(
     if not show:
         return {"status": "ok", "count": 0}
 
-    episodes_q = await db.execute(
-        select(Media.id).where(
-            Media.show_id == show.id,
-            Media.media_type == MediaType.episode,
-            Media.season_number == season_number,
+    media_filters = [
+        Media.show_id == show.id,
+        Media.media_type == MediaType.episode,
+    ]
+    if episode_order == "tvdb":
+        mapping_result = await db.execute(
+            select(EpisodeOrderMapping).where(
+                EpisodeOrderMapping.series_tmdb_id == series_tmdb_id,
+                EpisodeOrderMapping.tvdb_season_number == season_number,
+            )
         )
-    )
-    episode_ids = [r[0] for r in episodes_q.all()]
+        positions = [
+            and_(
+                Media.season_number == mapping.tmdb_season_number,
+                Media.episode_number == mapping.tmdb_episode_number,
+            )
+            for mapping in mapping_result.scalars().all()
+        ]
+        if not positions:
+            return {"status": "ok", "count": 0}
+        media_filters.append(or_(*positions))
+    else:
+        media_filters.append(Media.season_number == season_number)
+
+    episodes_q = await db.execute(select(Media.id).where(*media_filters))
+    episode_ids = [row[0] for row in episodes_q.all()]
     if not episode_ids:
         return {"status": "ok", "count": 0}
 

--- a/backend/routers/mdblist.py
+++ b/backend/routers/mdblist.py
@@ -436,7 +436,12 @@ async def _import_ratings(
     external_cache: dict[tuple[str, str], int | None],
     stats: dict[str, int],
 ) -> RatingChanges:
-    ratings_result = await db.execute(select(Rating).where(Rating.user_id == user_id))
+    ratings_result = await db.execute(
+        select(Rating).where(
+            Rating.user_id == user_id,
+            Rating.episode_order.is_(None),
+        )
+    )
     existing = {
         (rating.media_id, rating.season_number): rating
         for rating in ratings_result.scalars().all()
@@ -741,6 +746,7 @@ async def run_mdblist_push(user_id: int, job_id: int) -> None:
                     select(Rating.media_id, Rating.season_number, Rating.rating, Rating.rated_at).where(
                         Rating.user_id == user_id,
                         Rating.rating.isnot(None),
+                        Rating.episode_order.is_(None),
                     )
                 )
                 rating_rows = [

--- a/backend/routers/media.py
+++ b/backend/routers/media.py
@@ -24,6 +24,7 @@ from models.ratings import Rating
 from models.base import MediaType, CollectionSource
 from models.lists import List as UserList, ListItem
 from models.media_request import MediaRequest, RequestStatus
+from models.episode_order import EpisodeOrderMapping
 from models.profile import UserProfileData
 from core import tmdb
 from core.translations import (
@@ -1691,6 +1692,7 @@ class CollectRequest(PydanticModel):
 class CollectSeasonRequest(PydanticModel):
     series_tmdb_id: int
     season_number: int
+    episode_order: Optional[str] = None
 
 
 def _enrich_movie_list(results: list[dict], library_ids: set[int]) -> list[dict]:
@@ -2576,7 +2578,42 @@ async def collect_season(
         db.add(show)
         await db.flush()
 
-    episodes = await _resolve_season_episodes(db, show, body.series_tmdb_id, body.season_number, tmdb_key)
+    if body.episode_order == "tvdb":
+        mapping_result = await db.execute(
+            select(EpisodeOrderMapping).where(
+                EpisodeOrderMapping.series_tmdb_id == body.series_tmdb_id,
+                EpisodeOrderMapping.tvdb_season_number == body.season_number,
+            )
+        )
+        mappings = list(mapping_result.scalars().all())
+        if not mappings:
+            raise HTTPException(status_code=400, detail="TVDB episode mapping is not available")
+        target_positions = {
+            (mapping.tmdb_season_number, mapping.tmdb_episode_number)
+            for mapping in mappings
+        }
+        episodes = []
+        for canonical_season in sorted({season for season, _ in target_positions}):
+            resolved = await _resolve_season_episodes(
+                db,
+                show,
+                body.series_tmdb_id,
+                canonical_season,
+                tmdb_key,
+            )
+            episodes.extend(
+                episode
+                for episode in resolved
+                if (episode.season_number, episode.episode_number) in target_positions
+            )
+    else:
+        episodes = await _resolve_season_episodes(
+            db,
+            show,
+            body.series_tmdb_id,
+            body.season_number,
+            tmdb_key,
+        )
     if not episodes:
         return {"status": "ok", "count": 0}
 
@@ -2675,6 +2712,7 @@ async def uncollect_show(
 async def uncollect_season(
     series_tmdb_id: int = Query(...),
     season_number: int = Query(...),
+    episode_order: Optional[str] = Query(None),
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
@@ -2686,13 +2724,30 @@ async def uncollect_season(
     if not show:
         return {"status": "ok"}
 
-    episodes_q = await db.execute(
-        select(Media.id).where(
-            Media.show_id == show.id,
-            Media.media_type == MediaType.episode,
-            Media.season_number == season_number,
+    media_filters = [
+        Media.show_id == show.id,
+        Media.media_type == MediaType.episode,
+    ]
+    if episode_order == "tvdb":
+        mapping_result = await db.execute(
+            select(EpisodeOrderMapping).where(
+                EpisodeOrderMapping.series_tmdb_id == series_tmdb_id,
+                EpisodeOrderMapping.tvdb_season_number == season_number,
+            )
         )
-    )
+        positions = [
+            and_(
+                Media.season_number == mapping.tmdb_season_number,
+                Media.episode_number == mapping.tmdb_episode_number,
+            )
+            for mapping in mapping_result.scalars().all()
+        ]
+        if not positions:
+            return {"status": "ok"}
+        media_filters.append(or_(*positions))
+    else:
+        media_filters.append(Media.season_number == season_number)
+    episodes_q = await db.execute(select(Media.id).where(*media_filters))
     episode_ids = [r[0] for r in episodes_q.all()]
     if not episode_ids:
         return {"status": "ok"}

--- a/backend/routers/ratings.py
+++ b/backend/routers/ratings.py
@@ -24,6 +24,7 @@ class RatingIn(BaseModel):
     rating: float = Field(..., ge=0.0, le=10.0)
     review: Optional[str] = None
     season_number: Optional[int] = None
+    episode_order: Optional[str] = None
 
 
 def format_rating(rating: Rating, media: Media) -> dict:
@@ -38,6 +39,7 @@ def format_rating(rating: Rating, media: Media) -> dict:
             "release_date": media.release_date,
         },
         "season_number": rating.season_number,
+        "episode_order": rating.episode_order,
         "user_id": rating.user_id,
         "rating": rating.rating,
         "review": rating.review,
@@ -94,12 +96,20 @@ async def submit_rating(
             raise HTTPException(status_code=404, detail=f"TMDB Media not found: {e}")
 
     effective_season = None if media_type == MediaType.episode else body.season_number
+    effective_episode_order = (
+        body.episode_order
+        if media_type == MediaType.series and effective_season is not None
+        else None
+    )
+    if effective_episode_order not in (None, "tvdb"):
+        raise HTTPException(status_code=400, detail="Invalid episode order")
 
     result2 = await db.execute(
         select(Rating).where(
             Rating.media_id == media.id,
             Rating.user_id == current_user.id,
             Rating.season_number == effective_season,
+            Rating.episode_order == effective_episode_order,
         )
     )
     rating = result2.scalar_one_or_none()
@@ -115,11 +125,14 @@ async def submit_rating(
             rating=body.rating,
             review=body.review,
             season_number=effective_season,
+            episode_order=effective_episode_order,
         )
         db.add(rating)
 
     await db.commit()
     await db.refresh(rating)
+    if effective_episode_order == "tvdb":
+        return format_rating(rating, media)
 
     settings_result = await db.execute(
         select(UserSettings).where(UserSettings.user_id == current_user.id)
@@ -175,6 +188,7 @@ async def delete_rating(
     tmdb_id: int,
     media_type: str,
     season_number: Optional[int] = Query(None),
+    episode_order: Optional[str] = Query(None),
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
@@ -191,12 +205,18 @@ async def delete_rating(
         raise HTTPException(status_code=404, detail="Media not found")
 
     effective_season = None if mt == MediaType.episode else season_number
+    effective_episode_order = (
+        episode_order
+        if mt == MediaType.series and effective_season is not None
+        else None
+    )
 
     result = await db.execute(
         select(Rating).where(
             Rating.media_id == media.id,
             Rating.user_id == current_user.id,
             Rating.season_number == effective_season,
+            Rating.episode_order == effective_episode_order,
         )
     )
     rating = result.scalar_one_or_none()
@@ -204,6 +224,8 @@ async def delete_rating(
         raise HTTPException(status_code=404, detail="Rating not found")
     await db.delete(rating)
     await db.commit()
+    if effective_episode_order == "tvdb":
+        return {"status": "deleted"}
 
     settings_result = await db.execute(
         select(UserSettings).where(UserSettings.user_id == current_user.id)

--- a/backend/routers/shows.py
+++ b/backend/routers/shows.py
@@ -1,5 +1,6 @@
 import asyncio
 from datetime import datetime, date
+from pydantic import BaseModel
 from fastapi import APIRouter, Depends, Query, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select, func, case, cast as sa_cast, Text, or_, and_
@@ -16,11 +17,13 @@ from models.collection import Collection, CollectionFile
 from models.base import MediaType
 from models.show import Show as ShowModel
 from models.users import User, UserSettings
+from models.episode_order import EpisodeOrderMapping, UserShowEpisodeOrder
 from routers.media import format_media, get_user_tmdb_key, check_tmdb_key, enrich_with_state, refresh_technical_data, _extract_show_content_rating, get_where_to_watch, _effective_sonarr, _get_global_settings
 
 from dependencies import get_current_user
 from core import tmdb
 from core import tvdb as tvdb_client
+from core.episode_order import ensure_episode_order_mapping, get_episode_order, validate_episode_order
 from core.translations import (
     get_user_metadata_language,
     get_media_translations,
@@ -43,6 +46,111 @@ async def get_user_tvdb_key(db: AsyncSession, user_id: int) -> str | None:
     gs_result = await db.execute(select(GlobalSettings).where(GlobalSettings.id == 1))
     gs = gs_result.scalar_one_or_none()
     return gs.tvdb_api_key if gs else None
+
+
+async def _enrich_tvdb_seasons(
+    seasons: list[dict],
+    mappings: list[EpisodeOrderMapping],
+    *,
+    tvdb_api_key: str,
+    tvdb_language: str | None,
+    series_tmdb_id: int | None,
+    tmdb_api_key: str | None,
+    metadata_language: str | None,
+) -> tuple[list[dict], dict]:
+    """Add translated TVDB metadata and TMDB ratings to TVDB seasons."""
+    semaphore = asyncio.Semaphore(5)
+    tvdb_metadata: dict[int, dict] = {}
+    tmdb_show: dict = {}
+
+    async def fetch_tvdb_season(season: dict) -> None:
+        season_id = season.get("id")
+        season_number = season.get("season_number")
+        if season_id is None or season_number is None:
+            return
+        try:
+            async with semaphore:
+                raw = await tvdb_client.get_season(season_id, tvdb_api_key)
+            tvdb_metadata[season_number] = tvdb_client.format_season(
+                raw,
+                language=tvdb_language,
+            )
+        except Exception:
+            pass
+
+    async def fetch_tmdb_show() -> None:
+        nonlocal tmdb_show
+        if series_tmdb_id is None or not tmdb_api_key:
+            return
+        try:
+            tmdb_show = await tmdb.get_show(
+                series_tmdb_id,
+                tmdb_api_key,
+                language=metadata_language,
+            )
+        except Exception:
+            pass
+
+    await asyncio.gather(
+        *(fetch_tvdb_season(season) for season in seasons),
+        fetch_tmdb_show(),
+    )
+
+    tmdb_seasons = {
+        season.get("season_number"): season
+        for season in (tmdb_show.get("seasons") or [])
+        if season.get("season_number") is not None
+    }
+    mapping_counts: dict[int, dict[int, int]] = {}
+    for mapping in mappings:
+        if (
+            mapping.tvdb_season_number is None
+            or mapping.tmdb_season_number is None
+        ):
+            continue
+        counts = mapping_counts.setdefault(mapping.tvdb_season_number, {})
+        counts[mapping.tmdb_season_number] = (
+            counts.get(mapping.tmdb_season_number, 0) + 1
+        )
+
+    enriched = []
+    for season in seasons:
+        season_number = season.get("season_number")
+        tvdb_season = tvdb_metadata.get(season_number, {})
+        candidates = mapping_counts.get(season_number, {})
+        tmdb_season_number = (
+            max(
+                candidates,
+                key=lambda candidate: (
+                    candidates[candidate],
+                    candidate == season_number,
+                    -abs(candidate - season_number),
+                ),
+            )
+            if candidates
+            else season_number
+        )
+        tmdb_season = tmdb_seasons.get(tmdb_season_number, {})
+        enriched.append({
+            **season,
+            "name": tvdb_season.get("name") or season.get("name"),
+            "overview": (
+                tvdb_season.get("overview")
+                or tmdb_season.get("overview")
+                or season.get("overview")
+            ),
+            "poster_path": (
+                tvdb_season.get("poster_path")
+                or season.get("poster_path")
+            ),
+            "air_date": (
+                tvdb_season.get("air_date")
+                or season.get("air_date")
+                or tmdb_season.get("air_date")
+            ),
+            "tmdb_rating": tmdb_season.get("vote_average"),
+        })
+    return enriched, tmdb_show
 
 
 def format_show(show: ShowModel) -> dict:
@@ -169,6 +277,83 @@ async def list_shows(
     }
 
 
+class EpisodeOrderRequest(BaseModel):
+    episode_order: str
+    force_refresh: bool = False
+
+
+@router.post("/{series_tmdb_id}/episode-order")
+async def set_show_episode_order(
+    series_tmdb_id: int,
+    body: EpisodeOrderRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    try:
+        selected_order = validate_episode_order(body.episode_order)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+    preference = await get_episode_order(db, current_user.id, series_tmdb_id)
+    mapping_summary = None
+    tvdb_id = preference.tvdb_id if preference else None
+
+    if selected_order == "tvdb":
+        tmdb_api_key, tvdb_api_key = await asyncio.gather(
+            get_user_tmdb_key(db, current_user.id),
+            get_user_tvdb_key(db, current_user.id),
+        )
+        if not check_tmdb_key(tmdb_api_key):
+            raise HTTPException(status_code=400, detail="TMDB API key not configured")
+        if not tvdb_api_key:
+            raise HTTPException(status_code=400, detail="TVDB API key not configured")
+        try:
+            mapping_summary = await ensure_episode_order_mapping(
+                db,
+                series_tmdb_id,
+                tmdb_api_key,
+                tvdb_api_key,
+                force=body.force_refresh,
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc))
+        except Exception as exc:
+            raise HTTPException(status_code=502, detail=f"Episode mapping failed: {exc}")
+        tvdb_id = mapping_summary["tvdb_id"]
+
+    if preference:
+        preference.episode_order = selected_order
+        preference.tvdb_id = tvdb_id
+    else:
+        preference = UserShowEpisodeOrder(
+            user_id=current_user.id,
+            series_tmdb_id=series_tmdb_id,
+            episode_order=selected_order,
+            tvdb_id=tvdb_id,
+        )
+        db.add(preference)
+
+    if tvdb_id:
+        show_result = await db.execute(
+            select(ShowModel).where(ShowModel.tmdb_id == series_tmdb_id)
+        )
+        local_show = show_result.scalar_one_or_none()
+        if local_show:
+            local_show.tvdb_id = tvdb_id
+
+    await db.commit()
+    return {
+        "episode_order": selected_order,
+        "series_tmdb_id": series_tmdb_id,
+        "tvdb_id": tvdb_id,
+        "mapping": mapping_summary,
+        "redirect": (
+            f"/show/tvdb/{tvdb_id}" if selected_order == "tvdb"
+            else f"/show/{series_tmdb_id}"
+        ),
+    }
+
+
 @router.get("/{series_tmdb_id}")
 async def get_show(
     series_tmdb_id: int,
@@ -180,6 +365,8 @@ async def get_show(
         select(ShowModel).where(ShowModel.tmdb_id == series_tmdb_id)
     )
     show = show_result.scalar_one_or_none()
+    order_preference = await get_episode_order(db, current_user.id, series_tmdb_id)
+    selected_episode_order = order_preference.episode_order if order_preference else "tmdb"
 
     if show:
         # Fetch local episodes
@@ -328,6 +515,7 @@ async def get_show(
                     Rating.media_id == show_media.id,
                     Rating.user_id == current_user.id,
                     Rating.season_number.isnot(None),
+                    Rating.episode_order.is_(None),
                 )
                 .group_by(Rating.season_number)
             )
@@ -406,6 +594,12 @@ async def get_show(
 
         return {
             **show_dict,
+            "episode_order": selected_episode_order,
+            "tvdb_id": (
+                (order_preference.tvdb_id if order_preference else None)
+                or show.tvdb_id
+                or (tmdb_extra or show.tmdb_data or {}).get("external_ids", {}).get("tvdb_id")
+            ),
             "seasons_meta": enhanced_seasons_meta,
             "original_language": (show.tmdb_data or {}).get("original_language") or (tmdb_extra or {}).get("original_language"),
             "age_rating": _extract_show_content_rating(tmdb_extra) if tmdb_extra else None,
@@ -473,6 +667,11 @@ async def get_show(
         return {
             "id": None,
             "tmdb_id": series_tmdb_id,
+            "episode_order": selected_episode_order,
+            "tvdb_id": (
+                (order_preference.tvdb_id if order_preference else None)
+                or data.get("external_ids", {}).get("tvdb_id")
+            ),
             "title": data.get("name"),
             "original_title": data.get("original_name"),
             "overview": data.get("overview"),
@@ -852,6 +1051,7 @@ async def get_show_season(
                         Rating.media_id == show_media.id,
                         Rating.user_id == current_user.id,
                         Rating.season_number == season_number,
+                        Rating.episode_order.is_(None),
                     )
                 )
                 season_user_rating = rating_q.scalar_one_or_none()
@@ -1202,56 +1402,128 @@ async def get_tvdb_show(
     show_data = tvdb_client.format_series(raw, language=tvdb_lang)
     cast = tvdb_client.format_cast(raw)
 
-    # Look up local Show row by tvdb_id
-    show_result = await db.execute(select(ShowModel).where(ShowModel.tvdb_id == tvdb_id))
+    series_tmdb_id = show_data.get("tmdb_id_cross")
+    series_tmdb_id = int(series_tmdb_id) if series_tmdb_id else None
+    show_result = await db.execute(
+        select(ShowModel).where(
+            or_(
+                ShowModel.tvdb_id == tvdb_id,
+                ShowModel.tmdb_id == series_tmdb_id,
+            )
+        )
+    )
     show = show_result.scalar_one_or_none()
 
-    # Collect per-season library state if we have a local show
-    season_states: dict = {}
+    mapping_result = await db.execute(
+        select(EpisodeOrderMapping).where(
+            EpisodeOrderMapping.series_tmdb_id == series_tmdb_id
+        )
+    ) if series_tmdb_id else None
+    mappings = list(mapping_result.scalars().all()) if mapping_result else []
+    tmdb_api_key = await get_user_tmdb_key(db, current_user.id)
+    show_data["seasons"], tmdb_show = await _enrich_tvdb_seasons(
+        show_data["seasons"],
+        mappings,
+        tvdb_api_key=api_key,
+        tvdb_language=tvdb_lang,
+        series_tmdb_id=series_tmdb_id,
+        tmdb_api_key=tmdb_api_key,
+        metadata_language=metadata_lang,
+    )
+    mapping_by_tmdb = {
+        (mapping.tmdb_season_number, mapping.tmdb_episode_number): mapping
+        for mapping in mappings
+    }
+
+    collected_positions: dict[int, set[int]] = {}
+    watched_positions: dict[int, set[int]] = {}
+    season_ratings: dict[int, float] = {}
     if show:
-        coll_per_season_q = await db.execute(
-            select(Media.season_number, func.count(func.distinct(Media.episode_number)))
-            .join(Collection, Collection.media_id == Media.id)
-            .where(
+        local_eps_result = await db.execute(
+            select(Media).where(
                 Media.show_id == show.id,
-                Collection.user_id == current_user.id,
                 Media.media_type == MediaType.episode,
-                Media.season_number.isnot(None),
-                Media.episode_number.isnot(None),
             )
-            .group_by(Media.season_number)
         )
-        coll_per_season: dict = dict(coll_per_season_q.all())
-
-        watched_per_season_q = await db.execute(
-            select(Media.season_number, func.count(func.distinct(Media.episode_number)))
-            .join(WatchEvent, WatchEvent.media_id == Media.id)
-            .where(
-                Media.show_id == show.id,
-                WatchEvent.user_id == current_user.id,
-                Media.media_type == MediaType.episode,
-                Media.season_number.isnot(None),
-                Media.episode_number.isnot(None),
+        local_eps = list(local_eps_result.scalars().all())
+        local_media_ids = [episode.id for episode in local_eps]
+        collected_ids: set[int] = set()
+        watched_ids: set[int] = set()
+        if local_media_ids:
+            collected_result = await db.execute(
+                select(Collection.media_id).where(
+                    Collection.user_id == current_user.id,
+                    Collection.media_id.in_(local_media_ids),
+                )
             )
-            .group_by(Media.season_number)
-        )
-        watched_per_season: dict = dict(watched_per_season_q.all())
+            watched_result = await db.execute(
+                select(WatchEvent.media_id).where(
+                    WatchEvent.user_id == current_user.id,
+                    WatchEvent.media_id.in_(local_media_ids),
+                )
+            )
+            collected_ids = {row[0] for row in collected_result.all()}
+            watched_ids = {row[0] for row in watched_result.all()}
 
-        season_ep_counts = {s["season_number"]: s.get("episode_count", 0) for s in show_data["seasons"]}
+        for episode in local_eps:
+            mapping = mapping_by_tmdb.get(
+                (episode.season_number, episode.episode_number)
+            )
+            if mapping:
+                target_season = mapping.tvdb_season_number
+                target_episode = mapping.tvdb_episode_number
+            elif not mappings:
+                target_season = episode.season_number
+                target_episode = episode.episode_number
+            else:
+                continue
+            if target_season is None or target_episode is None:
+                continue
+            if episode.id in collected_ids:
+                collected_positions.setdefault(target_season, set()).add(target_episode)
+            if episode.id in watched_ids:
+                watched_positions.setdefault(target_season, set()).add(target_episode)
 
-        for sn in set(list(coll_per_season.keys()) + list(season_ep_counts.keys())):
-            collected = coll_per_season.get(sn, 0)
-            watched = watched_per_season.get(sn, 0)
-            total = season_ep_counts.get(sn, 0)
-            # When TVDB reports 0 episodes (common for web series), use collected count as denominator
-            effective_total = total if total > 0 else collected
-            season_states[sn] = {
-                "in_library": collected > 0,
-                "collection_pct": min(100, int((collected / effective_total) * 100)) if effective_total > 0 else 0,
-                "watched": watched >= effective_total if effective_total > 0 else False,
-                "watch_pct": min(100, int((watched / effective_total) * 100)) if effective_total > 0 else 0,
-                "user_rating": None,
-            }
+        if series_tmdb_id:
+            show_media_result = await db.execute(
+                select(Media).where(
+                    Media.tmdb_id == series_tmdb_id,
+                    Media.media_type == MediaType.series,
+                )
+            )
+            show_media = show_media_result.scalar_one_or_none()
+            if show_media:
+                rating_result = await db.execute(
+                    select(Rating.season_number, Rating.rating).where(
+                        Rating.user_id == current_user.id,
+                        Rating.media_id == show_media.id,
+                        Rating.episode_order == "tvdb",
+                        Rating.season_number.isnot(None),
+                    )
+                )
+                season_ratings = dict(rating_result.all())
+
+    season_states: dict = {}
+    season_ep_counts = {
+        season["season_number"]: season.get("episode_count", 0)
+        for season in show_data["seasons"]
+    }
+    for season_number_value in set(
+        list(season_ep_counts)
+        + list(collected_positions)
+        + list(watched_positions)
+    ):
+        collected = len(collected_positions.get(season_number_value, set()))
+        watched = len(watched_positions.get(season_number_value, set()))
+        total = season_ep_counts.get(season_number_value, 0)
+        effective_total = total if total > 0 else collected
+        season_states[season_number_value] = {
+            "in_library": collected > 0,
+            "collection_pct": min(100, int((collected / effective_total) * 100)) if effective_total > 0 else 0,
+            "watched": watched >= effective_total if effective_total > 0 else False,
+            "watch_pct": min(100, int((watched / effective_total) * 100)) if effective_total > 0 else 0,
+            "user_rating": season_ratings.get(season_number_value),
+        }
 
     in_library = bool(season_states and any(v["in_library"] for v in season_states.values()))
 
@@ -1288,8 +1560,17 @@ async def get_tvdb_show(
         except Exception:
             pass
 
-    # Where to watch (local media servers only; no TMDB streaming for TVDB-only shows)
-    where_to_watch = await get_where_to_watch(db, current_user.id, tvdb_id, MediaType.series, show=show) if show else []
+    where_to_watch = (
+        await get_where_to_watch(
+            db,
+            current_user.id,
+            series_tmdb_id,
+            MediaType.series,
+            show=show,
+        )
+        if show and series_tmdb_id
+        else []
+    )
 
     # Networks (name only; TVDB doesn't provide logos)
     networks = [{"id": None, "name": n.get("name"), "logo_path": None, "origin_country": None}
@@ -1298,12 +1579,13 @@ async def get_tvdb_show(
     return {
         **show_data,
         "id": show.id if show else None,
-        "tmdb_id": None,
+        "tmdb_id": series_tmdb_id,
         "type": "series",
         "tagline": None,
-        "tmdb_rating": None,
+        "tmdb_rating": tmdb_show.get("vote_average"),
         "imdb_id": show_data.get("imdb_id"),
         "tmdb_id_cross": show_data.get("tmdb_id_cross"),
+        "episode_order": "tvdb",
         "adult": False,
         "in_library": in_library,
         "watched": watched_overall,
@@ -1348,91 +1630,173 @@ async def get_tvdb_season(
     show_data = tvdb_client.format_series(raw_series, language=tvdb_lang)
     eps = [tvdb_client.format_episode(e) for e in raw_episodes]
 
-    # Look up local Show row and episode states
-    show_result = await db.execute(select(ShowModel).where(ShowModel.tvdb_id == tvdb_id))
-    show = show_result.scalar_one_or_none()
-
-    watched_ep_ids: set = set()
-    episode_ratings: dict = {}
-    user_collected_eps: set = set()
-
-    if show:
-        ep_result = await db.execute(
-            select(Media)
-            .where(
-                Media.show_id == show.id,
-                Media.media_type == MediaType.episode,
-                Media.season_number == season_number,
+    series_tmdb_id = show_data.get("tmdb_id_cross")
+    series_tmdb_id = int(series_tmdb_id) if series_tmdb_id else None
+    show_result = await db.execute(
+        select(ShowModel).where(
+            or_(
+                ShowModel.tvdb_id == tvdb_id,
+                ShowModel.tmdb_id == series_tmdb_id,
             )
         )
-        local_eps = ep_result.scalars().all()
-        local_media_ids = [m.id for m in local_eps]
+    )
+    show = show_result.scalar_one_or_none()
 
-        if local_media_ids:
-            watched_q = await db.execute(
-                select(WatchEvent.media_id)
-                .where(WatchEvent.user_id == current_user.id, WatchEvent.media_id.in_(local_media_ids))
-                .distinct()
+    mapping_result = await db.execute(
+        select(EpisodeOrderMapping).where(
+            EpisodeOrderMapping.series_tmdb_id == series_tmdb_id,
+            EpisodeOrderMapping.tvdb_season_number == season_number,
+        )
+    ) if series_tmdb_id else None
+    mappings = list(mapping_result.scalars().all()) if mapping_result else []
+    base_season_meta = next(
+        (
+            season
+            for season in show_data["seasons"]
+            if season["season_number"] == season_number
+        ),
+        {},
+    )
+    tmdb_api_key = await get_user_tmdb_key(db, current_user.id)
+    enriched_seasons, _ = await _enrich_tvdb_seasons(
+        [base_season_meta] if base_season_meta else [],
+        mappings,
+        tvdb_api_key=api_key,
+        tvdb_language=tvdb_lang,
+        series_tmdb_id=series_tmdb_id,
+        tmdb_api_key=tmdb_api_key,
+        metadata_language=metadata_lang,
+    )
+    season_meta = enriched_seasons[0] if enriched_seasons else base_season_meta
+    show_data["seasons"] = [
+        season_meta if season["season_number"] == season_number else season
+        for season in show_data["seasons"]
+    ]
+    mapping_by_tvdb_id = {mapping.tvdb_id: mapping for mapping in mappings}
+    mapping_by_position = {
+        (mapping.tvdb_season_number, mapping.tvdb_episode_number): mapping
+        for mapping in mappings
+    }
+
+    local_ep_map: dict[tuple[int, int], Media] = {}
+    if show:
+        ep_result = await db.execute(
+            select(Media).where(
+                Media.show_id == show.id,
+                Media.media_type == MediaType.episode,
             )
-            watched_ep_ids = {r[0] for r in watched_q.all()}
+        )
+        local_eps = list(ep_result.scalars().all())
+        local_ep_map = {
+            (episode.season_number, episode.episode_number): episode
+            for episode in local_eps
+            if episode.season_number is not None and episode.episode_number is not None
+        }
 
-            ep_ratings_q = await db.execute(
-                select(Rating.media_id, Rating.rating)
-                .where(
+    mapped_rows: list[tuple[dict, EpisodeOrderMapping | None, Media | None]] = []
+    for episode in eps:
+        mapping = mapping_by_tvdb_id.get(episode.get("tvdb_id"))
+        if not mapping:
+            mapping = mapping_by_position.get(
+                (season_number, episode.get("episode_number"))
+            )
+        if mapping:
+            local_episode = local_ep_map.get(
+                (mapping.tmdb_season_number, mapping.tmdb_episode_number)
+            )
+        elif not mappings:
+            local_episode = local_ep_map.get(
+                (season_number, episode.get("episode_number"))
+            )
+        else:
+            local_episode = None
+        mapped_rows.append((episode, mapping, local_episode))
+
+    local_media_ids = list({
+        local_episode.id
+        for _, _, local_episode in mapped_rows
+        if local_episode
+    })
+    watched_ep_ids: set[int] = set()
+    collected_ep_ids: set[int] = set()
+    episode_ratings: dict[int, float] = {}
+    if local_media_ids:
+        watched_q = await db.execute(
+            select(WatchEvent.media_id)
+            .where(
+                WatchEvent.user_id == current_user.id,
+                WatchEvent.media_id.in_(local_media_ids),
+            )
+            .distinct()
+        )
+        watched_ep_ids = {row[0] for row in watched_q.all()}
+        collected_q = await db.execute(
+            select(Collection.media_id)
+            .where(
+                Collection.user_id == current_user.id,
+                Collection.media_id.in_(local_media_ids),
+            )
+            .distinct()
+        )
+        collected_ep_ids = {row[0] for row in collected_q.all()}
+        episode_ratings_q = await db.execute(
+            select(Rating.media_id, Rating.rating).where(
+                Rating.user_id == current_user.id,
+                Rating.media_id.in_(local_media_ids),
+                Rating.season_number.is_(None),
+            )
+        )
+        episode_ratings = dict(episode_ratings_q.all())
+
+    season_user_rating = None
+    if series_tmdb_id:
+        show_media_result = await db.execute(
+            select(Media).where(
+                Media.tmdb_id == series_tmdb_id,
+                Media.media_type == MediaType.series,
+            )
+        )
+        show_media = show_media_result.scalar_one_or_none()
+        if show_media:
+            season_rating_result = await db.execute(
+                select(Rating.rating).where(
                     Rating.user_id == current_user.id,
-                    Rating.media_id.in_(local_media_ids),
-                    Rating.season_number.is_(None),
+                    Rating.media_id == show_media.id,
+                    Rating.season_number == season_number,
+                    Rating.episode_order == "tvdb",
                 )
             )
-            episode_ratings = {r[0]: r[1] for r in ep_ratings_q.all()}
-
-            coll_q = await db.execute(
-                select(Media.episode_number)
-                .join(Collection, Collection.media_id == Media.id)
-                .where(
-                    Media.show_id == show.id,
-                    Media.season_number == season_number,
-                    Collection.user_id == current_user.id,
-                    Media.media_type == MediaType.episode,
-                    Media.episode_number.isnot(None),
-                )
-                .distinct()
-            )
-            user_collected_eps = {r[0] for r in coll_q.all()}
-
-        # Build episode_number → local Media map
-        local_ep_map = {m.episode_number: m for m in local_eps}
-    else:
-        local_ep_map = {}
+            season_user_rating = season_rating_result.scalar_one_or_none()
 
     enriched_eps = []
-    for ep in eps:
-        ep_num = ep.get("episode_number")
-        local_m = local_ep_map.get(ep_num)
+    for episode, mapping, local_episode in mapped_rows:
         enriched_eps.append({
-            **ep,
-            "id": local_m.id if local_m else None,
-            "in_library": ep_num in user_collected_eps,
-            "watched": local_m.id in watched_ep_ids if local_m else False,
-            "user_rating": episode_ratings.get(local_m.id) if local_m else None,
+            **episode,
+            "id": local_episode.id if local_episode else None,
+            "tmdb_id": mapping.tmdb_episode_id if mapping else (
+                local_episode.tmdb_id if local_episode else None
+            ),
+            "show_tmdb_id": series_tmdb_id,
+            "tmdb_season_number": mapping.tmdb_season_number if mapping else season_number,
+            "tmdb_episode_number": mapping.tmdb_episode_number if mapping else episode.get("episode_number"),
+            "in_library": local_episode.id in collected_ep_ids if local_episode else False,
+            "watched": local_episode.id in watched_ep_ids if local_episode else False,
+            "user_rating": episode_ratings.get(local_episode.id) if local_episode else None,
             "in_lists": [],
         })
 
-    season_meta = next((s for s in show_data["seasons"] if s["season_number"] == season_number), {})
-
-    # Compute season-level stats
-    season_in_library = bool(user_collected_eps)
     total_eps = len(eps)
-    effective_total = total_eps if total_eps > 0 else len(user_collected_eps)
-    season_collection_pct = min(100, int((len(user_collected_eps) / effective_total) * 100)) if effective_total > 0 else 0
-    season_watched = bool(local_eps) and len(watched_ep_ids) >= len(local_eps) if show else False
-    season_watch_pct = min(100, int((len(watched_ep_ids) / effective_total) * 100)) if effective_total > 0 else 0
+    season_in_library = bool(collected_ep_ids)
+    season_collection_pct = min(100, int((len(collected_ep_ids) / total_eps) * 100)) if total_eps else 0
+    season_watched = total_eps > 0 and len(watched_ep_ids) >= total_eps
+    season_watch_pct = min(100, int((len(watched_ep_ids) / total_eps) * 100)) if total_eps else 0
 
     return {
         "tvdb_id": tvdb_id,
         "season_number": season_number,
         "name": season_meta.get("name") or f"Season {season_number}",
         "overview": season_meta.get("overview"),
+        "tmdb_rating": season_meta.get("tmdb_rating"),
         "poster_path": season_meta.get("poster_path"),
         "backdrop_path": show_data["backdrop_path"],
         "air_date": season_meta.get("air_date"),
@@ -1441,11 +1805,13 @@ async def get_tvdb_season(
         "season_watched": season_watched,
         "season_watch_pct": season_watch_pct,
         "season_collection_pct": season_collection_pct,
-        "season_user_rating": None,
+        "season_user_rating": season_user_rating,
         "show_in_library": show is not None,
         "show": {
             "id": show.id if show else None,
             "tvdb_id": tvdb_id,
+            "tmdb_id": series_tmdb_id,
+            "episode_order": "tvdb",
             "title": show_data["title"],
             "poster_path": show_data["poster_path"],
             "backdrop_path": show_data["backdrop_path"],
@@ -1483,13 +1849,38 @@ async def get_tvdb_episode(
     if not ep_data:
         raise HTTPException(status_code=404, detail="Episode not found")
 
-    show_result = await db.execute(select(ShowModel).where(ShowModel.tvdb_id == tvdb_id))
+    series_tmdb_id = show_data.get("tmdb_id_cross")
+    series_tmdb_id = int(series_tmdb_id) if series_tmdb_id else None
+    show_result = await db.execute(
+        select(ShowModel).where(
+            or_(
+                ShowModel.tvdb_id == tvdb_id,
+                ShowModel.tmdb_id == series_tmdb_id,
+            )
+        )
+    )
     show = show_result.scalar_one_or_none()
+    mapping_result = await db.execute(
+        select(EpisodeOrderMapping).where(
+            EpisodeOrderMapping.series_tmdb_id == series_tmdb_id,
+            or_(
+                EpisodeOrderMapping.tvdb_id == ep_data.get("tvdb_id"),
+                and_(
+                    EpisodeOrderMapping.tvdb_season_number == season_number,
+                    EpisodeOrderMapping.tvdb_episode_number == episode_number,
+                ),
+            ),
+        )
+    ) if series_tmdb_id else None
+    mapping = mapping_result.scalars().first() if mapping_result else None
+    canonical_season = mapping.tmdb_season_number if mapping else season_number
+    canonical_episode = mapping.tmdb_episode_number if mapping else episode_number
 
     in_library = False
     watched = False
     user_rating = None
     local_ep_id = None
+    local_ep = None
     library_info = None
     play_count = 0
 
@@ -1498,8 +1889,8 @@ async def get_tvdb_episode(
             select(Media).where(
                 Media.show_id == show.id,
                 Media.media_type == MediaType.episode,
-                Media.season_number == season_number,
-                Media.episode_number == episode_number,
+                Media.season_number == canonical_season,
+                Media.episode_number == canonical_episode,
             )
         )
         local_ep = local_ep_q.scalars().first()
@@ -1556,6 +1947,12 @@ async def get_tvdb_episode(
     return {
         **ep_data,
         "id": local_ep_id,
+        "tmdb_id": mapping.tmdb_episode_id if mapping else (
+            local_ep.tmdb_id if local_ep else None
+        ),
+        "show_tmdb_id": series_tmdb_id,
+        "tmdb_season_number": canonical_season,
+        "tmdb_episode_number": canonical_episode,
         "in_library": in_library,
         "watched": watched,
         "user_rating": user_rating,
@@ -1567,6 +1964,8 @@ async def get_tvdb_episode(
         "show": {
             "id": show.id if show else None,
             "tvdb_id": tvdb_id,
+            "tmdb_id": series_tmdb_id,
+            "episode_order": "tvdb",
             "title": show_data["title"],
             "poster_path": show_data["poster_path"],
             "backdrop_path": show_data["backdrop_path"],
@@ -1598,6 +1997,26 @@ async def refresh_tvdb_show_metadata(
         raw = await tvdb_client.get_series(tvdb_id, api_key)
     except Exception as e:
         raise HTTPException(status_code=502, detail=f"TVDB fetch failed: {e}")
+
+    if show.tmdb_id:
+        tmdb_api_key = await get_user_tmdb_key(db, current_user.id)
+        if not check_tmdb_key(tmdb_api_key):
+            raise HTTPException(status_code=400, detail="TMDB API key not configured")
+        try:
+            mapping = await ensure_episode_order_mapping(
+                db,
+                show.tmdb_id,
+                tmdb_api_key,
+                api_key,
+                force=True,
+            )
+        except Exception as exc:
+            raise HTTPException(status_code=502, detail=f"Episode mapping failed: {exc}")
+        await db.commit()
+        return {
+            "message": "Episode mapping refreshed successfully",
+            "mapping": mapping,
+        }
 
     show_fmt = tvdb_client.format_series(raw)
     show.title = show_fmt["title"] or show.title

--- a/backend/routers/shows.py
+++ b/backend/routers/shows.py
@@ -1472,11 +1472,11 @@ async def get_tvdb_show(
             if mapping:
                 target_season = mapping.tvdb_season_number
                 target_episode = mapping.tvdb_episode_number
-            elif not mappings:
+            else:
+                # No mapping for this specific episode — fall back to its own
+                # TMDB position rather than dropping it from the counts entirely.
                 target_season = episode.season_number
                 target_episode = episode.episode_number
-            else:
-                continue
             if target_season is None or target_episode is None:
                 continue
             if episode.id in collected_ids:
@@ -1704,12 +1704,12 @@ async def get_tvdb_season(
             local_episode = local_ep_map.get(
                 (mapping.tmdb_season_number, mapping.tmdb_episode_number)
             )
-        elif not mappings:
+        else:
+            # No mapping for this specific TVDB episode — fall back to matching
+            # by raw position rather than reporting it as missing from the library.
             local_episode = local_ep_map.get(
                 (season_number, episode.get("episode_number"))
             )
-        else:
-            local_episode = None
         mapped_rows.append((episode, mapping, local_episode))
 
     local_media_ids = list({

--- a/backend/routers/simkl.py
+++ b/backend/routers/simkl.py
@@ -401,7 +401,13 @@ async def run_simkl_sync(user_id: int, job_id: int) -> None:
                     logger.warning("Failed to fetch Simkl ratings: %s", exc)
                     ratings_data = {}
 
-                rat_res = await db.execute(select(Rating.media_id).where(Rating.user_id == user_id))
+                rat_res = await db.execute(
+                    select(Rating.media_id).where(
+                        Rating.user_id == user_id,
+                        Rating.season_number.is_(None),
+                        Rating.episode_order.is_(None),
+                    )
+                )
                 existing_rated: set[int] = {row[0] for row in rat_res}
 
                 for item in ratings_data.get("movies", []):
@@ -635,6 +641,8 @@ async def _run_simkl_push(user_id: int, job_id: int) -> None:
                     select(Rating.media_id, Rating.rating).where(
                         Rating.user_id == user_id,
                         Rating.rating.isnot(None),
+                        Rating.season_number.is_(None),
+                        Rating.episode_order.is_(None),
                     )
                 )
                 ratings_map = {row[0]: row[1] for row in ratings_result.all()}

--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -985,6 +985,7 @@ async def _fan_out_changes_to_other_connections(
                     select(Rating.media_id, Rating.season_number, Rating.rated_at).where(
                         Rating.user_id == user_id,
                         Rating.media_id.in_(chunk),
+                        Rating.episode_order.is_(None),
                     )
                 )
                 rated_at_by_key.update(
@@ -1219,7 +1220,13 @@ async def sync_items(
     existing_watched: set[int] = {row[0] for row in we_res}
 
     # Existing ratings: media_id → Rating
-    rat_res = await db.execute(select(Rating).where(Rating.user_id == user_id))
+    rat_res = await db.execute(
+        select(Rating).where(
+            Rating.user_id == user_id,
+            Rating.season_number.is_(None),
+            Rating.episode_order.is_(None),
+        )
+    )
     existing_ratings: dict[int, Rating] = {r.media_id: r for r in rat_res.scalars()}
 
     # ── Phase 2: Main sync loop (no N+1 queries, savepoints for error isolation) ──
@@ -2109,7 +2116,10 @@ async def _run_plex_sync(user_id: int, job_id: int, movie_limit: int, show_limit
             _new_ratings: RatingChanges = {}
             _new_collected: set[int] = set()
             ratings_result = await db.execute(
-                select(Rating).where(Rating.user_id == user_id)
+                select(Rating).where(
+                    Rating.user_id == user_id,
+                    Rating.episode_order.is_(None),
+                )
             )
             existing_ratings = {
                 (rating.media_id, rating.season_number): rating
@@ -3285,6 +3295,7 @@ async def _run_full_push(user_id: int, connection_id: int, job_id: int) -> None:
                     select(Rating.media_id, Rating.season_number, Rating.rating).where(
                         Rating.user_id == user_id,
                         Rating.rating.isnot(None),
+                        Rating.episode_order.is_(None),
                     )
                 )
                 ratings_map = {

--- a/backend/routers/trakt.py
+++ b/backend/routers/trakt.py
@@ -542,7 +542,10 @@ async def run_trakt_sync(user_id: int, job_id: int):
                 ratings_data = await trakt_client.get_ratings(client_id, access_token)
 
                 ratings_result = await db.execute(
-                    select(Rating).where(Rating.user_id == user_id)
+                    select(Rating).where(
+                        Rating.user_id == user_id,
+                        Rating.episode_order.is_(None),
+                    )
                 )
                 existing_ratings = {
                     (rating.media_id, rating.season_number): rating
@@ -997,6 +1000,7 @@ async def _run_trakt_push(user_id: int, job_id: int) -> None:
                     select(Rating.media_id, Rating.season_number, Rating.rating).where(
                         Rating.user_id == user_id,
                         Rating.rating.isnot(None),
+                        Rating.episode_order.is_(None),
                     )
                 )
                 ratings_map = {

--- a/backend/tests/test_episode_order.py
+++ b/backend/tests/test_episode_order.py
@@ -1,0 +1,264 @@
+import unittest
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+from types import SimpleNamespace
+
+from core.episode_order import ensure_episode_order_mapping, validate_episode_order
+from models.base import MediaType
+from models.media import Media
+from models.ratings import Rating
+from routers.ratings import RatingIn, submit_rating
+from routers.shows import _enrich_tvdb_seasons
+
+
+class _EmptyResult:
+    def scalars(self):
+        return self
+
+    def all(self):
+        return []
+
+
+class _ExistingResult(_EmptyResult):
+    def __init__(self, items):
+        self.items = items
+
+    def all(self):
+        return self.items
+
+
+class _ScalarOneResult:
+    def __init__(self, item):
+        self.item = item
+
+    def scalar_one_or_none(self):
+        return self.item
+
+
+class EpisodeOrderMappingTests(unittest.IsolatedAsyncioTestCase):
+    async def test_builds_bidirectional_positions_from_external_ids_and_safe_fallback(self) -> None:
+        db = AsyncMock()
+        db.execute.return_value = _EmptyResult()
+        db.add_all = MagicMock()
+
+        tmdb_show = {
+            "external_ids": {"tvdb_id": 389597},
+            "seasons": [{"season_number": 1}],
+        }
+        tmdb_season = {
+            "episodes": [
+                {
+                    "id": 5876034,
+                    "season_number": 1,
+                    "episode_number": 13,
+                    "name": "You Aren't E-Rank, Are You?",
+                    "air_date": "2025-01-04",
+                },
+                {
+                    "id": 5876035,
+                    "season_number": 1,
+                    "episode_number": 14,
+                    "name": "Éveil",
+                    "air_date": "2025-01-11",
+                },
+            ]
+        }
+        tvdb_show = {"seasons": [{"number": 2, "type": {"type": "official"}}]}
+        tvdb_episodes = [
+            {
+                "id": 10414110,
+                "seasonNumber": 2,
+                "number": 1,
+                "name": "You Aren't E-Rank, Are You?",
+                "aired": "2025-01-05",
+            },
+            {
+                "id": 10414111,
+                "seasonNumber": 2,
+                "number": 2,
+                "name": "Eveil",
+                "aired": "2025-01-12",
+            },
+        ]
+
+        with (
+            patch("core.episode_order.tmdb.get_show", AsyncMock(return_value=tmdb_show)),
+            patch("core.episode_order.tmdb.get_season", AsyncMock(return_value=tmdb_season)),
+            patch(
+                "core.episode_order.tmdb.get_episode_external_ids",
+                AsyncMock(side_effect=[{"tvdb_id": 10414110}, {"tvdb_id": None}]),
+            ),
+            patch("core.episode_order.tvdb.get_series", AsyncMock(return_value=tvdb_show)),
+            patch(
+                "core.episode_order.tvdb.get_series_episodes",
+                AsyncMock(return_value=tvdb_episodes),
+            ),
+        ):
+            summary = await ensure_episode_order_mapping(
+                db,
+                127532,
+                "tmdb-key",
+                "tvdb-key",
+            )
+
+        self.assertEqual(
+            summary,
+            {"tvdb_id": 389597, "matched": 2, "tmdb_episodes": 2, "unmatched": 0},
+        )
+        mappings = db.add_all.call_args.args[0]
+        self.assertEqual(
+            [
+                (
+                    mapping.tmdb_season_number,
+                    mapping.tmdb_episode_number,
+                    mapping.tvdb_season_number,
+                    mapping.tvdb_episode_number,
+                    mapping.match_method,
+                )
+                for mapping in mappings
+            ],
+            [
+                (1, 13, 2, 1, "external_id"),
+                (1, 14, 2, 2, "title_date"),
+            ],
+        )
+
+    async def test_cached_mapping_keeps_the_series_tvdb_id(self) -> None:
+        db = AsyncMock()
+        db.execute.return_value = _ExistingResult([
+            SimpleNamespace(tvdb_id=10414110),
+        ])
+        with patch(
+            "core.episode_order.tmdb.get_show",
+            AsyncMock(return_value={"external_ids": {"tvdb_id": 389597}}),
+        ):
+            summary = await ensure_episode_order_mapping(
+                db,
+                127532,
+                "tmdb-key",
+                "tvdb-key",
+            )
+
+        self.assertEqual(summary["tvdb_id"], 389597)
+        self.assertEqual(summary["matched"], 1)
+
+    async def test_tvdb_season_rating_stays_local(self) -> None:
+        media = Media(
+            id=1,
+            tmdb_id=127532,
+            media_type=MediaType.series,
+            title="Solo Leveling",
+        )
+        rating = Rating(
+            id=2,
+            user_id=3,
+            media_id=1,
+            season_number=2,
+            episode_order="tvdb",
+            rating=8.0,
+            rated_at=datetime(2026, 7, 19),
+        )
+        db = SimpleNamespace(
+            execute=AsyncMock(
+                side_effect=[
+                    _ScalarOneResult(media),
+                    _ScalarOneResult(rating),
+                ]
+            ),
+            add=MagicMock(),
+            commit=AsyncMock(),
+            refresh=AsyncMock(),
+        )
+
+        with patch(
+            "routers.sync._fan_out_changes_to_other_connections",
+            AsyncMock(),
+        ) as fan_out:
+            result = await submit_rating(
+                RatingIn(
+                    tmdb_id=127532,
+                    media_type="series",
+                    rating=8.0,
+                    season_number=2,
+                    episode_order="tvdb",
+                ),
+                db=db,
+                current_user=SimpleNamespace(id=3),
+            )
+
+        fan_out.assert_not_awaited()
+        self.assertEqual(result["season_number"], 2)
+        self.assertEqual(result["episode_order"], "tvdb")
+
+    async def test_tvdb_season_metadata_uses_tvdb_text_and_mapped_tmdb_rating(self) -> None:
+        mapping = SimpleNamespace(
+            tvdb_season_number=2,
+            tmdb_season_number=1,
+        )
+        tvdb_season = {
+            "id": 2120511,
+            "number": 2,
+            "name": "-Arise from the Shadow-",
+            "image": "https://artworks.thetvdb.com/season-2.jpg",
+            "translations": {
+                "nameTranslations": [
+                    {"language": "fra", "name": "Arise from the Shadow"},
+                ],
+                "overviewTranslations": [
+                    {"language": "eng", "overview": "English overview"},
+                    {"language": "fra", "overview": "Résumé français"},
+                ],
+            },
+        }
+        tmdb_show = {
+            "seasons": [
+                {
+                    "season_number": 1,
+                    "vote_average": 8.7,
+                    "overview": "TMDB overview",
+                },
+            ],
+        }
+
+        with (
+            patch(
+                "routers.shows.tvdb_client.get_season",
+                AsyncMock(return_value=tvdb_season),
+            ),
+            patch(
+                "routers.shows.tmdb.get_show",
+                AsyncMock(return_value=tmdb_show),
+            ),
+        ):
+            seasons, _ = await _enrich_tvdb_seasons(
+                [{
+                    "id": 2120511,
+                    "season_number": 2,
+                    "name": "Season 2",
+                    "overview": None,
+                    "poster_path": None,
+                    "episode_count": 13,
+                    "air_date": "2025-01-05",
+                }],
+                [mapping],
+                tvdb_api_key="tvdb-key",
+                tvdb_language="fra",
+                series_tmdb_id=127532,
+                tmdb_api_key="tmdb-key",
+                metadata_language="fr",
+            )
+
+        self.assertEqual(seasons[0]["name"], "Arise from the Shadow")
+        self.assertEqual(seasons[0]["overview"], "Résumé français")
+        self.assertEqual(seasons[0]["tmdb_rating"], 8.7)
+        self.assertEqual(seasons[0]["episode_count"], 13)
+
+    def test_rejects_unknown_episode_order(self) -> None:
+        self.assertEqual(validate_episode_order("tmdb"), "tmdb")
+        self.assertEqual(validate_episode_order("tvdb"), "tvdb")
+        with self.assertRaisesRegex(ValueError, "Unsupported episode order"):
+            validate_episode_order("absolute")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_episode_order.py
+++ b/backend/tests/test_episode_order.py
@@ -7,8 +7,9 @@ from core.episode_order import ensure_episode_order_mapping, validate_episode_or
 from models.base import MediaType
 from models.media import Media
 from models.ratings import Rating
+from models.show import Show as ShowModel
 from routers.ratings import RatingIn, submit_rating
-from routers.shows import _enrich_tvdb_seasons
+from routers.shows import _enrich_tvdb_seasons, get_tvdb_season
 
 
 class _EmptyResult:
@@ -252,6 +253,92 @@ class EpisodeOrderMappingTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(seasons[0]["overview"], "Résumé français")
         self.assertEqual(seasons[0]["tmdb_rating"], 8.7)
         self.assertEqual(seasons[0]["episode_count"], 13)
+
+    async def test_tvdb_season_counts_unmapped_episode_via_raw_position_fallback(self) -> None:
+        """Regression test: an episode with no explicit TMDB<->TVDB mapping must
+        still be counted toward watched/collected state if a local episode
+        exists at the same raw (season, episode) position, instead of being
+        silently dropped from the season's counts."""
+        show = ShowModel(id=42, tvdb_id=500, tmdb_id=999)
+        mapping = SimpleNamespace(
+            tvdb_id=5001,
+            tvdb_season_number=2,
+            tvdb_episode_number=1,
+            tmdb_season_number=1,
+            tmdb_episode_number=1,
+            tmdb_episode_id=9001,
+        )
+        mapped_episode = Media(
+            id=201,
+            show_id=42,
+            media_type=MediaType.episode,
+            season_number=1,
+            episode_number=1,
+            tmdb_id=9001,
+        )
+        # No mapping targets this episode, but it shares its raw TMDB position
+        # (season 2, episode 2) with the unmapped TVDB episode below.
+        unmapped_episode = Media(
+            id=202,
+            show_id=42,
+            media_type=MediaType.episode,
+            season_number=2,
+            episode_number=2,
+            tmdb_id=9002,
+        )
+
+        raw_series = {
+            "id": 500,
+            "name": "Test Show",
+            "remoteIds": [{"sourceName": "TheMovieDB", "id": "999"}],
+            "seasons": [{"number": 2, "type": {"type": "official"}, "id": 111}],
+        }
+        raw_episodes = [
+            {"id": 5001, "seasonNumber": 2, "number": 1, "name": "Ep1", "aired": "2025-01-01"},
+            {"id": 5002, "seasonNumber": 2, "number": 2, "name": "Ep2", "aired": "2025-01-08"},
+        ]
+
+        db = SimpleNamespace(
+            execute=AsyncMock(
+                side_effect=[
+                    _ScalarOneResult(show),                             # show_result
+                    _ExistingResult([mapping]),                         # mapping_result
+                    _ExistingResult([mapped_episode, unmapped_episode]),  # ep_result
+                    _ExistingResult([(201,), (202,)]),                  # watched_q — both watched
+                    _ExistingResult([(201,)]),                          # collected_q — only 201 collected
+                    _ExistingResult([]),                                # episode_ratings_q
+                    _ScalarOneResult(None),                             # show_media_result
+                ]
+            ),
+        )
+
+        with (
+            patch("routers.shows.get_user_tvdb_key", AsyncMock(return_value="tvdb-key")),
+            patch("routers.shows.get_user_metadata_language", AsyncMock(return_value=None)),
+            patch("routers.shows.get_user_tmdb_key", AsyncMock(return_value=None)),
+            patch("routers.shows.tvdb_client.get_series", AsyncMock(return_value=raw_series)),
+            patch("routers.shows.tvdb_client.get_series_episodes", AsyncMock(return_value=raw_episodes)),
+            patch("routers.shows.tvdb_client.get_season", AsyncMock(return_value={})),
+        ):
+            result = await get_tvdb_season(
+                tvdb_id=500,
+                season_number=2,
+                db=db,
+                current_user=SimpleNamespace(id=7),
+            )
+
+        episodes_by_number = {ep["episode_number"]: ep for ep in result["episodes"]}
+        self.assertEqual(episodes_by_number[1]["id"], 201)
+        self.assertTrue(episodes_by_number[1]["watched"])
+        self.assertTrue(episodes_by_number[1]["in_library"])
+
+        self.assertEqual(episodes_by_number[2]["id"], 202)
+        self.assertTrue(episodes_by_number[2]["watched"])
+        self.assertFalse(episodes_by_number[2]["in_library"])
+
+        self.assertEqual(result["season_watch_pct"], 100)
+        self.assertTrue(result["season_watched"])
+        self.assertEqual(result["season_collection_pct"], 50)
 
     def test_rejects_unknown_episode_order(self) -> None:
         self.assertEqual(validate_episode_order("tmdb"), "tmdb")

--- a/frontend/src/components/ActionBar.astro
+++ b/frontend/src/components/ActionBar.astro
@@ -10,6 +10,9 @@ interface Props {
   showTmdbId?: number;
   seasonNumber?: number;
   episodeNumber?: number;
+  displaySeasonNumber?: number;
+  episodeOrder?: "tmdb" | "tvdb";
+  tvdbId?: number;
   hideRequest?: boolean;
   hideLists?: boolean;
   isMonitored?: boolean;
@@ -31,6 +34,9 @@ const {
   showTmdbId,
   seasonNumber,
   episodeNumber,
+  displaySeasonNumber,
+  episodeOrder = "tmdb",
+  tvdbId,
   hideRequest = false,
   hideLists = false,
   isMonitored = false,
@@ -91,6 +97,9 @@ const requestTitle = isMonitored
   data-show-tmdb-id={showTmdbId ? String(showTmdbId) : ""}
   data-season={seasonNumber != null ? String(seasonNumber) : ""}
   data-episode-number={episodeNumber != null ? String(episodeNumber) : ""}
+  data-episode-order={episodeOrder}
+  data-tvdb-id={tvdbId != null ? String(tvdbId) : ""}
+  data-display-season={displaySeasonNumber != null ? String(displaySeasonNumber) : ""}
   data-media-id={mediaId != null ? String(mediaId) : ""}
   class="flex w-fit"
 >

--- a/frontend/src/components/EpisodeOrderSelector.astro
+++ b/frontend/src/components/EpisodeOrderSelector.astro
@@ -1,0 +1,90 @@
+---
+interface Props {
+  tmdbId: number;
+  tvdbId: number;
+  selected: "tmdb" | "tvdb";
+  token: string;
+}
+
+const { tmdbId, tvdbId, selected, token } = Astro.props;
+---
+
+<div
+  data-episode-order-selector
+  data-tmdb-id={String(tmdbId)}
+  data-tvdb-id={String(tvdbId)}
+  data-selected={selected}
+  data-token={token}
+  class="flex flex-wrap items-center gap-3 rounded-2xl border border-zinc-800 bg-zinc-900/60 px-4 py-3"
+>
+  <div>
+    <p class="text-xs font-black uppercase tracking-wider text-zinc-300">Episode order</p>
+    <p class="text-[11px] text-zinc-500">Choose how seasons are grouped for this show.</p>
+  </div>
+  <div class="ml-auto flex rounded-xl border border-zinc-700 bg-zinc-950 p-1" role="group" aria-label="Episode order">
+    <button
+      type="button"
+      data-order="tmdb"
+      aria-pressed={selected === "tmdb"}
+      class:list={[
+        "rounded-lg px-3 py-1.5 text-xs font-bold transition-colors",
+        selected === "tmdb" ? "bg-blue-600 text-white" : "text-zinc-400 hover:text-zinc-100",
+      ]}
+    >
+      TMDB
+    </button>
+    <button
+      type="button"
+      data-order="tvdb"
+      aria-pressed={selected === "tvdb"}
+      class:list={[
+        "rounded-lg px-3 py-1.5 text-xs font-bold transition-colors",
+        selected === "tvdb" ? "bg-blue-600 text-white" : "text-zinc-400 hover:text-zinc-100",
+      ]}
+    >
+      TVDB
+    </button>
+  </div>
+  <p data-order-error class="hidden w-full text-xs font-medium text-red-400"></p>
+</div>
+
+<script>
+  document.querySelectorAll<HTMLElement>('[data-episode-order-selector]').forEach((selector) => {
+    if (selector.dataset.bound === 'true') return;
+    selector.dataset.bound = 'true';
+
+    selector.querySelectorAll<HTMLButtonElement>('[data-order]').forEach((button) => {
+      button.addEventListener('click', async () => {
+        const episodeOrder = button.dataset.order as 'tmdb' | 'tvdb';
+        if (episodeOrder === selector.dataset.selected) return;
+
+        const buttons = selector.querySelectorAll<HTMLButtonElement>('[data-order]');
+        const error = selector.querySelector<HTMLElement>('[data-order-error]');
+        buttons.forEach((item) => { item.disabled = true; });
+        if (error) error.classList.add('hidden');
+        button.textContent = episodeOrder === 'tvdb' ? 'Mapping…' : 'Saving…';
+
+        try {
+          const response = await fetch(`/api/proxy/shows/${selector.dataset.tmdbId}/episode-order`, {
+            method: 'POST',
+            headers: {
+              Authorization: `Bearer ${selector.dataset.token}`,
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ episode_order: episodeOrder }),
+          });
+          const data = await response.json().catch(() => ({}));
+          if (!response.ok) throw new Error(data.detail || 'Unable to update episode order');
+          window.location.href = data.redirect;
+        } catch (exception) {
+          button.textContent = episodeOrder.toUpperCase();
+          buttons.forEach((item) => { item.disabled = false; });
+          if (error) {
+            error.textContent = exception instanceof Error ? exception.message : 'Unable to update episode order';
+            error.classList.remove('hidden');
+          }
+        }
+      });
+    });
+  });
+</script>

--- a/frontend/src/layouts/Base.astro
+++ b/frontend/src/layouts/Base.astro
@@ -708,7 +708,7 @@ const bottomNavItem = (active: boolean) =>
       _activeRatingBtn = null;
     }
 
-    function openRatingPopover(btn: HTMLElement, tmdbId: string, mediaType: string, currentRating: number | null, seasonNumber: number | null = null) {
+    function openRatingPopover(btn: HTMLElement, tmdbId: string, mediaType: string, currentRating: number | null, seasonNumber: number | null = null, episodeOrder: string = 'tmdb') {
       _activeRatingBtn = btn;
       const popover = document.getElementById('rating-popover')!;
       const starsEl = document.getElementById('rating-stars')!;
@@ -737,6 +737,7 @@ const bottomNavItem = (active: boolean) =>
           try {
             const ratingBody: Record<string, unknown> = { tmdb_id: Number(tmdbId), media_type: mediaType, rating: i };
             if (seasonNumber !== null) ratingBody.season_number = seasonNumber;
+            if (seasonNumber !== null && episodeOrder === 'tvdb') ratingBody.episode_order = 'tvdb';
             await apiFetch('/ratings', 'POST', ratingBody);
             btn.dataset.userRating = String(i);
             btn.dataset.state = 'active';
@@ -762,7 +763,8 @@ const bottomNavItem = (active: boolean) =>
       removeBtn.onclick = async () => {
         try {
           const seasonQuery = seasonNumber !== null ? `&season_number=${seasonNumber}` : '';
-          await apiFetch(`/ratings?tmdb_id=${tmdbId}&media_type=${mediaType}${seasonQuery}`, 'DELETE');
+          const orderQuery = seasonNumber !== null && episodeOrder === 'tvdb' ? '&episode_order=tvdb' : '';
+          await apiFetch(`/ratings?tmdb_id=${tmdbId}&media_type=${mediaType}${seasonQuery}${orderQuery}`, 'DELETE');
           btn.dataset.userRating = '';
           btn.dataset.state = 'inactive';
           btn.classList.remove('bg-amber-500/20', 'text-amber-400', 'hover:bg-amber-500/40');
@@ -1143,6 +1145,7 @@ const bottomNavItem = (active: boolean) =>
       const tmdbId = tmdbIdRaw && tmdbIdRaw !== 'null' ? tmdbIdRaw : '';
       const mediaId = card.dataset.id || '';
       const mediaType = card.dataset.mediaType!;
+      const episodeOrder = card.dataset.episodeOrder || 'tmdb';
 
       if (action === 'watched') {
         const isWatched = btn.dataset.watched === 'true';
@@ -1174,10 +1177,16 @@ const bottomNavItem = (active: boolean) =>
 
         try {
           if (mediaType === 'series' && season) {
+            const orderQuery = episodeOrder === 'tvdb' ? '&episode_order=tvdb' : '';
             if (isWatched) {
-              await apiFetch(`/history/season?series_tmdb_id=${seriesId}&season_number=${season}`, 'DELETE');
+              await apiFetch(`/history/season?series_tmdb_id=${seriesId}&season_number=${season}${orderQuery}`, 'DELETE');
             } else {
-              await apiFetch('/history/season', 'POST', { series_tmdb_id: Number(seriesId), season_number: Number(season) });
+              const watchBody: Record<string, number | string> = {
+                series_tmdb_id: Number(seriesId),
+                season_number: Number(season),
+              };
+              if (episodeOrder === 'tvdb') watchBody.episode_order = 'tvdb';
+              await apiFetch('/history/season', 'POST', watchBody);
             }
           } else if (mediaType === 'series') {
             if (isWatched) {
@@ -1212,7 +1221,8 @@ const bottomNavItem = (active: boolean) =>
 
           // If marking a season as watched/unwatched, update all episodes for that season on the page
           if (mediaType === 'series' && season) {
-            const allEpCards = document.querySelectorAll(`[data-card][data-media-type="episode"][data-show-tmdb-id="${seriesId}"][data-season="${season}"]`);
+            const seasonAttribute = episodeOrder === 'tvdb' ? 'data-display-season' : 'data-season';
+            const allEpCards = document.querySelectorAll(`[data-card][data-media-type="episode"][data-show-tmdb-id="${seriesId}"][${seasonAttribute}="${season}"]`);
             allEpCards.forEach(c => {
               const eBtn = c.querySelector('[data-action="watched"]');
               if (eBtn) updateWatchedButtonUI(eBtn, nowWatched);
@@ -1248,9 +1258,15 @@ const bottomNavItem = (active: boolean) =>
             if (inLibrary) {
               const ok = await showConfirm('Remove season from collection?', 'This will remove all collection entries for this season.');
               if (!ok) return;
-              await apiFetch(`/media/collect-season?series_tmdb_id=${seriesId}&season_number=${season}`, 'DELETE');
+              const orderQuery = episodeOrder === 'tvdb' ? '&episode_order=tvdb' : '';
+              await apiFetch(`/media/collect-season?series_tmdb_id=${seriesId}&season_number=${season}${orderQuery}`, 'DELETE');
             } else {
-              await apiFetch('/media/collect-season', 'POST', { series_tmdb_id: Number(seriesId), season_number: Number(season) });
+              const collectSeasonBody: Record<string, number | string> = {
+                series_tmdb_id: Number(seriesId),
+                season_number: Number(season),
+              };
+              if (episodeOrder === 'tvdb') collectSeasonBody.episode_order = 'tvdb';
+              await apiFetch('/media/collect-season', 'POST', collectSeasonBody);
             }
           } else {
             if (inLibrary) {
@@ -1292,7 +1308,7 @@ const bottomNavItem = (active: boolean) =>
         const currentRating = btn.dataset.userRating ? Number(btn.dataset.userRating) : null;
         const ratingSeason = (mediaType === 'series' && card.dataset.season) ? Number(card.dataset.season) : null;
         if (document.getElementById('rating-popover')!.classList.contains('hidden') || _activeRatingBtn !== btn) {
-          openRatingPopover(btn, tmdbId, mediaType, currentRating, ratingSeason);
+          openRatingPopover(btn, tmdbId, mediaType, currentRating, ratingSeason, episodeOrder);
         } else {
           closeRatingPopover();
         }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -638,6 +638,10 @@ export interface CollectionDetail {
 
 export interface TvdbEpisode {
   tvdb_id: number | null;
+  tmdb_id: number | null;
+  show_tmdb_id: number | null;
+  tmdb_season_number: number;
+  tmdb_episode_number: number;
   season_number: number;
   episode_number: number;
   name: string | null;
@@ -654,6 +658,10 @@ export interface TvdbEpisode {
 
 export interface TvdbEpisodeDetail {
   tvdb_id: number | null;
+  tmdb_id: number | null;
+  show_tmdb_id: number | null;
+  tmdb_season_number: number;
+  tmdb_episode_number: number;
   season_number: number;
   episode_number: number;
   name: string | null;
@@ -677,7 +685,7 @@ export interface TvdbEpisodeDetail {
   } | null;
   cast: { tmdb_id: null; person_id: number | null; name: string; character: string; profile_path: string | null }[];
   episodes: { episode_number: number; name: string | null }[];
-  show: { id: number | null; tvdb_id: number; title: string; poster_path: string | null; backdrop_path: string | null };
+  show: { id: number | null; tvdb_id: number; tmdb_id: number | null; episode_order: "tvdb"; title: string; poster_path: string | null; backdrop_path: string | null };
   season: { name: string; season_number: number; poster_path: string | null };
 }
 
@@ -686,11 +694,13 @@ export interface TvdbSeason {
   season_number: number;
   name: string;
   overview: string | null;
+  tmdb_rating: number | null;
   poster_path: string | null;
   backdrop_path: string | null;
   air_date: string | null;
   episodes: TvdbEpisode[];
   season_in_library: boolean;
+  season_watch_pct: number;
   season_watched: boolean;
   season_collection_pct: number;
   season_user_rating: number | null;
@@ -698,6 +708,8 @@ export interface TvdbSeason {
   show: {
     id: number | null;
     tvdb_id: number;
+    tmdb_id: number | null;
+    episode_order: "tvdb";
     title: string;
     poster_path: string | null;
     backdrop_path: string | null;
@@ -709,6 +721,7 @@ export interface TvdbSeasonMeta {
   season_number: number;
   name: string;
   overview: string | null;
+  tmdb_rating: number | null;
   poster_path: string | null;
   episode_count: number;
   air_date: string | null;
@@ -717,7 +730,7 @@ export interface TvdbSeasonMeta {
 export interface TvdbShow {
   id: number | null;
   tvdb_id: number;
-  tmdb_id: null;
+  tmdb_id: number | null;
   type: string;
   title: string;
   original_title: string | null;
@@ -728,11 +741,12 @@ export interface TvdbShow {
   last_air_date: string | null;
   status: string | null;
   tagline: null;
-  tmdb_rating: null;
+  tmdb_rating: number | null;
   age_rating: string | null;
   original_language: string | null;
   imdb_id: string | null;
   tmdb_id_cross: number | null;
+  episode_order: "tvdb";
   genres: string[];
   network: string | null;
   networks: { id: null; name: string; logo_path: null; origin_country: null }[];
@@ -754,6 +768,8 @@ export interface TvdbShow {
 export interface Show {
   id: number | null;
   tmdb_id: number;
+  tvdb_id?: number | null;
+  episode_order: "tmdb" | "tvdb";
   title: string;
   original_title: string | null;
   overview: string;
@@ -1115,6 +1131,19 @@ export const api = {
 
     refreshMetadata: (seriesTmdbId: number, token: string) =>
       post<{ message: string }>(`/shows/${seriesTmdbId}/refresh`, undefined, token),
+
+    setEpisodeOrder: (seriesTmdbId: number, episodeOrder: "tmdb" | "tvdb", token: string, forceRefresh = false) =>
+      post<{
+        episode_order: "tmdb" | "tvdb";
+        series_tmdb_id: number;
+        tvdb_id: number | null;
+        redirect: string;
+        mapping: { matched: number; tmdb_episodes: number; unmatched: number } | null;
+      }>(
+        `/shows/${seriesTmdbId}/episode-order`,
+        { episode_order: episodeOrder, force_refresh: forceRefresh },
+        token,
+      ),
 
     getTvdb: (tvdbId: number, token?: string) =>
       get<TvdbShow>(`/shows/tvdb/${tvdbId}`, undefined, token),

--- a/frontend/src/lib/media-format.ts
+++ b/frontend/src/lib/media-format.ts
@@ -1,0 +1,10 @@
+export function formatSeasonTitle(seasonNumber: number, name?: string | null): string {
+  const fallback = `Season ${seasonNumber}`;
+  const trimDecorators = (value: string) => value.replace(/^[-–—:·\s]+|[-–—:·\s]+$/g, "").trim();
+  const normalized = trimDecorators(name ?? "").replace(
+    new RegExp(`^season\\s+${seasonNumber}\\s*[-–—:·]?\\s*`, "i"),
+    "",
+  );
+  const customName = trimDecorators(normalized);
+  return customName ? `${fallback} · ${customName}` : fallback;
+}

--- a/frontend/src/pages/show/[id].astro
+++ b/frontend/src/pages/show/[id].astro
@@ -3,6 +3,7 @@ import Base from "../../layouts/Base.astro";
 import MediaRow from "../../components/MediaRow.astro";
 import ActionBar from "../../components/ActionBar.astro";
 import CommentsSection from "../../components/CommentsSection.astro";
+import EpisodeOrderSelector from "../../components/EpisodeOrderSelector.astro";
 import { api, type Show } from "../../lib/api";
 export const prerender = false;
 
@@ -21,6 +22,10 @@ try {
 
 if (!show && !error) {
     return Astro.redirect("/404");
+}
+
+if (show?.episode_order === "tvdb" && show.tvdb_id) {
+  return Astro.redirect(`/show/tvdb/${show.tvdb_id}`);
 }
 
 const seasons = Object.entries(show?.seasons ?? {}).sort(
@@ -167,6 +172,16 @@ const originalLanguage = show?.original_language
                 userRating={show.user_rating ?? null}
               />
             </div>
+            {show.tvdb_id && (
+              <div class="mb-6">
+                <EpisodeOrderSelector
+                  tmdbId={show.tmdb_id}
+                  tvdbId={show.tvdb_id}
+                  selected="tmdb"
+                  token={token}
+                />
+              </div>
+            )}
 
             {show.id && (
               <div class="mb-8">

--- a/frontend/src/pages/show/tvdb/[id].astro
+++ b/frontend/src/pages/show/tvdb/[id].astro
@@ -2,7 +2,9 @@
 import Base from "../../../layouts/Base.astro";
 import ActionBar from "../../../components/ActionBar.astro";
 import CommentsSection from "../../../components/CommentsSection.astro";
+import EpisodeOrderSelector from "../../../components/EpisodeOrderSelector.astro";
 import { api, type TvdbShow } from "../../../lib/api";
+import { formatSeasonTitle } from "../../../lib/media-format";
 export const prerender = false;
 
 const { id } = Astro.params;
@@ -22,7 +24,9 @@ if (!show && !error) {
   return Astro.redirect("/404");
 }
 
-const seasons = (show?.seasons_meta ?? []).filter((s) => (s.season_number ?? 0) > 0);
+const seasons = (show?.seasons_meta ?? []).filter(
+  (season) => (season.season_number ?? 0) > 0 && (season.episode_count ?? 0) > 0
+);
 const year = show?.first_air_date?.slice(0, 4) ?? null;
 const langNames = new Intl.DisplayNames(["en"], { type: "language" });
 const originalLanguage = show?.original_language
@@ -133,20 +137,30 @@ const originalLanguage = show?.original_language
 
             <div class="mb-6">
               <ActionBar
-                tmdbId={show.tvdb_id}
+                tmdbId={show.tmdb_id_cross ?? show.tvdb_id}
                 mediaType="series"
                 watched={show.watched}
                 inLists={show.in_lists}
                 inLibrary={show.in_library}
                 collectionPct={show.collection_pct}
                 watchPct={show.watch_pct ?? 0}
-                showTmdbId={show.tvdb_id}
+                showTmdbId={show.tmdb_id_cross ?? undefined}
                 isMonitored={show.is_monitored}
                 requestEnabled={show.request_enabled}
                 requestStatus={show.request_status}
                 userRating={show.user_rating}
               />
             </div>
+            {show.tmdb_id_cross && (
+              <div class="mb-6">
+                <EpisodeOrderSelector
+                  tmdbId={show.tmdb_id_cross}
+                  tvdbId={show.tvdb_id}
+                  selected="tvdb"
+                  token={token}
+                />
+              </div>
+            )}
 
             {show.id && (
               <div class="mb-8">
@@ -217,6 +231,7 @@ const originalLanguage = show?.original_language
           <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
             {seasons.map((s) => {
               const seasonNum = s.season_number;
+              const seasonTitle = formatSeasonTitle(seasonNum, s.name);
               const poster = s.poster_path || show!.poster_path;
               const seasonState = show!.season_states?.[seasonNum] ?? { watched: false, in_library: false, collection_pct: 0, user_rating: null };
 
@@ -226,7 +241,7 @@ const originalLanguage = show?.original_language
                     <div class="w-28 shrink-0">
                       <div class="aspect-[2/3] rounded-2xl overflow-hidden border border-zinc-800 shadow-lg group-hover/season:ring-2 group-hover/season:ring-blue-500/50 transition-all duration-500">
                         {poster ? (
-                          <img src={poster} alt={s.name} class="w-full h-full object-cover group-hover/season:scale-110 transition-transform duration-700" />
+                          <img src={poster} alt={seasonTitle} class="w-full h-full object-cover group-hover/season:scale-110 transition-transform duration-700" />
                         ) : (
                           <div class="w-full h-full bg-zinc-900 flex flex-col items-center justify-center text-zinc-500 gap-1">
                             <span class="text-3xl">📺</span>
@@ -236,7 +251,15 @@ const originalLanguage = show?.original_language
                       </div>
                     </div>
                     <div class="flex-1 py-2">
-                      <h3 class="text-xl font-black text-zinc-100 group-hover/season:text-blue-400 transition-colors mb-1">{s.name || `Season ${seasonNum}`}</h3>
+                      <div class="flex items-start justify-between gap-4 mb-1">
+                        <h3 class="text-xl font-black text-zinc-100 group-hover/season:text-blue-400 transition-colors">{seasonTitle}</h3>
+                        {s.tmdb_rating != null && s.tmdb_rating > 0 && (
+                          <div class="bg-zinc-950 border border-zinc-800 px-2 py-1 rounded-xl flex items-center gap-1.5 shrink-0 shadow-sm">
+                            <span class="text-yellow-400 text-xs">★</span>
+                            <span class="text-zinc-100 text-xs font-bold">{s.tmdb_rating.toFixed(1)}</span>
+                          </div>
+                        )}
+                      </div>
                       <div class="flex items-center gap-2 mb-3">
                         <span class="text-[10px] font-black text-zinc-500 uppercase tracking-widest bg-zinc-950 px-2 py-0.5 rounded border border-zinc-800">
                           {s.episode_count} Episodes
@@ -246,7 +269,7 @@ const originalLanguage = show?.original_language
                     </div>
                   </a>
                   <ActionBar
-                    tmdbId={show!.tvdb_id}
+                    tmdbId={show!.tmdb_id_cross ?? show!.tvdb_id}
                     mediaType="series"
                     watched={seasonState.watched}
                     inLists={[]}
@@ -254,6 +277,9 @@ const originalLanguage = show?.original_language
                     collectionPct={seasonState.collection_pct}
                     watchPct={seasonState.watch_pct ?? 0}
                     seasonNumber={seasonNum}
+                    showTmdbId={show!.tmdb_id_cross ?? undefined}
+                    episodeOrder="tvdb"
+                    tvdbId={show!.tvdb_id}
                     hideRequest={true}
                     hideLists={true}
                     userRating={seasonState.user_rating ?? null}
@@ -313,7 +339,7 @@ const originalLanguage = show?.original_language
 
         <CommentsSection
           mediaType="series"
-          tmdbId={show.tvdb_id}
+          tmdbId={show.tmdb_id_cross ?? show.tvdb_id}
         />
 
         {show.tmdb_id_cross && (

--- a/frontend/src/pages/show/tvdb/[id]/season/[season_number].astro
+++ b/frontend/src/pages/show/tvdb/[id]/season/[season_number].astro
@@ -3,6 +3,7 @@ import Base from "../../../../../layouts/Base.astro";
 import ActionBar from "../../../../../components/ActionBar.astro";
 import CommentsSection from "../../../../../components/CommentsSection.astro";
 import { api, type TvdbSeason } from "../../../../../lib/api";
+import { formatSeasonTitle } from "../../../../../lib/media-format";
 export const prerender = false;
 
 const { id, season_number } = Astro.params;
@@ -23,9 +24,12 @@ if (!season && !error) {
 }
 
 const show = season?.show;
+const seasonTitle = season
+  ? formatSeasonTitle(Number(season_number), season.name)
+  : "Season Details";
 ---
 
-<Base title={season ? `${show?.title} — ${season.name}` : "Season Details"}>
+<Base title={season ? `${show?.title} — ${seasonTitle}` : "Season Details"}>
   {error && !season && (
     <div class="max-w-md mx-auto mt-20 text-center">
       <div class="bg-red-500/10 border border-red-500/20 text-red-500 p-6 rounded-2xl mb-6">
@@ -52,15 +56,15 @@ const show = season?.show;
           <span class="text-zinc-700">/</span>
           <a href={`/show/tvdb/${id}`} class="hover:text-zinc-100 transition truncate">{show?.title}</a>
           <span class="text-zinc-700">/</span>
-          <span class="text-zinc-100 font-bold">{season.name}</span>
+          <span class="text-zinc-100 font-bold">{seasonTitle}</span>
         </nav>
 
         <div class="flex flex-col md:flex-row gap-8 lg:gap-12 mb-16">
           <div class="w-56 shrink-0 mx-auto md:mx-0">
             <div class="aspect-[2/3] rounded-2xl overflow-hidden shadow-2xl border border-zinc-800 bg-zinc-900 ring-1 ring-white/10 relative">
               {(season.poster_path || show?.poster_path) ? (
-                <button id="poster-zoom-btn" class="w-full h-full group/poster block cursor-zoom-in" aria-label={`Enlarge poster for ${season.name}`}>
-                  <img src={season.poster_path ?? show?.poster_path ?? ""} alt={season.name} class="w-full h-full object-cover transition-transform duration-300 group-hover/poster:scale-105" />
+                <button id="poster-zoom-btn" class="w-full h-full group/poster block cursor-zoom-in" aria-label={`Enlarge poster for ${seasonTitle}`}>
+                  <img src={season.poster_path ?? show?.poster_path ?? ""} alt={seasonTitle} class="w-full h-full object-cover transition-transform duration-300 group-hover/poster:scale-105" />
                   <div class="absolute inset-0 flex items-center justify-center opacity-0 group-hover/poster:opacity-100 transition-opacity duration-200 bg-black/30">
                     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor" class="w-8 h-8 text-white drop-shadow-lg">
                       <path stroke-linecap="round" stroke-linejoin="round" d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607ZM10.5 7.5v6m3-3h-6" />
@@ -78,7 +82,7 @@ const show = season?.show;
 
           <div class="flex-1 pt-4 text-center md:text-left">
             <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4 mb-2">
-              <h1 class="text-4xl md:text-5xl font-black text-zinc-100 tracking-tight">{season.name}</h1>
+              <h1 class="text-4xl md:text-5xl font-black text-zinc-100 tracking-tight">{seasonTitle}</h1>
 
               {show?.seasons_meta && show.seasons_meta.length > 1 && (
                 <div class="flex items-center gap-2 shrink-0">
@@ -123,6 +127,12 @@ const show = season?.show;
 
             <div class="flex flex-wrap justify-center md:justify-start items-center gap-4 text-zinc-400 text-sm mb-8 bg-zinc-900/40 p-3 rounded-xl border border-zinc-800/50 backdrop-blur-sm inline-flex">
               <span class="font-bold text-zinc-300">{season.episodes?.length || 0} Episodes</span>
+              {season.tmdb_rating != null && season.tmdb_rating > 0 && (
+                <span class="flex items-center gap-1.5 font-bold text-zinc-100">
+                  <span class="text-yellow-400">★</span>
+                  {season.tmdb_rating.toFixed(1)}
+                </span>
+              )}
               {season.air_date && (
                 <span>Premiered {new Date(season.air_date).toLocaleDateString(undefined, { year: "numeric", month: "long", day: "numeric" })}</span>
               )}
@@ -130,7 +140,7 @@ const show = season?.show;
 
             <div class="mb-6">
               <ActionBar
-                tmdbId={Number(id)}
+                tmdbId={season.show.tmdb_id ?? Number(id)}
                 mediaType="series"
                 watched={season.season_watched}
                 inLists={[]}
@@ -138,6 +148,9 @@ const show = season?.show;
                 collectionPct={season.season_collection_pct}
                 watchPct={season.season_watch_pct ?? 0}
                 seasonNumber={Number(season_number)}
+                showTmdbId={season.show.tmdb_id ?? undefined}
+                episodeOrder="tvdb"
+                tvdbId={Number(id)}
                 requestEnabled={false}
                 hideLists={true}
                 userRating={season.season_user_rating}
@@ -175,7 +188,7 @@ const show = season?.show;
 
         <CommentsSection
           mediaType="series"
-          tmdbId={Number(id)}
+          tmdbId={season.show.tmdb_id ?? Number(id)}
           seasonNumber={Number(season_number)}
         />
 
@@ -236,15 +249,18 @@ const show = season?.show;
                 </a>
                 <div class="px-5 pb-5">
                   <ActionBar
-                    tmdbId={ep.tvdb_id ?? Number(id)}
+                    tmdbId={ep.tmdb_id ?? ep.tvdb_id ?? Number(id)}
                     mediaType="episode"
                     watched={ep.watched}
                     inLists={ep.in_lists}
                     inLibrary={ep.in_library}
                     collectionPct={ep.in_library ? 100 : 0}
-                    showTmdbId={Number(id)}
-                    seasonNumber={Number(season_number)}
-                    episodeNumber={ep.episode_number}
+                    showTmdbId={ep.show_tmdb_id ?? season.show.tmdb_id ?? undefined}
+                    seasonNumber={ep.tmdb_season_number}
+                    episodeNumber={ep.tmdb_episode_number}
+                    displaySeasonNumber={Number(season_number)}
+                    episodeOrder="tvdb"
+                    tvdbId={Number(id)}
                     hideRequest={true}
                     userRating={ep.user_rating}
                   />

--- a/frontend/src/pages/show/tvdb/[id]/season/[season_number]/[episode_number].astro
+++ b/frontend/src/pages/show/tvdb/[id]/season/[season_number]/[episode_number].astro
@@ -157,15 +157,18 @@ const thumbnail = episode?.image_url || show?.poster_path || null;
 
             <div class="mb-4">
               <ActionBar
-                tmdbId={episode.tvdb_id ?? Number(id)}
+                tmdbId={episode.tmdb_id ?? episode.tvdb_id ?? Number(id)}
                 mediaType="episode"
                 watched={episode.watched}
                 inLists={episode.in_lists}
                 inLibrary={episode.in_library}
                 collectionPct={episode.in_library ? 100 : 0}
-                showTmdbId={Number(id)}
-                seasonNumber={Number(season_number)}
-                episodeNumber={Number(episode_number)}
+                showTmdbId={episode.show_tmdb_id ?? episode.show.tmdb_id ?? undefined}
+                seasonNumber={episode.tmdb_season_number}
+                episodeNumber={episode.tmdb_episode_number}
+                displaySeasonNumber={Number(season_number)}
+                episodeOrder="tvdb"
+                tvdbId={Number(id)}
                 mediaId={episode.id}
                 hideRequest={true}
                 userRating={episode.user_rating}
@@ -173,13 +176,14 @@ const thumbnail = episode?.image_url || show?.poster_path || null;
             </div>
 
             <ManualScrobble
-              tmdbId={null}
+              tmdbId={episode.tmdb_id}
               mediaId={episode.id}
               mediaType="episode"
               runtime={episode.runtime}
               title={episode.name ?? `Episode ${episode_number}`}
-              seasonNumber={Number(season_number)}
-              episodeNumber={Number(episode_number)}
+              showTmdbId={episode.show_tmdb_id ?? episode.show.tmdb_id ?? undefined}
+              seasonNumber={episode.tmdb_season_number}
+              episodeNumber={episode.tmdb_episode_number}
             />
 
             <!-- Library info -->
@@ -228,7 +232,7 @@ const thumbnail = episode?.image_url || show?.poster_path || null;
                   <span id="refresh-label">Refresh Metadata</span>
                 </button>
                 <VideoPlayer
-                  tmdbId={episode.tvdb_id ?? Number(id)}
+                  tmdbId={episode.tmdb_id ?? episode.tvdb_id ?? Number(id)}
                   mediaId={episode.id}
                   mediaType="episode"
                   inLibrary={episode.in_library}
@@ -255,9 +259,9 @@ const thumbnail = episode?.image_url || show?.poster_path || null;
 
         <CommentsSection
           mediaType="series"
-          tmdbId={Number(id)}
-          seasonNumber={Number(season_number)}
-          episodeNumber={Number(episode_number)}
+          tmdbId={episode.show_tmdb_id ?? episode.show.tmdb_id ?? Number(id)}
+          seasonNumber={episode.tmdb_season_number}
+          episodeNumber={episode.tmdb_episode_number}
         />
 
         <!-- Cast -->


### PR DESCRIPTION
## Summary

- add a per-show TMDB/TVDB episode-order preference with an Alembic migration and persisted TMDB ↔ TVDB episode mappings
- add TVDB-native show, season, and episode routes and UI while preserving canonical local collection, watched, rating, and Nuvio/provider actions
- isolate TVDB season ratings from canonical provider fan-out and enrich TVDB seasons with translated TVDB overviews and mapped TMDB ratings
- remap season-level collection, watched, rating, and history operations to canonical TMDB episodes without changing the selected TVDB presentation order

## Validation

- `python -m unittest discover -s tests -v` — 46 tests passed
- `npm run build` — Astro production build passed
- Alembic upgrade and downgrade validated against an isolated PostgreSQL database
- local Docker smoke test validated Solo Leveling (`TVDB 389597` / `TMDB 127532`): order selection persistence, mapped S2 episode state/actions, season titles, translated overviews, and TMDB ratings
