### PR TITLE
fix(nuvio): sync collections and separate auto push

### DIFF
--- a/backend/core/nuvio.py
+++ b/backend/core/nuvio.py
@@ -238,6 +238,117 @@ async def pull_sync_data(
     return session, {"library": library, "watched": watched, "progress": progress}
 
 
+_LIBRARY_PUSH_FIELDS = (
+    "content_id",
+    "content_type",
+    "name",
+    "poster",
+    "poster_shape",
+    "background",
+    "description",
+    "release_info",
+    "imdb_rating",
+    "genres",
+    "addon_base_url",
+    "added_at",
+)
+
+
+def _library_push_item(item: dict[str, Any]) -> dict[str, Any]:
+    return {
+        field: item[field]
+        for field in _LIBRARY_PUSH_FIELDS
+        if field in item and item[field] is not None
+    }
+
+
+async def push_library(
+    url: str,
+    refresh_token: str,
+    profile_id: int,
+    items: list[dict[str, Any]],
+) -> NuvioSession:
+    """Replace a Nuvio library while preserving remote playback metadata."""
+    async with httpx.AsyncClient(timeout=30.0, follow_redirects=False) as client:
+        session = await refresh_session(url, refresh_token, client=client)
+        remote_items = await _pull_library(
+            client,
+            url,
+            session.access_token,
+            profile_id,
+        )
+        remote_by_id = {
+            str(item.get("content_id")): _library_push_item(item)
+            for item in remote_items
+            if item.get("content_id")
+        }
+        snapshot: list[dict[str, Any]] = []
+        for item in items:
+            content_id = str(item.get("content_id") or "")
+            if not content_id:
+                continue
+            snapshot.append({
+                **remote_by_id.get(content_id, {}),
+                **_library_push_item(item),
+            })
+        await _rpc(
+            client,
+            url,
+            session.access_token,
+            "sync_push_library",
+            {"p_profile_id": profile_id, "p_items": snapshot},
+        )
+    return session
+
+
+async def merge_library(
+    url: str,
+    refresh_token: str,
+    profile_id: int,
+    *,
+    additions: list[dict[str, Any]],
+    removed_content_ids: set[str],
+) -> tuple[NuvioSession, int]:
+    """Read, merge, and safely replace a Nuvio library snapshot."""
+    async with httpx.AsyncClient(timeout=30.0, follow_redirects=False) as client:
+        session = await refresh_session(url, refresh_token, client=client)
+        remote_items = await _pull_library(
+            client,
+            url,
+            session.access_token,
+            profile_id,
+        )
+        merged = {
+            str(item.get("content_id")): _library_push_item(item)
+            for item in remote_items
+            if item.get("content_id")
+        }
+        for content_id in removed_content_ids:
+            merged.pop(content_id, None)
+        for item in additions:
+            content_id = str(item.get("content_id") or "")
+            if not content_id:
+                continue
+            existing = merged.get(content_id, {})
+            merged[content_id] = {
+                **existing,
+                **_library_push_item(item),
+            }
+        await _rpc(
+            client,
+            url,
+            session.access_token,
+            "sync_push_library",
+            {
+                "p_profile_id": profile_id,
+                "p_items": list(merged.values()),
+            },
+        )
+    return session, len(merged)
+
+
+
+
 async def _push_sync_items(
     url: str,
     refresh_token: str,

--- a/backend/core/nuvio.py
+++ b/backend/core/nuvio.py
@@ -255,11 +255,15 @@ _LIBRARY_PUSH_FIELDS = (
 
 
 def _library_push_item(item: dict[str, Any]) -> dict[str, Any]:
-    return {
-        field: item[field]
-        for field in _LIBRARY_PUSH_FIELDS
-        if field in item and item[field] is not None
-    }
+    cleaned: dict[str, Any] = {}
+    for field in _LIBRARY_PUSH_FIELDS:
+        if field not in item:
+            continue
+        value = item[field]
+        if value is None or value == "" or (field == "genres" and not value):
+            continue
+        cleaned[field] = value
+    return cleaned
 
 
 async def push_library(

--- a/backend/main.py
+++ b/backend/main.py
@@ -20,73 +20,127 @@ from models.playback_session import PlaybackSession
 
 
 async def _auto_sync_scheduler():
+    from datetime import datetime, timedelta, timezone
+
     from db import async_sessionmaker
     from models.connections import MediaServerConnection
-    from routers.sync import run_jellyfin_sync, run_emby_sync, run_plex_sync, run_nuvio_sync
-    from datetime import datetime, timezone
+    from routers.sync import (
+        _run_full_push,
+        run_emby_sync,
+        run_jellyfin_sync,
+        run_nuvio_sync,
+        run_plex_sync,
+    )
 
-    CHECK_INTERVAL = 300  # seconds between scheduler ticks
-
-    source_map = {"jellyfin": CollectionSource.jellyfin, "emby": CollectionSource.emby, "plex": CollectionSource.plex, "nuvio": CollectionSource.nuvio}
-    runner_map = {"jellyfin": run_jellyfin_sync, "emby": run_emby_sync, "plex": run_plex_sync, "nuvio": run_nuvio_sync}
+    check_interval = 300  # seconds between scheduler ticks
+    source_map = {
+        "jellyfin": CollectionSource.jellyfin,
+        "emby": CollectionSource.emby,
+        "plex": CollectionSource.plex,
+        "nuvio": CollectionSource.nuvio,
+    }
+    runner_map = {
+        "jellyfin": run_jellyfin_sync,
+        "emby": run_emby_sync,
+        "plex": run_plex_sync,
+        "nuvio": run_nuvio_sync,
+    }
 
     while True:
-        await asyncio.sleep(CHECK_INTERVAL)
+        await asyncio.sleep(check_interval)
         try:
             async_session = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
             async with async_session() as db:
                 result = await db.execute(
                     select(MediaServerConnection).where(
-                        MediaServerConnection.auto_sync_interval.isnot(None)
+                        or_(
+                            MediaServerConnection.auto_sync_interval.isnot(None),
+                            MediaServerConnection.auto_push_interval.isnot(None),
+                        )
                     )
                 )
                 connections = result.scalars().all()
-
                 now = datetime.now(timezone.utc).replace(tzinfo=None)
 
                 for conn in connections:
-                    user_id = conn.user_id
                     source = source_map.get(conn.type)
-                    run_fn = runner_map.get(conn.type)
-                    if not source or not run_fn:
+                    pull_runner = runner_map.get(conn.type)
+                    if not source or not pull_runner:
                         continue
 
-                    # Skip if a sync is already pending or running for this connection
                     active_q = await db.execute(
-                        select(SyncJob).where(
-                            SyncJob.user_id == user_id,
+                        select(SyncJob)
+                        .where(
+                            SyncJob.user_id == conn.user_id,
                             SyncJob.source == source,
                             SyncJob.connection_id == conn.id,
                             SyncJob.status.in_([SyncStatus.pending, SyncStatus.running]),
                         )
+                        .limit(1)
                     )
                     if active_q.scalar_one_or_none():
                         continue
 
-                    # Find the last completed or failed sync for this user+source+connection
-                    last_q = await db.execute(
-                        select(SyncJob).where(
-                            SyncJob.user_id == user_id,
-                            SyncJob.source == source,
-                            SyncJob.connection_id == conn.id,
-                            SyncJob.status.in_([SyncStatus.completed, SyncStatus.failed]),
-                        ).order_by(SyncJob.updated_at.desc()).limit(1)
+                    schedules: list[tuple[str, float, object]] = []
+                    if conn.auto_sync_interval is not None:
+                        schedules.append(("pull", conn.auto_sync_interval, pull_runner))
+                    if (
+                        conn.auto_push_interval is not None
+                        and (
+                            conn.push_collection
+                            or conn.push_watched
+                            or conn.push_playback
+                            or conn.push_ratings
+                        )
+                    ):
+                        schedules.append(("push", conn.auto_push_interval, _run_full_push))
+
+                    due: list[tuple[datetime, str, object]] = []
+                    for job_type, interval, runner in schedules:
+                        last_q = await db.execute(
+                            select(SyncJob)
+                            .where(
+                                SyncJob.user_id == conn.user_id,
+                                SyncJob.source == source,
+                                SyncJob.connection_id == conn.id,
+                                SyncJob.job_type == job_type,
+                                SyncJob.status.in_([SyncStatus.completed, SyncStatus.failed]),
+                            )
+                            .order_by(SyncJob.updated_at.desc())
+                            .limit(1)
+                        )
+                        last_job = last_q.scalar_one_or_none()
+                        next_run = (
+                            last_job.updated_at + timedelta(hours=interval)
+                            if last_job
+                            else datetime.min
+                        )
+                        if next_run <= now:
+                            due.append((next_run, job_type, runner))
+
+                    if not due:
+                        continue
+                    _, job_type, runner = min(due, key=lambda item: item[0])
+                    job = SyncJob(
+                        user_id=conn.user_id,
+                        source=source,
+                        status=SyncStatus.pending,
+                        connection_id=conn.id,
+                        job_type=job_type,
                     )
-                    last_job = last_q.scalar_one_or_none()
-
-                    if last_job:
-                        elapsed_hours = (now - last_job.updated_at).total_seconds() / 3600
-                        if elapsed_hours < conn.auto_sync_interval:
-                            continue
-
-                    job = SyncJob(user_id=user_id, source=source, status=SyncStatus.pending, connection_id=conn.id)
                     db.add(job)
                     await db.flush()
                     job_id = job.id
                     await db.commit()
 
-                    print(f"Auto-sync: queuing {conn.type} sync for user {user_id}, connection {conn.id} (job {job_id})")
-                    asyncio.create_task(run_fn(user_id, job_id, 0, 0, conn.id))
+                    print(
+                        f"Auto-{job_type}: queuing {conn.type} for user {conn.user_id}, "
+                        f"connection {conn.id} (job {job_id})"
+                    )
+                    if job_type == "push":
+                        asyncio.create_task(runner(conn.user_id, conn.id, job_id))
+                    else:
+                        asyncio.create_task(runner(conn.user_id, job_id, 0, 0, conn.id))
 
         except Exception as e:
             print(f"Auto-sync scheduler error: {e}")

--- a/backend/migrations/versions/z0a1b2c3d4e5_add_nuvio_push_collection.py
+++ b/backend/migrations/versions/z0a1b2c3d4e5_add_nuvio_push_collection.py
@@ -1,0 +1,31 @@
+"""add Nuvio collection push and auto-push interval
+
+Revision ID: z0a1b2c3d4e5
+Revises: x8y9z0a1b2c3
+Create Date: 2026-07-19
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "z0a1b2c3d4e5"
+down_revision = "x8y9z0a1b2c3"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "media_server_connections",
+        sa.Column("push_collection", sa.Boolean(), nullable=False, server_default="false"),
+    )
+    op.add_column(
+        "media_server_connections",
+        sa.Column("auto_push_interval", sa.Float(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("media_server_connections", "auto_push_interval")
+    op.drop_column("media_server_connections", "push_collection")

--- a/backend/models/connections.py
+++ b/backend/models/connections.py
@@ -28,11 +28,13 @@ class MediaServerConnection(Base):
 
     # Outbound push flags (Scrob → source)
     push_watched     : Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="false")
+    push_collection  : Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="false")
     push_playback    : Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="false")
     push_ratings     : Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="false")
 
     # Auto sync interval in hours (null = disabled)
     auto_sync_interval : Mapped[Optional[float]] = mapped_column(Float, nullable=True)
+    auto_push_interval : Mapped[Optional[float]] = mapped_column(Float, nullable=True)
 
     # Plex watchlist → Radarr/Sonarr auto-request (Plex connections only)
     watchlist_to_radarr       : Mapped[bool]           = mapped_column(Boolean, nullable=False, default=False, server_default="false")

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -475,9 +475,11 @@ async def create_connection(
         sync_ratings=body.sync_ratings if body.type != "nuvio" else False,
         sync_playback=body.sync_playback,
         push_watched=body.push_watched,
+        push_collection=body.push_collection if body.type == "nuvio" else False,
         push_playback=body.push_playback if body.type == "nuvio" else False,
         push_ratings=body.push_ratings if body.type != "nuvio" else False,
         auto_sync_interval=body.auto_sync_interval,
+        auto_push_interval=body.auto_push_interval,
     )
     db.add(conn)
     await db.commit()
@@ -522,8 +524,10 @@ async def update_connection(
         update_data["sync_ratings"] = False
         update_data["push_ratings"] = False
         update_data["push_playback"] = update_data.get("push_playback", conn.push_playback)
+        update_data["push_collection"] = update_data.get("push_collection", conn.push_collection)
     else:
         update_data["push_playback"] = False
+        update_data["push_collection"] = False
 
     for field, value in update_data.items():
         setattr(conn, field, value)

--- a/backend/routers/media.py
+++ b/backend/routers/media.py
@@ -38,6 +38,11 @@ from models.show import Show as ShowModel
 from models.global_settings import GlobalSettings
 
 router = APIRouter()
+_PLAYABLE_COLLECTION_SOURCES = {
+    CollectionSource.jellyfin,
+    CollectionSource.emby,
+    CollectionSource.plex,
+}
 
 
 class SessionReportRequest(BaseModel):
@@ -2359,11 +2364,18 @@ async def manually_collect(
         source_id=str(body.tmdb_id),
     ))
     await db.commit()
+    await _push_collection_change(db, current_user.id, {media.id}, added=True)
     return {"status": "ok", "message": "Added to collection"}
 
 
-async def _push_collection_removal(db: AsyncSession, user_id: int, media_ids: set[int]) -> None:
-    """Fan out a local collection removal to Trakt/MDBList push targets."""
+async def _push_collection_change(
+    db: AsyncSession,
+    user_id: int,
+    media_ids: set[int],
+    *,
+    added: bool,
+) -> None:
+    """Fan out a local collection mutation to enabled push targets."""
     if not media_ids:
         return
     settings_result = await db.execute(select(UserSettings).where(UserSettings.user_id == user_id))
@@ -2371,7 +2383,14 @@ async def _push_collection_removal(db: AsyncSession, user_id: int, media_ids: se
     from routers.sync import _fan_out_changes_to_other_connections
 
     await _fan_out_changes_to_other_connections(
-        db, user_id, None, set(), {}, settings=settings, removed_collected_ids=media_ids,
+        db,
+        user_id,
+        None,
+        set(),
+        {},
+        settings=settings,
+        new_collected_ids=media_ids if added else set(),
+        removed_collected_ids=set() if added else media_ids,
     )
 
 
@@ -2388,7 +2407,7 @@ async def clear_collection(
     await db.execute(delete(Collection).where(Collection.user_id == current_user.id))
     await db.commit()
 
-    await _push_collection_removal(db, current_user.id, media_ids)
+    await _push_collection_change(db, current_user.id, media_ids, added=False)
     return {"status": "ok"}
 
 
@@ -2425,7 +2444,7 @@ async def manually_uncollect(
     )
     await db.commit()
 
-    await _push_collection_removal(db, current_user.id, {media.id})
+    await _push_collection_change(db, current_user.id, {media.id}, added=False)
     return {"status": "ok", "message": "Removed from collection"}
 
 
@@ -2582,6 +2601,12 @@ async def collect_season(
 
     added = await _collect_episodes(db, current_user.id, episodes)
     await db.commit()
+    await _push_collection_change(
+        db,
+        current_user.id,
+        {episode.id for episode in episodes},
+        added=True,
+    )
     return {"status": "ok", "count": added}
 
 
@@ -2632,11 +2657,14 @@ async def collect_show(
     ]
 
     total_added = 0
+    collected_media_ids: set[int] = set()
     for sn in season_numbers:
         episodes = await _resolve_season_episodes(db, show, body.tmdb_id, sn, tmdb_key)
         total_added += await _collect_episodes(db, current_user.id, episodes)
+        collected_media_ids.update(episode.id for episode in episodes)
 
     await db.commit()
+    await _push_collection_change(db, current_user.id, collected_media_ids, added=True)
     return {"status": "ok", "count": total_added}
 
 
@@ -2667,7 +2695,7 @@ async def uncollect_show(
             )
         )
         await db.commit()
-        await _push_collection_removal(db, current_user.id, set(episode_ids))
+        await _push_collection_change(db, current_user.id, set(episode_ids), added=False)
     return {"status": "ok"}
 
 
@@ -2705,7 +2733,7 @@ async def uncollect_season(
     )
     await db.commit()
 
-    await _push_collection_removal(db, current_user.id, set(episode_ids))
+    await _push_collection_change(db, current_user.id, set(episode_ids), added=False)
     return {"status": "ok"}
 
 
@@ -4106,6 +4134,7 @@ async def get_media_details(
                 await db.commit()
             # Check local info for library tags
             library_info = None
+            playable = False
             if local_ep:
                 coll_q = (
                     select(CollectionFile)
@@ -4114,7 +4143,14 @@ async def get_media_details(
                     .order_by(CollectionFile.added_at.desc())
                 )
                 coll_res = await db.execute(coll_q)
-                coll_file = coll_res.scalars().first()
+                coll_files = coll_res.scalars().all()
+                playable = any(
+                    coll_file.source in _PLAYABLE_COLLECTION_SOURCES
+                    and coll_file.connection_id is not None
+                    and coll_file.source_id is not None
+                    for coll_file in coll_files
+                )
+                coll_file = coll_files[0] if coll_files else None
                 if coll_file:
                     library_info = {
                         "resolution": coll_file.resolution,
@@ -4158,6 +4194,7 @@ async def get_media_details(
                 ],
                 "genres": (show.tmdb_data or {}).get("genres", []),
                 "in_library": ep_state.get("in_library", False),
+                "playable": playable,
                 "watched": ep_state.get("watched", False),
                 "in_lists": ep_state.get("in_lists", []),
                 "user_rating": ep_state.get("user_rating"),
@@ -4178,7 +4215,7 @@ async def get_media_details(
         media = all_media[0] if all_media else None
         all_media_ids = [m.id for m in all_media]
 
-        local_info = {"in_library": False, "library": None, "id": None}
+        local_info = {"in_library": False, "playable": False, "library": None, "id": None}
         if all_media:
             local_info["in_library"] = True
             local_info["id"] = media.id
@@ -4197,7 +4234,14 @@ async def get_media_details(
                 .order_by(CollectionFile.added_at.desc())
             )
             coll_res = await db.execute(coll_q)
-            coll_file = coll_res.scalars().first()
+            coll_files = coll_res.scalars().all()
+            local_info["playable"] = any(
+                coll_file.source in _PLAYABLE_COLLECTION_SOURCES
+                and coll_file.connection_id is not None
+                and coll_file.source_id is not None
+                for coll_file in coll_files
+            )
+            coll_file = coll_files[0] if coll_files else None
             if coll_file:
                 local_info["library"] = {
                     "resolution": coll_file.resolution,

--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -396,7 +396,9 @@ async def _ensure_nuvio_imdb_ids(
     media_rows: list[Media],
     shows_by_id: dict[int, Show],
     api_key: str | None,
+    shows_by_tmdb: dict[int, Show] | None = None,
 ) -> None:
+    shows_by_tmdb = shows_by_tmdb or {}
     if not api_key:
         return
 
@@ -406,9 +408,16 @@ async def _ensure_nuvio_imdb_ids(
             show = shows_by_id.get(media.show_id)
             if show and show.tmdb_id and not _nuvio_imdb_id(show):
                 targets[("tv", show.tmdb_id)] = show
-        elif media.tmdb_id and not _nuvio_imdb_id(media):
+        elif media.tmdb_id:
+            entity: Media | Show = (
+                shows_by_tmdb.get(media.tmdb_id)
+                if media.media_type == MediaType.series
+                else media
+            ) or media
+            if _nuvio_imdb_id(entity):
+                continue
             target_type = "movie" if media.media_type == MediaType.movie else "tv"
-            targets[(target_type, media.tmdb_id)] = media
+            targets[(target_type, media.tmdb_id)] = entity
     if not targets:
         return
 
@@ -443,11 +452,7 @@ async def _ensure_nuvio_imdb_ids(
     )
     logger.info("Resolved %s outbound Nuvio IMDb identifiers through TMDB", len(targets))
 def _nuvio_library_content_id(media: Media, show: Show | None = None) -> str | None:
-    if media.media_type == MediaType.episode:
-        tmdb_id = show.tmdb_id if show else None
-    else:
-        tmdb_id = media.tmdb_id
-    return f"tmdb:{tmdb_id}" if tmdb_id else None
+    return _nuvio_imdb_id(show or media)
 
 
 def _nuvio_genres(entity: Media | Show) -> list[str]:
@@ -493,6 +498,7 @@ def _nuvio_library_item(
 async def _build_nuvio_library_items(
     db: AsyncSession,
     user_id: int,
+    api_key: str | None = None,
 ) -> list[dict]:
     result = await db.execute(
         select(Collection.added_at, Media)
@@ -531,6 +537,12 @@ async def _build_nuvio_library_items(
             for show in series_shows
             if show.tmdb_id is not None
         }
+    await _ensure_nuvio_imdb_ids(
+        [media for _, media in rows],
+        shows_by_id,
+        api_key,
+        shows_by_tmdb,
+    )
 
     items_by_content_id: dict[str, dict] = {}
     for added_at, media in rows:
@@ -840,22 +852,67 @@ async def _fan_out_changes_to_other_connections(
                 return await coro
 
         nuvio_watched_items: list[dict] | None = None
+        has_nuvio_collection_target = any(
+            conn.type == "nuvio" and conn.push_collection
+            for conn in push_candidates
+        )
         nuvio_api_key = (
             await _get_effective_tmdb_key(db, settings)
-            if any(conn.type == "nuvio" and conn.push_watched for conn in push_candidates)
+            if any(
+                conn.type == "nuvio" and (conn.push_watched or conn.push_collection)
+                for conn in push_candidates
+            )
             else None
         )
         collection_changed_ids = new_collected_ids | removed_collected_ids
+        collection_shows_by_tmdb: dict[int, Show] = {}
+        if has_nuvio_collection_target:
+            collection_series_tmdb_ids = {
+                media.tmdb_id
+                for media_id in collection_changed_ids
+                if (media := media_by_id.get(media_id))
+                if media.media_type == MediaType.series and media.tmdb_id is not None
+            }
+            if collection_series_tmdb_ids:
+                collection_shows = await _select_in_chunks(
+                    db,
+                    lambda chunk: select(Show).where(Show.tmdb_id.in_(chunk)),
+                    list(collection_series_tmdb_ids),
+                )
+                collection_shows_by_tmdb = {
+                    show.tmdb_id: show
+                    for show in collection_shows
+                    if show.tmdb_id is not None
+                }
+            await _ensure_nuvio_imdb_ids(
+                [
+                    media
+                    for media_id in collection_changed_ids
+                    if (media := media_by_id.get(media_id))
+                ],
+                shows_by_id,
+                nuvio_api_key,
+                collection_shows_by_tmdb,
+            )
         nuvio_changed_content_ids = {
             content_id
             for media_id in collection_changed_ids
             if (media := media_by_id.get(media_id))
-            if (content_id := _nuvio_library_content_id(media, shows_by_id.get(media.show_id)))
+            if (
+                content_id := _nuvio_library_content_id(
+                    media,
+                    (
+                        shows_by_id.get(media.show_id)
+                        if media.media_type == MediaType.episode
+                        else collection_shows_by_tmdb.get(media.tmdb_id)
+                    ),
+                )
+            )
         }
         nuvio_library_items = (
-            await _build_nuvio_library_items(db, user_id)
+            await _build_nuvio_library_items(db, user_id, api_key=nuvio_api_key)
             if nuvio_changed_content_ids
-            and any(conn.type == "nuvio" and conn.push_collection for conn in push_candidates)
+            and has_nuvio_collection_target
             else []
         )
 
@@ -3493,7 +3550,7 @@ async def _run_full_push(user_id: int, connection_id: int, job_id: int) -> None:
                 user_settings = settings_result.scalar_one_or_none()
                 api_key = await _get_effective_tmdb_key(db, user_settings)
                 library_items = (
-                    await _build_nuvio_library_items(db, user_id)
+                    await _build_nuvio_library_items(db, user_id, api_key=api_key)
                     if conn.push_collection
                     else []
                 )

--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -46,6 +46,7 @@ router = APIRouter()
 
 # Global semaphore — at most one sync running at a time across all users
 _sync_semaphore = asyncio.Semaphore(1)
+_nuvio_push_locks: dict[int, asyncio.Lock] = {}
 
 BATCH_SIZE = 500
 TMDB_CONCURRENCY = 5  # Max concurrent TMDB requests
@@ -441,6 +442,112 @@ async def _ensure_nuvio_imdb_ids(
         ]
     )
     logger.info("Resolved %s outbound Nuvio IMDb identifiers through TMDB", len(targets))
+def _nuvio_library_content_id(media: Media, show: Show | None = None) -> str | None:
+    if media.media_type == MediaType.episode:
+        tmdb_id = show.tmdb_id if show else None
+    else:
+        tmdb_id = media.tmdb_id
+    return f"tmdb:{tmdb_id}" if tmdb_id else None
+
+
+def _nuvio_genres(entity: Media | Show) -> list[str]:
+    raw_genres = (entity.tmdb_data or {}).get("genres") or []
+    genres: list[str] = []
+    for genre in raw_genres:
+        name = genre.get("name") if isinstance(genre, dict) else genre
+        if name:
+            genres.append(str(name))
+    return genres
+
+
+def _nuvio_library_item(
+    media: Media,
+    added_at: datetime,
+    show: Show | None = None,
+) -> dict | None:
+    content_id = _nuvio_library_content_id(media, show)
+    if not content_id:
+        return None
+    entity: Media | Show = show if media.media_type == MediaType.episode and show else media
+    added = added_at if added_at.tzinfo else added_at.replace(tzinfo=timezone.utc)
+    release_date = (
+        entity.first_air_date
+        if isinstance(entity, Show)
+        else entity.release_date
+    )
+    return {
+        "content_id": content_id,
+        "content_type": "movie" if media.media_type == MediaType.movie else "series",
+        "name": entity.title,
+        "poster": entity.poster_path,
+        "poster_shape": "poster",
+        "background": entity.backdrop_path,
+        "description": entity.overview,
+        "release_info": str(release_date or "")[:4] or None,
+        "imdb_rating": entity.tmdb_rating,
+        "genres": _nuvio_genres(entity),
+        "added_at": int(added.timestamp() * 1000),
+    }
+
+
+async def _build_nuvio_library_items(
+    db: AsyncSession,
+    user_id: int,
+) -> list[dict]:
+    result = await db.execute(
+        select(Collection.added_at, Media)
+        .join(Media, Media.id == Collection.media_id)
+        .where(Collection.user_id == user_id)
+        .order_by(Collection.added_at, Collection.id)
+    )
+    rows = result.all()
+    show_ids = {
+        media.show_id
+        for _, media in rows
+        if media.media_type == MediaType.episode and media.show_id is not None
+    }
+    shows_by_id: dict[int, Show] = {}
+    if show_ids:
+        shows = await _select_in_chunks(
+            db,
+            lambda chunk: select(Show).where(Show.id.in_(chunk)),
+            list(show_ids),
+        )
+        shows_by_id = {show.id: show for show in shows}
+
+    items_by_content_id: dict[str, dict] = {}
+    for added_at, media in rows:
+        item = _nuvio_library_item(media, added_at, shows_by_id.get(media.show_id))
+        if item:
+            items_by_content_id.setdefault(item["content_id"], item)
+    return list(items_by_content_id.values())
+
+
+async def _push_nuvio_library_delta(
+    conn: MediaServerConnection,
+    current_items: list[dict],
+    changed_content_ids: set[str],
+) -> bool:
+    items_by_id = {item["content_id"]: item for item in current_items}
+    additions = [
+        items_by_id[content_id]
+        for content_id in changed_content_ids
+        if content_id in items_by_id
+    ]
+    removals = changed_content_ids - items_by_id.keys()
+    lock = _nuvio_push_locks.setdefault(conn.id, asyncio.Lock())
+    async with lock:
+        session, _ = await nuvio.merge_library(
+            conn.url,
+            conn.token,
+            _nuvio_profile_id(conn),
+            additions=additions,
+            removed_content_ids=set(removals),
+        )
+        conn.token = session.refresh_token
+    return True
+
+
 
 
 def _nuvio_watched_item(
@@ -674,7 +781,11 @@ async def _fan_out_changes_to_other_connections(
         select(MediaServerConnection).where(*conns_filter)
     )
     other_conns = other_conns_result.scalars().all()
-    push_candidates = [c for c in other_conns if c.push_watched or c.push_ratings]
+    push_candidates = [
+        conn
+        for conn in other_conns
+        if getattr(conn, "push_collection", False) or conn.push_watched or conn.push_ratings
+    ]
 
     push_tasks = []
     server_rating_changes = {key: 0.0 for key in removed_ratings}
@@ -712,15 +823,30 @@ async def _fan_out_changes_to_other_connections(
             if any(conn.type == "nuvio" and conn.push_watched for conn in push_candidates)
             else None
         )
+        collection_changed_ids = new_collected_ids | removed_collected_ids
+        nuvio_changed_content_ids = {
+            content_id
+            for media_id in collection_changed_ids
+            if (media := media_by_id.get(media_id))
+            if (content_id := _nuvio_library_content_id(media, shows_by_id.get(media.show_id)))
+        }
+        nuvio_library_items = (
+            await _build_nuvio_library_items(db, user_id)
+            if nuvio_changed_content_ids
+            and any(conn.type == "nuvio" and conn.push_collection for conn in push_candidates)
+            else []
+        )
 
         async def _push_to_nuvio(conn: MediaServerConnection, items: list[dict]) -> bool:
-            session = await nuvio.push_watched_items(
-                conn.url,
-                conn.token,
-                _nuvio_profile_id(conn),
-                items,
-            )
-            conn.token = session.refresh_token
+            lock = _nuvio_push_locks.setdefault(conn.id, asyncio.Lock())
+            async with lock:
+                session = await nuvio.push_watched_items(
+                    conn.url,
+                    conn.token,
+                    _nuvio_profile_id(conn),
+                    items,
+                )
+                conn.token = session.refresh_token
             return True
 
         for conn in push_candidates:
@@ -735,6 +861,16 @@ async def _fan_out_changes_to_other_connections(
                         )
                     if nuvio_watched_items:
                         push_tasks.append(_guarded(_push_to_nuvio(conn, nuvio_watched_items)))
+                if conn.push_collection and nuvio_changed_content_ids:
+                    push_tasks.append(
+                        _guarded(
+                            _push_nuvio_library_delta(
+                                conn,
+                                nuvio_library_items,
+                                nuvio_changed_content_ids,
+                            )
+                        )
+                    )
                 continue
             conn_source = CollectionSource(conn.type)
             if conn.push_watched:
@@ -2594,6 +2730,108 @@ def _normalize_nuvio_item(
     return media_type, item
 
 
+async def _apply_nuvio_watch_history(
+    db: AsyncSession,
+    user_id: int,
+    rows: list[dict],
+    show_map: dict[str, int],
+    tmdb_ids: dict[str, int],
+) -> set[int]:
+    standalone_tmdb_ids = {
+        tmdb_id
+        for row in rows
+        if (
+            str(row.get("content_type") or "").lower() == "movie"
+            or (row.get("season") is None and row.get("episode") is None)
+        )
+        if (tmdb_id := tmdb_ids.get(str(row.get("content_id") or ""))) is not None
+    }
+    standalone_by_key: dict[tuple[MediaType, int], Media] = {}
+    if standalone_tmdb_ids:
+        result = await db.execute(
+            select(Media).where(
+                Media.media_type.in_([MediaType.movie, MediaType.series]),
+                Media.tmdb_id.in_(standalone_tmdb_ids),
+            )
+        )
+        standalone_by_key = {
+            (media.media_type, media.tmdb_id): media
+            for media in result.scalars().all()
+            if media.tmdb_id is not None
+        }
+
+    show_ids = set(show_map.values())
+    episodes_by_key: dict[tuple[int, int, int], Media] = {}
+    if show_ids:
+        result = await db.execute(
+            select(Media).where(
+                Media.media_type == MediaType.episode,
+                Media.show_id.in_(show_ids),
+            )
+        )
+        episodes_by_key = {
+            (media.show_id, media.season_number, media.episode_number): media
+            for media in result.scalars().all()
+            if media.show_id is not None
+            and media.season_number is not None
+            and media.episode_number is not None
+        }
+
+    candidates: list[tuple[Media, datetime]] = []
+    for row in rows:
+        content_id = str(row.get("content_id") or "")
+        tmdb_id = tmdb_ids.get(content_id)
+        watched_at = _nuvio_datetime(row.get("watched_at"))
+        if tmdb_id is None or watched_at is None:
+            continue
+        content_type = str(row.get("content_type") or "").lower()
+        season = row.get("season")
+        episode = row.get("episode")
+        if content_type == "movie":
+            media = standalone_by_key.get((MediaType.movie, tmdb_id))
+        elif season is None or episode is None:
+            media = standalone_by_key.get((MediaType.series, tmdb_id))
+        else:
+            show_id = show_map.get(content_id)
+            media = (
+                episodes_by_key.get((show_id, int(season), int(episode)))
+                if show_id is not None
+                else None
+            )
+        if media is not None:
+            candidates.append((media, watched_at))
+
+    if not candidates:
+        return set()
+    media_ids = {media.id for media, _ in candidates}
+    existing_result = await db.execute(
+        select(WatchEvent.media_id, WatchEvent.watched_at).where(
+            WatchEvent.user_id == user_id,
+            WatchEvent.media_id.in_(media_ids),
+        )
+    )
+    existing = set(existing_result.all())
+    added_media_ids: set[int] = set()
+    for media, watched_at in candidates:
+        key = (media.id, watched_at)
+        if key in existing:
+            continue
+        db.add(
+            WatchEvent(
+                user_id=user_id,
+                media_id=media.id,
+                watched_at=watched_at,
+                completed=True,
+                play_count=1,
+                progress_percent=1.0,
+            )
+        )
+        existing.add(key)
+        added_media_ids.add(media.id)
+    await db.commit()
+    return added_media_ids
+
+
 async def _apply_nuvio_progress(
     db: AsyncSession,
     user_id: int,
@@ -2893,7 +3131,7 @@ async def _run_nuvio_sync(
                     normalized_watched,
                     media_type,
                     sync_collection=False,
-                    sync_watched=True,
+                    sync_watched=False,
                 )
             for media_type in (MediaType.movie, MediaType.series, MediaType.episode):
                 await sync_group(
@@ -2901,6 +3139,17 @@ async def _run_nuvio_sync(
                     media_type,
                     sync_collection=False,
                     sync_watched=False,
+                )
+
+            if watched_records:
+                new_watched_ids.update(
+                    await _apply_nuvio_watch_history(
+                        db,
+                        user_id,
+                        watched_records,
+                        show_map,
+                        tmdb_ids,
+                    )
                 )
 
             if progress_records:
@@ -3221,6 +3470,11 @@ async def _run_full_push(user_id: int, connection_id: int, job_id: int) -> None:
                 )
                 user_settings = settings_result.scalar_one_or_none()
                 api_key = await _get_effective_tmdb_key(db, user_settings)
+                library_items = (
+                    await _build_nuvio_library_items(db, user_id)
+                    if conn.push_collection
+                    else []
+                )
                 watched_items = (
                     await _build_nuvio_watched_items(db, user_id, api_key=api_key)
                     if conn.push_watched
@@ -3231,22 +3485,36 @@ async def _run_full_push(user_id: int, connection_id: int, job_id: int) -> None:
                     if conn.push_playback
                     else []
                 )
-                total = len(watched_items) + len(progress_items)
+                total = len(library_items) + len(watched_items) + len(progress_items)
                 await db.execute(
                     update(SyncJob)
                     .where(SyncJob.id == job_id)
                     .values(total_items=total, processed_items=0)
                 )
                 await db.commit()
-                if watched_items or progress_items:
-                    session = await nuvio.push_sync_items(
-                        conn.url,
-                        conn.token,
-                        _nuvio_profile_id(conn),
-                        watched_items,
-                        progress_items,
-                    )
-                    conn.token = session.refresh_token
+
+                lock = _nuvio_push_locks.setdefault(conn.id, asyncio.Lock())
+                async with lock:
+                    token = conn.token
+                    if conn.push_collection:
+                        session = await nuvio.push_library(
+                            conn.url,
+                            token,
+                            _nuvio_profile_id(conn),
+                            library_items,
+                        )
+                        token = session.refresh_token
+                    if watched_items or progress_items:
+                        session = await nuvio.push_sync_items(
+                            conn.url,
+                            token,
+                            _nuvio_profile_id(conn),
+                            watched_items,
+                            progress_items,
+                        )
+                        token = session.refresh_token
+                    conn.token = token
+
                 await db.execute(
                     update(SyncJob)
                     .where(SyncJob.id == job_id)
@@ -3256,6 +3524,7 @@ async def _run_full_push(user_id: int, connection_id: int, job_id: int) -> None:
                         stats={
                             "succeeded": total,
                             "failed": 0,
+                            "collection": len(library_items),
                             "watched": len(watched_items),
                             "progress": len(progress_items),
                         },
@@ -3263,8 +3532,10 @@ async def _run_full_push(user_id: int, connection_id: int, job_id: int) -> None:
                 )
                 await db.commit()
                 logger.info(
-                    "Full Nuvio push for connection %s: %s watched and %s progress items",
+                    "Full Nuvio push for connection %s: %s collection, %s watched, "
+                    "and %s progress items",
                     connection_id,
+                    len(library_items),
                     len(watched_items),
                     len(progress_items),
                 )
@@ -3535,8 +3806,16 @@ async def push_upstream(
     current_user: User = Depends(get_current_user),
 ):
     conn = await _get_connection_or_404(db, connection_id, current_user.id)
-    if not conn.push_watched and not conn.push_ratings and not conn.push_playback:
-        raise HTTPException(status_code=400, detail="Enable 'Scrob → Server' push flags for this connection first")
+    if not (
+        conn.push_collection
+        or conn.push_watched
+        or conn.push_ratings
+        or conn.push_playback
+    ):
+        raise HTTPException(
+            status_code=400,
+            detail="Enable 'Scrob → Server' push flags for this connection first",
+        )
 
     source_map = {"jellyfin": CollectionSource.jellyfin, "emby": CollectionSource.emby, "plex": CollectionSource.plex, "nuvio": CollectionSource.nuvio}
     source = source_map.get(conn.type, CollectionSource.jellyfin)

--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -468,7 +468,7 @@ def _nuvio_library_item(
     content_id = _nuvio_library_content_id(media, show)
     if not content_id:
         return None
-    entity: Media | Show = show if media.media_type == MediaType.episode and show else media
+    entity: Media | Show = show or media
     added = added_at if added_at.tzinfo else added_at.replace(tzinfo=timezone.utc)
     release_date = (
         entity.first_air_date
@@ -478,7 +478,7 @@ def _nuvio_library_item(
     return {
         "content_id": content_id,
         "content_type": "movie" if media.media_type == MediaType.movie else "series",
-        "name": entity.title,
+        "name": media.title if media.media_type == MediaType.series else entity.title,
         "poster": entity.poster_path,
         "poster_shape": "poster",
         "background": entity.backdrop_path,
@@ -506,7 +506,13 @@ async def _build_nuvio_library_items(
         for _, media in rows
         if media.media_type == MediaType.episode and media.show_id is not None
     }
+    series_tmdb_ids = {
+        media.tmdb_id
+        for _, media in rows
+        if media.media_type == MediaType.series and media.tmdb_id is not None
+    }
     shows_by_id: dict[int, Show] = {}
+    shows_by_tmdb: dict[int, Show] = {}
     if show_ids:
         shows = await _select_in_chunks(
             db,
@@ -514,10 +520,26 @@ async def _build_nuvio_library_items(
             list(show_ids),
         )
         shows_by_id = {show.id: show for show in shows}
+    if series_tmdb_ids:
+        series_shows = await _select_in_chunks(
+            db,
+            lambda chunk: select(Show).where(Show.tmdb_id.in_(chunk)),
+            list(series_tmdb_ids),
+        )
+        shows_by_tmdb = {
+            show.tmdb_id: show
+            for show in series_shows
+            if show.tmdb_id is not None
+        }
 
     items_by_content_id: dict[str, dict] = {}
     for added_at, media in rows:
-        item = _nuvio_library_item(media, added_at, shows_by_id.get(media.show_id))
+        show = (
+            shows_by_id.get(media.show_id)
+            if media.media_type == MediaType.episode
+            else shows_by_tmdb.get(media.tmdb_id)
+        )
+        item = _nuvio_library_item(media, added_at, show)
         if item:
             items_by_content_id.setdefault(item["content_id"], item)
     return list(items_by_content_id.values())

--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -3576,11 +3576,17 @@ async def _run_full_push(user_id: int, connection_id: int, job_id: int) -> None:
                 async with lock:
                     token = conn.token
                     if conn.push_collection:
-                        session = await nuvio.push_library(
+                        # Merge rather than replace: a full/scheduled push only knows
+                        # the current local library, not what changed since last time,
+                        # so it must never drop remote-only items it can't account for.
+                        # Real removals still propagate through the real-time delta
+                        # push (_push_nuvio_library_delta) when an item is uncollected.
+                        session, _ = await nuvio.merge_library(
                             conn.url,
                             token,
                             _nuvio_profile_id(conn),
-                            library_items,
+                            additions=library_items,
+                            removed_content_ids=set(),
                         )
                         token = session.refresh_token
                     if watched_items or progress_items:

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -163,9 +163,11 @@ class MediaServerConnectionBase(BaseModel):
     sync_ratings: bool = True
     sync_playback: bool = True
     push_watched: bool = False
+    push_collection: bool = False
     push_playback: bool = False
     push_ratings: bool = False
     auto_sync_interval: Optional[float] = None
+    auto_push_interval: Optional[float] = None
     watchlist_to_radarr: bool = False
     watchlist_to_sonarr: bool = False
     watchlist_all_users: bool = False
@@ -189,9 +191,11 @@ class MediaServerConnectionUpdate(BaseModel):
     sync_ratings: Optional[bool] = None
     sync_playback: Optional[bool] = None
     push_watched: Optional[bool] = None
+    push_collection: Optional[bool] = None
     push_playback: Optional[bool] = None
     push_ratings: Optional[bool] = None
     auto_sync_interval: Optional[float] = None
+    auto_push_interval: Optional[float] = None
     watchlist_to_radarr: Optional[bool] = None
     watchlist_to_sonarr: Optional[bool] = None
     watchlist_all_users: Optional[bool] = None

--- a/backend/tests/test_nuvio.py
+++ b/backend/tests/test_nuvio.py
@@ -20,6 +20,7 @@ from routers.sync import (
     _apply_nuvio_watch_history,
     _ensure_nuvio_imdb_ids,
     _normalize_nuvio_item,
+    _nuvio_library_item,
     _nuvio_progress_item,
     _nuvio_watched_item,
 )
@@ -337,6 +338,9 @@ class NuvioClientTests(unittest.IsolatedAsyncioTestCase):
                             "content_type": "movie",
                             "name": "Old title",
                             "addon_base_url": "https://addon.example",
+                            "poster": "https://images.example/poster.jpg",
+                            "background": "https://images.example/background.jpg",
+                            "genres": ["Drama"],
                         },
                         {
                             "content_id": "tmdb:2",
@@ -361,7 +365,14 @@ class NuvioClientTests(unittest.IsolatedAsyncioTestCase):
                 "old-refresh",
                 1,
                 additions=[
-                    {"content_id": "tmdb:1", "content_type": "movie", "name": "New title"},
+                    {
+                        "content_id": "tmdb:1",
+                        "content_type": "movie",
+                        "name": "New title",
+                        "poster": "",
+                        "background": None,
+                        "genres": [],
+                    },
                     {"content_id": "tmdb:3", "content_type": "movie", "name": "Added"},
                 ],
                 removed_content_ids=set(),
@@ -373,6 +384,9 @@ class NuvioClientTests(unittest.IsolatedAsyncioTestCase):
         updated = next(item for item in pushed_items if item["content_id"] == "tmdb:1")
         self.assertEqual(updated["name"], "New title")
         self.assertEqual(updated["addon_base_url"], "https://addon.example")
+        self.assertEqual(updated["poster"], "https://images.example/poster.jpg")
+        self.assertEqual(updated["background"], "https://images.example/background.jpg")
+        self.assertEqual(updated["genres"], ["Drama"])
 
     async def test_push_library_replaces_snapshot_but_preserves_playback_metadata(self) -> None:
         pushed_items: list[dict] = []
@@ -562,6 +576,43 @@ class NuvioNormalizationTests(unittest.TestCase):
         self.assertEqual(item["UserData"]["Played"], True)
         self.assertEqual(item["UserData"]["PlayCount"], 1)
         self.assertIsNotNone(item["UserData"]["LastPlayedDate"])
+
+    def test_series_library_item_uses_canonical_show_artwork(self) -> None:
+        media = Media(
+            id=20,
+            tmdb_id=4607,
+            media_type=MediaType.series,
+            title="Lost : Les Disparus",
+            poster_path="",
+            backdrop_path="",
+        )
+        show = Show(
+            id=5,
+            tmdb_id=4607,
+            title="Lost",
+            poster_path="https://image.tmdb.org/t/p/w500/poster.jpg",
+            backdrop_path="https://image.tmdb.org/t/p/w1280/background.jpg",
+            overview="A mysterious island.",
+            first_air_date="2004-09-22",
+            tmdb_rating=8.0,
+            tmdb_data={"genres": [{"name": "Drama"}]},
+        )
+
+        item = _nuvio_library_item(
+            media,
+            datetime(2026, 7, 19, tzinfo=timezone.utc),
+            show,
+        )
+
+        self.assertIsNotNone(item)
+        self.assertEqual(item["name"], "Lost : Les Disparus")
+        self.assertEqual(item["poster"], show.poster_path)
+        self.assertEqual(item["background"], show.backdrop_path)
+        self.assertEqual(item["description"], show.overview)
+        self.assertEqual(item["release_info"], "2004")
+        self.assertEqual(item["imdb_rating"], 8.0)
+        self.assertEqual(item["genres"], ["Drama"])
+
 
     def test_imdb_content_uses_resolved_tmdb_id(self) -> None:
         normalized = _normalize_nuvio_item(

--- a/backend/tests/test_nuvio.py
+++ b/backend/tests/test_nuvio.py
@@ -437,12 +437,13 @@ class NuvioClientTests(unittest.IsolatedAsyncioTestCase):
 
 
 class NuvioCollectionFanoutTests(unittest.IsolatedAsyncioTestCase):
-    async def test_local_collection_addition_pushes_tmdb_item_to_nuvio(self) -> None:
+    async def test_local_collection_addition_pushes_imdb_item_to_nuvio(self) -> None:
         movie = Media(
             id=10,
             tmdb_id=1368337,
             media_type=MediaType.movie,
             title="The Odyssey",
+            tmdb_data={"external_ids": {"imdb_id": "tt33764258"}},
         )
         conn = SimpleNamespace(
             id=4,
@@ -466,10 +467,16 @@ class NuvioCollectionFanoutTests(unittest.IsolatedAsyncioTestCase):
             commit=AsyncMock(),
         )
 
-        with patch(
-            "routers.sync._push_nuvio_library_delta",
-            AsyncMock(return_value=True),
-        ) as push_delta:
+        with (
+            patch(
+                "routers.sync._get_effective_tmdb_key",
+                AsyncMock(return_value="tmdb-token"),
+            ),
+            patch(
+                "routers.sync._push_nuvio_library_delta",
+                AsyncMock(return_value=True),
+            ) as push_delta,
+        ):
             await _fan_out_changes_to_other_connections(
                 db,
                 user_id=7,
@@ -482,12 +489,12 @@ class NuvioCollectionFanoutTests(unittest.IsolatedAsyncioTestCase):
 
         push_delta.assert_awaited_once()
         _, current_items, changed_ids = push_delta.await_args.args
-        self.assertEqual(changed_ids, {"tmdb:1368337"})
+        self.assertEqual(changed_ids, {"tt33764258"})
         self.assertEqual(
             current_items,
             [
                 {
-                    "content_id": "tmdb:1368337",
+                    "content_id": "tt33764258",
                     "content_type": "movie",
                     "name": "The Odyssey",
                     "poster": None,
@@ -595,7 +602,10 @@ class NuvioNormalizationTests(unittest.TestCase):
             overview="A mysterious island.",
             first_air_date="2004-09-22",
             tmdb_rating=8.0,
-            tmdb_data={"genres": [{"name": "Drama"}]},
+            tmdb_data={
+                "genres": [{"name": "Drama"}],
+                "external_ids": {"imdb_id": "tt0411008"},
+            },
         )
 
         item = _nuvio_library_item(
@@ -605,6 +615,7 @@ class NuvioNormalizationTests(unittest.TestCase):
         )
 
         self.assertIsNotNone(item)
+        self.assertEqual(item["content_id"], "tt0411008")
         self.assertEqual(item["name"], "Lost : Les Disparus")
         self.assertEqual(item["poster"], show.poster_path)
         self.assertEqual(item["background"], show.backdrop_path)

--- a/backend/tests/test_nuvio.py
+++ b/backend/tests/test_nuvio.py
@@ -2,7 +2,8 @@ import json
 from datetime import datetime, timezone
 import os
 import unittest
-from unittest.mock import patch
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 
@@ -15,6 +16,8 @@ from models.media import Media
 from models.playback_progress import PlaybackProgress
 from models.show import Show
 from routers.sync import (
+    _fan_out_changes_to_other_connections,
+    _apply_nuvio_watch_history,
     _ensure_nuvio_imdb_ids,
     _normalize_nuvio_item,
     _nuvio_progress_item,
@@ -23,6 +26,18 @@ from routers.sync import (
 
 
 _REAL_ASYNC_CLIENT = httpx.AsyncClient
+
+class _Result:
+    def __init__(self, *, scalars=None, rows=None):
+        self._scalars = scalars or []
+        self._rows = rows or []
+
+    def scalars(self):
+        return _Result(rows=self._scalars)
+
+    def all(self):
+        return self._rows
+
 
 
 class NuvioClientTests(unittest.IsolatedAsyncioTestCase):
@@ -299,6 +314,229 @@ class NuvioClientTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(movie.tmdb_data["external_ids"]["imdb_id"], "tt0137523")
         self.assertEqual(show.tmdb_data["external_ids"]["imdb_id"], "tt14688458")
 
+
+    async def test_merge_library_preserves_unrelated_remote_items(self) -> None:
+        pushed_items: list[dict] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path == "/auth/v1/token":
+                return httpx.Response(
+                    200,
+                    json={
+                        "access_token": "access-token",
+                        "refresh_token": "rotated-refresh",
+                        "expires_in": 3600,
+                    },
+                )
+            if request.url.path.endswith("/sync_pull_library"):
+                return httpx.Response(
+                    200,
+                    json=[
+                        {
+                            "content_id": "tmdb:1",
+                            "content_type": "movie",
+                            "name": "Old title",
+                            "addon_base_url": "https://addon.example",
+                        },
+                        {
+                            "content_id": "tmdb:2",
+                            "content_type": "movie",
+                            "name": "Keep me",
+                        },
+                    ],
+                )
+            if request.url.path.endswith("/sync_push_library"):
+                pushed_items.extend(json.loads(request.content)["p_items"])
+                return httpx.Response(204)
+            return httpx.Response(404, json={"message": "unexpected request"})
+
+        transport = httpx.MockTransport(handler)
+        with patch.object(
+            nuvio.httpx,
+            "AsyncClient",
+            side_effect=lambda **kwargs: _REAL_ASYNC_CLIENT(transport=transport, **kwargs),
+        ):
+            session, count = await nuvio.merge_library(
+                "https://api.nuvio.tv",
+                "old-refresh",
+                1,
+                additions=[
+                    {"content_id": "tmdb:1", "content_type": "movie", "name": "New title"},
+                    {"content_id": "tmdb:3", "content_type": "movie", "name": "Added"},
+                ],
+                removed_content_ids=set(),
+            )
+
+        self.assertEqual(session.refresh_token, "rotated-refresh")
+        self.assertEqual(count, 3)
+        self.assertEqual({item["content_id"] for item in pushed_items}, {"tmdb:1", "tmdb:2", "tmdb:3"})
+        updated = next(item for item in pushed_items if item["content_id"] == "tmdb:1")
+        self.assertEqual(updated["name"], "New title")
+        self.assertEqual(updated["addon_base_url"], "https://addon.example")
+
+    async def test_push_library_replaces_snapshot_but_preserves_playback_metadata(self) -> None:
+        pushed_items: list[dict] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path == "/auth/v1/token":
+                return httpx.Response(
+                    200,
+                    json={
+                        "access_token": "access-token",
+                        "refresh_token": "rotated-refresh",
+                        "expires_in": 3600,
+                    },
+                )
+            if request.url.path.endswith("/sync_pull_library"):
+                return httpx.Response(
+                    200,
+                    json=[
+                        {
+                            "content_id": "tmdb:1",
+                            "content_type": "movie",
+                            "addon_base_url": "https://addon.example",
+                        },
+                        {"content_id": "tmdb:2", "content_type": "movie"},
+                    ],
+                )
+            if request.url.path.endswith("/sync_push_library"):
+                pushed_items.extend(json.loads(request.content)["p_items"])
+                return httpx.Response(204)
+            return httpx.Response(404, json={"message": "unexpected request"})
+
+        transport = httpx.MockTransport(handler)
+        with patch.object(
+            nuvio.httpx,
+            "AsyncClient",
+            side_effect=lambda **kwargs: _REAL_ASYNC_CLIENT(transport=transport, **kwargs),
+        ):
+            await nuvio.push_library(
+                "https://api.nuvio.tv",
+                "old-refresh",
+                1,
+                [{"content_id": "tmdb:1", "content_type": "movie", "name": "Only item"}],
+            )
+
+        self.assertEqual(len(pushed_items), 1)
+        self.assertEqual(pushed_items[0]["content_id"], "tmdb:1")
+        self.assertEqual(pushed_items[0]["addon_base_url"], "https://addon.example")
+
+
+class NuvioCollectionFanoutTests(unittest.IsolatedAsyncioTestCase):
+    async def test_local_collection_addition_pushes_tmdb_item_to_nuvio(self) -> None:
+        movie = Media(
+            id=10,
+            tmdb_id=1368337,
+            media_type=MediaType.movie,
+            title="The Odyssey",
+        )
+        conn = SimpleNamespace(
+            id=4,
+            type="nuvio",
+            url="https://api.nuvio.tv",
+            token="refresh-token",
+            server_user_id="1",
+            push_collection=True,
+            push_watched=False,
+            push_ratings=False,
+        )
+        db = SimpleNamespace(
+            execute=AsyncMock(
+                side_effect=[
+                    _Result(scalars=[movie]),
+                    _Result(scalars=[conn]),
+                    _Result(rows=[]),
+                    _Result(rows=[(datetime(2026, 7, 19, tzinfo=timezone.utc), movie)]),
+                ]
+            ),
+            commit=AsyncMock(),
+        )
+
+        with patch(
+            "routers.sync._push_nuvio_library_delta",
+            AsyncMock(return_value=True),
+        ) as push_delta:
+            await _fan_out_changes_to_other_connections(
+                db,
+                user_id=7,
+                exclude_connection_id=None,
+                new_watched_ids=set(),
+                new_ratings={},
+                settings=None,
+                new_collected_ids={movie.id},
+            )
+
+        push_delta.assert_awaited_once()
+        _, current_items, changed_ids = push_delta.await_args.args
+        self.assertEqual(changed_ids, {"tmdb:1368337"})
+        self.assertEqual(
+            current_items,
+            [
+                {
+                    "content_id": "tmdb:1368337",
+                    "content_type": "movie",
+                    "name": "The Odyssey",
+                    "poster": None,
+                    "poster_shape": "poster",
+                    "background": None,
+                    "description": None,
+                    "release_info": None,
+                    "imdb_rating": None,
+                    "genres": [],
+                    "added_at": 1784419200000,
+                }
+            ],
+        )
+
+
+class NuvioWatchHistoryTests(unittest.IsolatedAsyncioTestCase):
+    async def test_distinct_watch_timestamps_are_imported_idempotently(self) -> None:
+        movie = Media(id=10, tmdb_id=550, media_type=MediaType.movie, title="Fight Club")
+        db = SimpleNamespace(
+            execute=AsyncMock(
+                side_effect=[
+                    _Result(scalars=[movie]),
+                    _Result(rows=[]),
+                ]
+            ),
+            add=MagicMock(),
+            commit=AsyncMock(),
+        )
+        rows = [
+            {
+                "content_id": "tmdb:550",
+                "content_type": "movie",
+                "watched_at": 1711600000000,
+            },
+            {
+                "content_id": "tmdb:550",
+                "content_type": "movie",
+                "watched_at": 1711700000000,
+            },
+            {
+                "content_id": "tmdb:550",
+                "content_type": "movie",
+                "watched_at": 1711700000000,
+            },
+        ]
+
+        added = await _apply_nuvio_watch_history(
+            db,
+            user_id=7,
+            rows=rows,
+            show_map={},
+            tmdb_ids={"tmdb:550": 550},
+        )
+
+        self.assertEqual(added, {10})
+        self.assertEqual(db.add.call_count, 2)
+        self.assertEqual(
+            {call.args[0].watched_at for call in db.add.call_args_list},
+            {
+                datetime(2024, 3, 28, 4, 26, 40),
+                datetime(2024, 3, 29, 8, 13, 20),
+            },
+        )
 
 class NuvioNormalizationTests(unittest.TestCase):
     def test_episode_history_maps_to_tmdb_series_and_watch_state(self) -> None:

--- a/backend/tests/test_nuvio.py
+++ b/backend/tests/test_nuvio.py
@@ -23,6 +23,7 @@ from routers.sync import (
     _nuvio_library_item,
     _nuvio_progress_item,
     _nuvio_watched_item,
+    _run_full_push,
 )
 
 
@@ -38,6 +39,24 @@ class _Result:
 
     def all(self):
         return self._rows
+
+    def scalar_one_or_none(self):
+        return self._scalars[0] if self._scalars else None
+
+
+class _SessionCM:
+    """Fakes the `async with async_sessionmaker(...)() as db:` pattern used by
+    background job functions that open their own session instead of taking
+    `db` as a parameter."""
+
+    def __init__(self, db):
+        self._db = db
+
+    async def __aenter__(self):
+        return self._db
+
+    async def __aexit__(self, *exc_info):
+        return False
 
 
 
@@ -759,6 +778,93 @@ class NuvioNormalizationTests(unittest.TestCase):
             title="Fight Club",
         )
         self.assertIsNone(_nuvio_watched_item(tmdb_only_movie, watched_at))
+
+
+class NuvioFullPushTests(unittest.IsolatedAsyncioTestCase):
+    async def test_full_push_merges_instead_of_replacing_remote_library(self) -> None:
+        """Regression test: a scheduled/full push only knows the current local
+        library, not what changed since last time, so it must never drop a
+        remote-only item it can't account for — only the real-time delta push
+        (on an actual local removal) may do that."""
+        conn = SimpleNamespace(
+            id=4,
+            user_id=7,
+            type="nuvio",
+            url="https://api.nuvio.tv",
+            token="old-refresh",
+            server_user_id="1",
+            push_collection=True,
+            push_watched=False,
+            push_playback=False,
+        )
+        user_settings = SimpleNamespace(tmdb_api_key="tmdb-key")
+
+        db = SimpleNamespace(
+            execute=AsyncMock(
+                side_effect=[
+                    None,  # SyncJob status=running update
+                    _Result(scalars=[conn]),  # conn_result
+                    _Result(scalars=[user_settings]),  # settings_result
+                    None,  # SyncJob total_items update
+                    None,  # SyncJob status=completed update
+                ]
+            ),
+            commit=AsyncMock(),
+        )
+
+        pushed_items: list[dict] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path == "/auth/v1/token":
+                return httpx.Response(
+                    200,
+                    json={
+                        "access_token": "access-token",
+                        "refresh_token": "rotated-refresh",
+                        "expires_in": 3600,
+                    },
+                )
+            if request.url.path.endswith("/sync_pull_library"):
+                return httpx.Response(
+                    200,
+                    json=[
+                        {"content_id": "tmdb:1", "content_type": "movie", "name": "Local movie"},
+                        {"content_id": "tt9999999", "content_type": "movie", "name": "Added on Nuvio directly"},
+                    ],
+                )
+            if request.url.path.endswith("/sync_push_library"):
+                pushed_items.extend(json.loads(request.content)["p_items"])
+                return httpx.Response(204)
+            return httpx.Response(404, json={"message": "unexpected request"})
+
+        transport = httpx.MockTransport(handler)
+
+        with (
+            patch(
+                "routers.sync.async_sessionmaker",
+                lambda *args, **kwargs: (lambda: _SessionCM(db)),
+            ),
+            patch(
+                "routers.sync._build_nuvio_library_items",
+                AsyncMock(return_value=[
+                    {"content_id": "tmdb:1", "content_type": "movie", "name": "Local movie"},
+                ]),
+            ),
+            patch.object(
+                nuvio.httpx,
+                "AsyncClient",
+                side_effect=lambda **kwargs: _REAL_ASYNC_CLIENT(transport=transport, **kwargs),
+            ),
+        ):
+            await _run_full_push(user_id=7, connection_id=4, job_id=99)
+
+        # The remote-only item ("tt9999999", never known locally) must survive
+        # the push alongside the locally-known item, instead of being wiped by
+        # a hard snapshot replace.
+        self.assertEqual(
+            {item["content_id"] for item in pushed_items},
+            {"tmdb:1", "tt9999999"},
+        )
 
 
 if __name__ == "__main__":

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -445,9 +445,11 @@ export interface MediaServerConnection {
   sync_ratings: boolean;
   sync_playback: boolean;
   push_watched: boolean;
+  push_collection: boolean;
   push_playback: boolean;
   push_ratings: boolean;
   auto_sync_interval: number | null;
+  auto_push_interval: number | null;
   created_at: string;
 }
 
@@ -463,9 +465,11 @@ export interface MediaServerConnectionCreate {
   sync_ratings?: boolean;
   sync_playback?: boolean;
   push_watched?: boolean;
+  push_collection?: boolean;
   push_playback?: boolean;
   push_ratings?: boolean;
   auto_sync_interval?: number | null;
+  auto_push_interval?: number | null;
 }
 
 export type MediaServerConnectionUpdate = Partial<Omit<MediaServerConnectionCreate, "type">>;
@@ -543,6 +547,7 @@ export interface MediaItem {
   next_up_hidden?: boolean;
   known_for_department?: string | null;
   in_library?: boolean;
+  playable?: boolean;
   // Card action state
   watched?: boolean;
   in_lists?: number[];

--- a/frontend/src/pages/media/[type]/[id].astro
+++ b/frontend/src/pages/media/[type]/[id].astro
@@ -268,14 +268,16 @@ const refreshUrl = isEpisode
                     <span id="refresh-label">Refresh Metadata</span>
                   </button>
                 )}
-                <VideoPlayer
-                  tmdbId={item.tmdb_id}
-                  mediaType={item.type}
-                  inLibrary={item.in_library ?? false}
-                  title={item.title}
-                  token={token}
-                  secondary
-                />
+                {item.playable && (
+                  <VideoPlayer
+                    tmdbId={item.tmdb_id}
+                    mediaType={item.type}
+                    inLibrary={item.in_library ?? false}
+                    title={item.title}
+                    token={token}
+                    secondary
+                  />
+                )}
               </div>
             )}
 

--- a/frontend/src/pages/settings.astro
+++ b/frontend/src/pages/settings.astro
@@ -273,6 +273,7 @@ if (me.totp_enabled) {
                       <div class="bg-zinc-950 rounded-xl p-4 space-y-3">
                         <p class="text-xs font-semibold uppercase tracking-wide text-zinc-500">Scrob → {typeLabel}</p>
                         {[
+                          ...(conn.type === "nuvio" ? [{ key: "push_collection", label: "Collection status" }] : []),
                           { key: "push_watched", label: "Watched status" },
                           ...(conn.type === "nuvio" ? [{ key: "push_playback", label: "Playback progress" }] : []),
                           ...(conn.type === "nuvio" ? [] : [{ key: "push_ratings", label: "Ratings" }]),
@@ -289,7 +290,7 @@ if (me.totp_enabled) {
                         >Push</button>
                       </div>
                       <div class="bg-zinc-950 rounded-xl p-4 space-y-3">
-                        <p class="text-xs font-semibold uppercase tracking-wide text-zinc-500">Auto Pull</p>
+                        <p class="text-xs font-semibold uppercase tracking-wide text-zinc-500">Auto Sync</p>
                         <div class="flex items-center justify-between gap-4">
                           <label class="text-sm text-zinc-300">Pull interval</label>
                           <select class="conn-auto-sync bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2 text-sm text-zinc-100 focus:outline-none focus:ring-2 focus:ring-blue-500 transition-all cursor-pointer" data-conn-id={conn.id}>
@@ -305,6 +306,24 @@ if (me.totp_enabled) {
                               { value: 48, label: "Every 48h" },
                             ].map(({ value, label }) => (
                               <option value={String(value)} selected={conn.auto_sync_interval === value}>{label}</option>
+                            ))}
+                          </select>
+                        </div>
+                        <div class="flex items-center justify-between gap-4">
+                          <label class="text-sm text-zinc-300">Push interval</label>
+                          <select class="conn-auto-push bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2 text-sm text-zinc-100 focus:outline-none focus:ring-2 focus:ring-blue-500 transition-all cursor-pointer" data-conn-id={conn.id}>
+                            <option value="" selected={!conn.auto_push_interval}>Disabled</option>
+                            {[
+                              { value: 0.25, label: "Every 15m" },
+                              { value: 0.5, label: "Every 30m" },
+                              { value: 1, label: "Every 1h" },
+                              { value: 3, label: "Every 3h" },
+                              { value: 6, label: "Every 6h" },
+                              { value: 12, label: "Every 12h" },
+                              { value: 24, label: "Every 24h" },
+                              { value: 48, label: "Every 48h" },
+                            ].map(({ value, label }) => (
+                              <option value={String(value)} selected={conn.auto_push_interval === value}>{label}</option>
                             ))}
                           </select>
                         </div>
@@ -443,6 +462,10 @@ if (me.totp_enabled) {
                           <span class="text-sm text-zinc-300 group-hover:text-zinc-100 transition-colors">{label}</span>
                         </label>
                       ))}
+                      <label id="new-push-collection-row" class="hidden new-provider-pref flex items-center gap-3 cursor-pointer group">
+                        <input type="checkbox" id="new-push-collection" class="w-4 h-4 rounded cursor-pointer" disabled />
+                        <span class="text-sm text-zinc-300 group-hover:text-zinc-100 transition-colors">Collection status</span>
+                      </label>
                       <label id="new-push-playback-row" class="hidden new-provider-pref flex items-center gap-3 cursor-pointer group">
                         <input type="checkbox" id="new-push-playback" class="w-4 h-4 rounded cursor-pointer" disabled />
                         <span class="text-sm text-zinc-300 group-hover:text-zinc-100 transition-colors">Playback progress</span>
@@ -451,8 +474,24 @@ if (me.totp_enabled) {
                     <div class="bg-zinc-950 rounded-xl p-4 space-y-3">
                       <p class="text-xs font-semibold uppercase tracking-wide text-zinc-500">Auto Sync</p>
                       <div class="flex items-center justify-between gap-4">
-                        <label class="text-sm text-zinc-300">Sync interval</label>
+                        <label class="text-sm text-zinc-300">Pull interval</label>
                         <select id="new-auto-sync" class="bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2 text-sm text-zinc-100 cursor-pointer">
+                          <option value="">Disabled</option>
+                          {[
+                            { value: 0.25, label: "Every 15m" },
+                            { value: 0.5, label: "Every 30m" },
+                            { value: 1, label: "Every 1h" },
+                            { value: 3, label: "Every 3h" },
+                            { value: 6, label: "Every 6h" },
+                            { value: 12, label: "Every 12h" },
+                            { value: 24, label: "Every 24h" },
+                            { value: 48, label: "Every 48h" },
+                          ].map(({ value, label }) => (<option value={String(value)}>{label}</option>))}
+                        </select>
+                      </div>
+                      <div class="flex items-center justify-between gap-4">
+                        <label class="text-sm text-zinc-300">Push interval</label>
+                        <select id="new-auto-push" class="bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2 text-sm text-zinc-100 cursor-pointer">
                           <option value="">Disabled</option>
                           {[
                             { value: 0.25, label: "Every 15m" },
@@ -2590,6 +2629,10 @@ if (me.totp_enabled) {
                 const v = (card?.querySelector('.conn-auto-sync') as HTMLSelectElement)?.value;
                 return v ? parseFloat(v) : null;
               })(),
+              auto_push_interval: (() => {
+                const v = (card?.querySelector('.conn-auto-push') as HTMLSelectElement)?.value;
+                return v ? parseFloat(v) : null;
+              })(),
             };
             card?.querySelectorAll('.conn-pref-checkbox').forEach((cb: any) => {
               body[cb.getAttribute('data-pref')] = cb.checked;
@@ -3511,6 +3554,9 @@ if (me.totp_enabled) {
       const pushPlayback = document.getElementById('new-push-playback') as HTMLInputElement | null;
       pushPlayback?.closest('label')?.classList.toggle('hidden', !isNuvio);
       if (pushPlayback) pushPlayback.disabled = !isNuvio;
+      const pushCollection = document.getElementById('new-push-collection') as HTMLInputElement | null;
+      pushCollection?.closest('label')?.classList.toggle('hidden', !isNuvio);
+      if (pushCollection) pushCollection.disabled = !isNuvio;
       for (const checkbox of [syncRatings, pushRatings]) {
         checkbox?.closest('label')?.classList.toggle('hidden', isNuvio);
         if (checkbox) checkbox.disabled = isNuvio;
@@ -3623,10 +3669,15 @@ if (me.totp_enabled) {
             sync_ratings: type === 'nuvio' ? false : ((document.getElementById('new-sync-ratings') as HTMLInputElement)?.checked ?? true),
             sync_playback: (document.getElementById('new-sync-playback') as HTMLInputElement)?.checked ?? true,
             push_watched: (document.getElementById('new-push-watched') as HTMLInputElement)?.checked ?? false,
+            push_collection: type === 'nuvio' && ((document.getElementById('new-push-collection') as HTMLInputElement)?.checked ?? false),
             push_playback: type === 'nuvio' && ((document.getElementById('new-push-playback') as HTMLInputElement)?.checked ?? false),
             push_ratings: type === 'nuvio' ? false : ((document.getElementById('new-push-ratings') as HTMLInputElement)?.checked ?? false),
             auto_sync_interval: (() => {
               const value = (document.getElementById('new-auto-sync') as HTMLSelectElement)?.value;
+              return value ? parseFloat(value) : null;
+            })(),
+            auto_push_interval: (() => {
+              const value = (document.getElementById('new-auto-push') as HTMLSelectElement)?.value;
               return value ? parseFloat(value) : null;
             })(),
           };


### PR DESCRIPTION
## Summary
- make Nuvio collection synchronization bidirectional and non-destructive by merging local additions/removals into the remote snapshot
- use canonical bare IMDb IDs for Nuvio library items and enrich series artwork/metadata from Scrob's canonical show records
- preserve existing remote artwork when an incoming optional metadata field is blank
- split automatic pull and push schedules for every media-server provider; expose separate Pull interval and Push interval controls
- keep Nuvio-only library entries non-playable unless a real Plex/Jellyfin/Emby source exists
- preserve every Nuvio watch-history timestamp instead of collapsing repeated plays

## Validation
- `python -m unittest discover -s tests -v` — 46 tests passed on the PR branch
- combined local branch with episode-order changes — 51 tests passed
- `npm run build` — Astro production build passed
- fresh Docker/PostgreSQL migration through `z0a1b2c3d4e5` — container healthy
- existing Nuvio connection UI shows Collection status, Playback progress, Pull interval, and Push interval
- real Nuvio full push completed: 21 collection items, 6,307 total payload records, 0 failures
- remote verification: all 21 library IDs are bare IMDb IDs and all 21 have poster URLs
- verified samples: The Odyssey `tt33764258` and Lost `tt0411008` contain TMDB poster and background URLs
