### PR TITLE
fix(trakt): make history sync incremental and idempotent

### DIFF
--- a/backend/core/trakt.py
+++ b/backend/core/trakt.py
@@ -19,18 +19,18 @@ TRAKT_BASE = "https://api.trakt.tv"
 TIMEOUT = 30.0
 PAGE_SIZE = 250
 
-
 def _iso_utc(value: datetime) -> str:
-    """Format a datetime as an ISO-8601 UTC string with a Z suffix.
+    """Format a datetime as ISO-8601 UTC with millisecond precision.
 
-    WatchEvent.watched_at is stored naive but always represents UTC, so a
-    naive value is treated as already-UTC rather than the local timezone.
+    WatchEvent timestamps are stored as naive UTC values. Millisecond precision
+    matches Trakt's history responses and keeps local/remote idempotency keys stable.
     """
     if value.tzinfo is None:
         value = value.replace(tzinfo=timezone.utc)
     else:
         value = value.astimezone(timezone.utc)
-    return value.replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    return value.isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
 
 
 async def _get_all_pages(
@@ -169,38 +169,45 @@ async def validate_token(client_id: str, access_token: str) -> bool:
 
 # ── User Data Fetching ────────────────────────────────────────────────────────
 
-async def get_history_movies(client_id: str, access_token: str) -> list[dict]:
-    """Fetch every individual movie play from the user's watch history.
-
-    Unlike /sync/watched/movies (which collapses all plays of a title into a
-    single {plays, last_watched_at} row), /sync/history/movies returns one
-    entry per play, each with its own id and watched_at — required to import
-    more than the most recent play of a title.
-
-    Returns list of: {id, watched_at, movie: {title, ids: {tmdb, ...}}}
-    """
+async def get_history_movies(
+    client_id: str,
+    access_token: str,
+    start_at: datetime | None = None,
+    end_at: datetime | None = None,
+) -> list[dict]:
+    """Fetch individual movie plays, optionally bounded by a UTC time window."""
+    params = {
+        key: _iso_utc(value)
+        for key, value in (("start_at", start_at), ("end_at", end_at))
+        if value is not None
+    }
     async with httpx.AsyncClient(timeout=60.0) as client:
         return await _get_all_pages(
             client,
             "/sync/history/movies",
             _headers(client_id, access_token),
+            params,
         )
 
 
-async def get_history_episodes(client_id: str, access_token: str) -> list[dict]:
-    """Fetch every individual episode play from the user's watch history.
-
-    See get_history_movies() for why /sync/history is used instead of the
-    aggregated /sync/watched/shows endpoint.
-
-    Returns list of: {id, watched_at, episode: {season, number, ids},
-                       show: {title, ids: {tmdb, ...}}}
-    """
+async def get_history_episodes(
+    client_id: str,
+    access_token: str,
+    start_at: datetime | None = None,
+    end_at: datetime | None = None,
+) -> list[dict]:
+    """Fetch individual episode plays, optionally bounded by a UTC time window."""
+    params = {
+        key: _iso_utc(value)
+        for key, value in (("start_at", start_at), ("end_at", end_at))
+        if value is not None
+    }
     async with httpx.AsyncClient(timeout=120.0) as client:
         return await _get_all_pages(
             client,
             "/sync/history/episodes",
             _headers(client_id, access_token),
+            params,
         )
 
 
@@ -271,6 +278,7 @@ async def add_to_history_batch(
             headers=_headers(client_id, access_token),
         )
         resp.raise_for_status()
+
 
 
 async def add_to_collection_batch(

--- a/backend/migrations/versions/b6c7d8e9f0a1_add_trakt_history_cursor.py
+++ b/backend/migrations/versions/b6c7d8e9f0a1_add_trakt_history_cursor.py
@@ -1,0 +1,26 @@
+"""add Trakt history cursor
+
+Revision ID: b6c7d8e9f0a1
+Revises: a9b8c7d6e5f4
+Create Date: 2026-07-26
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "b6c7d8e9f0a1"
+down_revision = "a9b8c7d6e5f4"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "user_settings",
+        sa.Column("trakt_history_cursor_at", sa.DateTime(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("user_settings", "trakt_history_cursor_at")

--- a/backend/models/users.py
+++ b/backend/models/users.py
@@ -78,6 +78,7 @@ class UserSettings(Base):
     # Trakt inbound sync flags (Trakt → Scrob)
     trakt_sync_watched       : Mapped[bool] = mapped_column(Boolean, nullable=False, default=True, server_default="true")
     trakt_sync_ratings       : Mapped[bool] = mapped_column(Boolean, nullable=False, default=True, server_default="true")
+    trakt_history_cursor_at  : Mapped[Optional[datetime]] = mapped_column(DateTime)
 
     # Trakt outbound push flags (Scrob → Trakt)
     trakt_push_watched       : Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="false")

--- a/backend/routers/trakt.py
+++ b/backend/routers/trakt.py
@@ -9,9 +9,9 @@ Endpoints:
 
 import asyncio
 import logging
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
@@ -35,6 +35,50 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 TMDB_CONCURRENCY = 10
+TRAKT_HISTORY_OVERLAP = timedelta(minutes=5)
+TRAKT_HISTORY_PUSH_BATCH_SIZE = 100
+
+
+def _normalize_history_time(value: datetime) -> datetime:
+    if value.tzinfo is not None:
+        value = value.astimezone(timezone.utc).replace(tzinfo=None)
+    return value.replace(microsecond=(value.microsecond // 1000) * 1000)
+
+
+def _history_window(
+    cursor: datetime | None,
+    full_resync: bool,
+    cutoff: datetime,
+) -> tuple[datetime | None, datetime]:
+    start_at = None if full_resync or cursor is None else cursor - TRAKT_HISTORY_OVERLAP
+    return start_at, cutoff
+
+
+def _remote_history_keys(
+    movies: list[dict],
+    episodes: list[dict],
+) -> set[tuple]:
+    keys: set[tuple] = set()
+    for item in movies:
+        tmdb_id = item.get("movie", {}).get("ids", {}).get("tmdb")
+        watched_at = _parse_trakt_datetime(item.get("watched_at"))
+        if tmdb_id and watched_at:
+            keys.add(("movie", int(tmdb_id), _normalize_history_time(watched_at)))
+    for item in episodes:
+        show_tmdb_id = item.get("show", {}).get("ids", {}).get("tmdb")
+        episode = item.get("episode", {})
+        season = episode.get("season")
+        number = episode.get("number")
+        watched_at = _parse_trakt_datetime(item.get("watched_at"))
+        if show_tmdb_id and season is not None and number is not None and watched_at:
+            keys.add((
+                "episode",
+                int(show_tmdb_id),
+                int(season),
+                int(number),
+                _normalize_history_time(watched_at),
+            ))
+    return keys
 
 
 def _parse_trakt_datetime(value: str | None) -> datetime | None:
@@ -119,6 +163,7 @@ async def trakt_device_poll(
     settings.trakt_refresh_token = token_data["refresh_token"]
     settings.trakt_token_expires_at = token_data.get("expires_in", 0) + int(datetime.now(timezone.utc).timestamp())
     settings.trakt_device_code = None
+    settings.trakt_history_cursor_at = None
     await db.commit()
 
     return {"status": "connected"}
@@ -144,6 +189,7 @@ async def trakt_disconnect(
         settings.trakt_refresh_token = None
         settings.trakt_token_expires_at = None
         settings.trakt_device_code = None
+        settings.trakt_history_cursor_at = None
         await db.commit()
 
     return {"status": "disconnected"}
@@ -322,7 +368,7 @@ async def _get_or_create_episode_media(
         return None
 
 
-async def run_trakt_sync(user_id: int, job_id: int):
+async def run_trakt_sync(user_id: int, job_id: int, full_resync: bool = False):
     from routers.sync import SyncCancelled, _raise_if_cancelled
     print(f"Starting Trakt sync for user {user_id}, job {job_id}")
     async_session = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
@@ -386,6 +432,15 @@ async def run_trakt_sync(user_id: int, job_id: int):
             _new_watched: set[int] = set()
             _new_ratings: RatingChanges = {}
             watched_processed = 0
+            history_cutoff = datetime.now(timezone.utc).replace(tzinfo=None)
+            history_start, history_end = _history_window(
+                getattr(settings, "trakt_history_cursor_at", None),
+                full_resync,
+                history_cutoff,
+            )
+            history_error_count = stats["errors"]
+            history_had_errors = False
+            stats["history_mode"] = "full" if history_start is None else "incremental"
 
             # ── Watched Movies ────────────────────────────────────────────────
             # Uses /sync/history (one row per play) rather than /sync/watched
@@ -393,7 +448,12 @@ async def run_trakt_sync(user_id: int, job_id: int):
             # gets its own WatchEvent instead of only the most recent one.
             if sync_watched:
                 print(f"  Fetching movie watch history from Trakt...")
-                history_movies = await trakt_client.get_history_movies(client_id, access_token)
+                history_movies = await trakt_client.get_history_movies(
+                    client_id,
+                    access_token,
+                    start_at=history_start,
+                    end_at=history_end,
+                )
                 print(f"  {len(history_movies)} movie plays fetched from Trakt")
                 await db.execute(update(SyncJob).where(SyncJob.id == job_id).values(total_items=len(history_movies)))
                 await db.commit()
@@ -456,7 +516,12 @@ async def run_trakt_sync(user_id: int, job_id: int):
             # one row per play instead of one aggregated row per episode.
             if sync_watched:
                 print(f"  Fetching episode watch history from Trakt...")
-                history_episodes = await trakt_client.get_history_episodes(client_id, access_token)
+                history_episodes = await trakt_client.get_history_episodes(
+                    client_id,
+                    access_token,
+                    start_at=history_start,
+                    end_at=history_end,
+                )
                 print(f"  {len(history_episodes)} episode plays fetched from Trakt")
 
                 await db.execute(update(SyncJob).where(SyncJob.id == job_id).values(
@@ -538,6 +603,7 @@ async def run_trakt_sync(user_id: int, job_id: int):
                         await db.commit()
                         await _raise_if_cancelled(db, job_id)
                 await db.commit()
+                history_had_errors = stats["errors"] > history_error_count
 
             await _raise_if_cancelled(db, job_id)
 
@@ -908,6 +974,9 @@ async def run_trakt_sync(user_id: int, job_id: int):
 
                     await db.commit()
 
+            if sync_watched and not history_had_errors:
+                settings.trakt_history_cursor_at = history_end
+
             print(
                 f"Trakt sync job {job_id} completed. "
                 f"Movies: {stats['movies']} new, {stats.get('skipped', 0)} skipped. "
@@ -949,6 +1018,7 @@ async def run_trakt_sync(user_id: int, job_id: int):
 @router.post("/sync")
 async def sync_trakt(
     background_tasks: BackgroundTasks,
+    full: bool = Query(default=False),
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
@@ -972,8 +1042,9 @@ async def sync_trakt(
     await db.commit()
     await db.refresh(job)
 
-    background_tasks.add_task(run_trakt_sync, current_user.id, job.id)
-    return {"status": "started", "job_id": job.id, "message": "Trakt sync is running in the background"}
+    background_tasks.add_task(run_trakt_sync, current_user.id, job.id, full)
+    mode = "full resync" if full else "incremental sync"
+    return {"status": "started", "job_id": job.id, "message": f"Trakt {mode} is running in the background"}
 
 
 async def _run_trakt_push(user_id: int, job_id: int) -> None:
@@ -986,27 +1057,34 @@ async def _run_trakt_push(user_id: int, job_id: int) -> None:
             )
             await db.commit()
 
-            settings_result = await db.execute(select(UserSettings).where(UserSettings.user_id == user_id))
+            settings_result = await db.execute(
+                select(UserSettings).where(UserSettings.user_id == user_id)
+            )
             settings = settings_result.scalar_one_or_none()
             if not settings or not settings.trakt_access_token or not settings.trakt_client_id:
-                await db.execute(update(SyncJob).where(SyncJob.id == job_id).values(status=SyncStatus.failed, error_message="Trakt is not connected"))
+                await db.execute(
+                    update(SyncJob)
+                    .where(SyncJob.id == job_id)
+                    .values(status=SyncStatus.failed, error_message="Trakt is not connected")
+                )
                 await db.commit()
                 return
 
             all_media_ids: set[int] = set()
-            watched_ids: set[int] = set()
+            watch_events: list[tuple[int, datetime]] = []
             collected_ids: set[int] = set()
             ratings_map: RatingChanges = {}
 
             if settings.trakt_push_watched:
                 watched_result = await db.execute(
-                    select(WatchEvent.media_id).where(WatchEvent.user_id == user_id).distinct()
+                    select(WatchEvent.media_id, WatchEvent.watched_at).where(
+                        WatchEvent.user_id == user_id,
+                        WatchEvent.completed.is_(True),
+                    )
                 )
-                watched_ids = {row[0] for row in watched_result.all()}
-                all_media_ids |= watched_ids
+                watch_events = [(media_id, watched_at) for media_id, watched_at in watched_result.all()]
+                all_media_ids |= {media_id for media_id, _ in watch_events}
 
-                from routers.sync import _latest_watched_at
-                watched_at_by_media = await _latest_watched_at(db, user_id, list(watched_ids))
 
             if settings.trakt_push_collection:
                 collected_result = await db.execute(
@@ -1030,59 +1108,149 @@ async def _run_trakt_push(user_id: int, job_id: int) -> None:
                 all_media_ids |= {media_id for media_id, _ in ratings_map}
 
             if not all_media_ids:
-                await db.execute(update(SyncJob).where(SyncJob.id == job_id).values(status=SyncStatus.completed, stats={"succeeded": 0, "failed": 0}, processed_items=0, total_items=0))
+                await db.execute(
+                    update(SyncJob)
+                    .where(SyncJob.id == job_id)
+                    .values(
+                        status=SyncStatus.completed,
+                        stats={"succeeded": 0, "failed": 0, "skipped": 0},
+                        processed_items=0,
+                        total_items=0,
+                    )
+                )
                 await db.commit()
                 return
 
-            await db.execute(update(SyncJob).where(SyncJob.id == job_id).values(total_items=len(all_media_ids)))
-            await db.commit()
-
             media_result = await db.execute(select(Media).where(Media.id.in_(all_media_ids)))
-            media_by_id: dict[int, Media] = {m.id: m for m in media_result.scalars().all()}
+            media_by_id: dict[int, Media] = {media.id: media for media in media_result.scalars().all()}
 
-            show_ids = {m.show_id for m in media_by_id.values() if m.show_id}
+            show_ids = {media.show_id for media in media_by_id.values() if media.show_id}
             shows_by_id: dict[int, Show] = {}
             if show_ids:
                 shows_result = await db.execute(select(Show).where(Show.id.in_(show_ids)))
-                shows_by_id = {s.id: s for s in shows_result.scalars().all()}
+                shows_by_id = {show.id: show for show in shows_result.scalars().all()}
 
-            push_tasks: list[tuple[str, "Coroutine"]] = []
+            push_tasks: list[tuple[str, int, "Coroutine"]] = []
+            watched_already_present = 0
 
             if settings.trakt_push_watched:
-                trakt_watched_movies: list[tuple[int, datetime | None]] = []
-                trakt_watched_episodes: list[tuple[int, int, int, datetime | None]] = []
-                for mid in watched_ids:
-                    media = media_by_id.get(mid)
-                    if not media or not media.tmdb_id:
+                movie_candidates: list[tuple[tuple, int, datetime]] = []
+                episode_candidates: list[tuple[tuple, int, int, int, datetime]] = []
+                local_keys: set[tuple] = set()
+
+                for media_id, watched_at in watch_events:
+                    media = media_by_id.get(media_id)
+                    if not media:
                         continue
-                    watched_at = watched_at_by_media.get(mid)
-                    if media.media_type == MediaType.movie:
-                        trakt_watched_movies.append((media.tmdb_id, watched_at))
-                    elif media.media_type == MediaType.episode and media.show_id and media.season_number is not None and media.episode_number is not None:
+                    normalized_at = _normalize_history_time(watched_at)
+                    if media.media_type == MediaType.movie and media.tmdb_id:
+                        key = ("movie", media.tmdb_id, normalized_at)
+                        if key not in local_keys:
+                            local_keys.add(key)
+                            movie_candidates.append((key, media.tmdb_id, watched_at))
+                    elif (
+                        media.media_type == MediaType.episode
+                        and media.show_id
+                        and media.season_number is not None
+                        and media.episode_number is not None
+                    ):
                         show = shows_by_id.get(media.show_id)
                         if show and show.tmdb_id:
-                            trakt_watched_episodes.append((show.tmdb_id, media.season_number, media.episode_number, watched_at))
-                if trakt_watched_movies or trakt_watched_episodes:
-                    push_tasks.append(("watched", trakt_client.add_to_history_batch(
-                        settings.trakt_client_id, settings.trakt_access_token,
-                        trakt_watched_movies, trakt_watched_episodes,
-                    )))
+                            key = (
+                                "episode",
+                                show.tmdb_id,
+                                media.season_number,
+                                media.episode_number,
+                                normalized_at,
+                            )
+                            if key not in local_keys:
+                                local_keys.add(key)
+                                episode_candidates.append((
+                                    key,
+                                    show.tmdb_id,
+                                    media.season_number,
+                                    media.episode_number,
+                                    watched_at,
+                                ))
+
+                if local_keys:
+                    timestamps = [key[-1] for key in local_keys]
+                    remote_movies, remote_episodes = await asyncio.gather(
+                        trakt_client.get_history_movies(
+                            settings.trakt_client_id,
+                            settings.trakt_access_token,
+                            start_at=min(timestamps) - TRAKT_HISTORY_OVERLAP,
+                            end_at=max(timestamps) + TRAKT_HISTORY_OVERLAP,
+                        ),
+                        trakt_client.get_history_episodes(
+                            settings.trakt_client_id,
+                            settings.trakt_access_token,
+                            start_at=min(timestamps) - TRAKT_HISTORY_OVERLAP,
+                            end_at=max(timestamps) + TRAKT_HISTORY_OVERLAP,
+                        ),
+                    )
+                    remote_keys = _remote_history_keys(remote_movies, remote_episodes)
+                    watched_already_present = len(local_keys & remote_keys)
+                    pending: list[tuple[str, tuple]] = [
+                        ("movie", (tmdb_id, watched_at))
+                        for key, tmdb_id, watched_at in movie_candidates
+                        if key not in remote_keys
+                    ]
+                    pending.extend(
+                        ("episode", (show_tmdb_id, season, episode_number, watched_at))
+                        for key, show_tmdb_id, season, episode_number, watched_at in episode_candidates
+                        if key not in remote_keys
+                    )
+
+                    for index in range(0, len(pending), TRAKT_HISTORY_PUSH_BATCH_SIZE):
+                        chunk = pending[index:index + TRAKT_HISTORY_PUSH_BATCH_SIZE]
+                        movies = [payload for kind, payload in chunk if kind == "movie"]
+                        episodes = [payload for kind, payload in chunk if kind == "episode"]
+                        push_tasks.append((
+                            "watched",
+                            len(chunk),
+                            trakt_client.add_to_history_batch(
+                                settings.trakt_client_id,
+                                settings.trakt_access_token,
+                                movies,
+                                episodes,
+                            ),
+                        ))
 
             if settings.trakt_push_collection:
                 collection_movies: list[int] = []
                 collection_episodes: list[tuple[int, int, int]] = []
-                for mid in collected_ids:
-                    media = media_by_id.get(mid)
-                    if not media or not media.tmdb_id:
+                for media_id in collected_ids:
+                    media = media_by_id.get(media_id)
+                    if not media:
                         continue
-                    if media.media_type == MediaType.movie:
+                    if media.media_type == MediaType.movie and media.tmdb_id:
                         collection_movies.append(media.tmdb_id)
-                    elif media.media_type == MediaType.episode and media.show_id and media.season_number is not None and media.episode_number is not None:
+                    elif (
+                        media.media_type == MediaType.episode
+                        and media.show_id
+                        and media.season_number is not None
+                        and media.episode_number is not None
+                    ):
                         show = shows_by_id.get(media.show_id)
                         if show and show.tmdb_id:
-                            collection_episodes.append((show.tmdb_id, media.season_number, media.episode_number))
-                if collection_movies or collection_episodes:
-                    push_tasks.append(("collection", trakt_client.add_to_collection_batch(settings.trakt_client_id, settings.trakt_access_token, collection_movies, collection_episodes)))
+                            collection_episodes.append((
+                                show.tmdb_id,
+                                media.season_number,
+                                media.episode_number,
+                            ))
+                collection_count = len(collection_movies) + len(collection_episodes)
+                if collection_count:
+                    push_tasks.append((
+                        "collection",
+                        collection_count,
+                        trakt_client.add_to_collection_batch(
+                            settings.trakt_client_id,
+                            settings.trakt_access_token,
+                            collection_movies,
+                            collection_episodes,
+                        ),
+                    ))
 
             if settings.trakt_push_ratings:
                 from routers.sync import _get_effective_tmdb_key, _resolve_tmdb_season_ids
@@ -1093,14 +1261,15 @@ async def _run_trakt_push(user_id: int, job_id: int) -> None:
                     await _get_effective_tmdb_key(db, settings),
                 )
                 for key, rating in ratings_map.items():
-                    mid, season_number = key
-                    media = media_by_id.get(mid)
+                    media_id, season_number = key
+                    media = media_by_id.get(media_id)
                     if not media or not media.tmdb_id:
                         continue
                     if season_number is not None:
                         if season_tmdb_id := season_tmdb_ids.get(key):
                             push_tasks.append((
                                 "ratings",
+                                1,
                                 trakt_client.set_season_rating(
                                     settings.trakt_client_id,
                                     settings.trakt_access_token,
@@ -1109,55 +1278,110 @@ async def _run_trakt_push(user_id: int, job_id: int) -> None:
                                 ),
                             ))
                     elif media.media_type == MediaType.movie:
-                        push_tasks.append(("ratings", trakt_client.set_movie_rating(settings.trakt_client_id, settings.trakt_access_token, media.tmdb_id, rating)))
+                        push_tasks.append((
+                            "ratings",
+                            1,
+                            trakt_client.set_movie_rating(
+                                settings.trakt_client_id,
+                                settings.trakt_access_token,
+                                media.tmdb_id,
+                                rating,
+                            ),
+                        ))
                     elif media.media_type == MediaType.series:
-                        push_tasks.append(("ratings", trakt_client.set_show_rating(settings.trakt_client_id, settings.trakt_access_token, media.tmdb_id, rating)))
+                        push_tasks.append((
+                            "ratings",
+                            1,
+                            trakt_client.set_show_rating(
+                                settings.trakt_client_id,
+                                settings.trakt_access_token,
+                                media.tmdb_id,
+                                rating,
+                            ),
+                        ))
 
-            total = len(push_tasks)
+            total = sum(item_count for _, item_count, _ in push_tasks)
+            await db.execute(
+                update(SyncJob).where(SyncJob.id == job_id).values(total_items=total)
+            )
+            await db.commit()
+
             if not push_tasks:
-                print(f"Trakt push job {job_id}: nothing to push (0 candidates matched enabled push flags).")
-                await db.execute(update(SyncJob).where(SyncJob.id == job_id).values(status=SyncStatus.completed, stats={"succeeded": 0, "failed": 0}, processed_items=0))
+                print(f"Trakt push job {job_id}: all watched events already exist remotely.")
+                await db.execute(
+                    update(SyncJob)
+                    .where(SyncJob.id == job_id)
+                    .values(
+                        status=SyncStatus.completed,
+                        stats={"succeeded": 0, "failed": 0, "skipped": watched_already_present},
+                        processed_items=0,
+                    )
+                )
                 await db.commit()
                 return
 
             queued_counts: dict[str, int] = {}
-            for category, _ in push_tasks:
-                queued_counts[category] = queued_counts.get(category, 0) + 1
+            for category, item_count, _ in push_tasks:
+                queued_counts[category] = queued_counts.get(category, 0) + item_count
             print(
                 f"Trakt push job {job_id}: queued "
-                + ", ".join(f"{n} {cat}" for cat, n in queued_counts.items())
-                + f" ({total} total)."
+                + ", ".join(f"{count} {category}" for category, count in queued_counts.items())
+                + f" ({total} total, {watched_already_present} already present)."
             )
-            BATCH_SIZE = 50
+
+            request_batch_size = 50
             succeeded = 0
             failed = 0
             succeeded_by_category: dict[str, int] = {}
             failed_by_category: dict[str, int] = {}
-            for i in range(0, total, BATCH_SIZE):
-                batch = push_tasks[i:i + BATCH_SIZE]
-                batch_categories = [category for category, _ in batch]
-                results = await asyncio.gather(*[task for _, task in batch], return_exceptions=True)
-                for category, result in zip(batch_categories, results):
+            for index in range(0, len(push_tasks), request_batch_size):
+                batch = push_tasks[index:index + request_batch_size]
+                results = await asyncio.gather(
+                    *[task for _, _, task in batch],
+                    return_exceptions=True,
+                )
+                for (category, item_count, _), result in zip(batch, results):
                     if isinstance(result, Exception):
-                        failed += 1
-                        failed_by_category[category] = failed_by_category.get(category, 0) + 1
+                        failed += item_count
+                        failed_by_category[category] = (
+                            failed_by_category.get(category, 0) + item_count
+                        )
                     else:
-                        succeeded += 1
-                        succeeded_by_category[category] = succeeded_by_category.get(category, 0) + 1
-                await db.execute(update(SyncJob).where(SyncJob.id == job_id).values(processed_items=succeeded + failed))
+                        succeeded += item_count
+                        succeeded_by_category[category] = (
+                            succeeded_by_category.get(category, 0) + item_count
+                        )
+                await db.execute(
+                    update(SyncJob)
+                    .where(SyncJob.id == job_id)
+                    .values(processed_items=succeeded + failed)
+                )
                 await db.commit()
                 await _raise_if_cancelled(db, job_id)
             breakdown = ", ".join(
-                f"{cat}: {succeeded_by_category.get(cat, 0)} succeeded"
-                + (f", {failed_by_category[cat]} failed" if failed_by_category.get(cat) else "")
-                for cat in queued_counts
+                f"{category}: {succeeded_by_category.get(category, 0)} succeeded"
+                + (
+                    f", {failed_by_category[category]} failed"
+                    if failed_by_category.get(category)
+                    else ""
+                )
+                for category in queued_counts
             )
-            print(f"Trakt push job {job_id} completed. {breakdown}. Total: {succeeded}/{total} succeeded.")
+            print(
+                f"Trakt push job {job_id} completed. {breakdown}. "
+                f"Total: {succeeded}/{total} succeeded, {watched_already_present} skipped."
+            )
 
             await db.execute(
-                update(SyncJob).where(SyncJob.id == job_id).values(
+                update(SyncJob)
+                .where(SyncJob.id == job_id)
+                .values(
                     status=SyncStatus.completed,
-                    stats={"succeeded": succeeded, "failed": failed},
+                    stats={
+                        "succeeded": succeeded,
+                        "failed": failed,
+                        "skipped": watched_already_present,
+                    },
                     processed_items=succeeded + failed,
                 )
             )
@@ -1174,7 +1398,11 @@ async def _run_trakt_push(user_id: int, job_id: int) -> None:
 
         except Exception as exc:
             print(f"Trakt push job {job_id} failed: {exc}")
-            await db.execute(update(SyncJob).where(SyncJob.id == job_id).values(status=SyncStatus.failed, error_message=str(exc)))
+            await db.execute(
+                update(SyncJob)
+                .where(SyncJob.id == job_id)
+                .values(status=SyncStatus.failed, error_message=str(exc))
+            )
             await db.commit()
 
 

--- a/backend/tests/test_season_ratings.py
+++ b/backend/tests/test_season_ratings.py
@@ -38,6 +38,7 @@ def _settings() -> SimpleNamespace:
         mdblist_push_ratings=True,
         mdblist_push_collection=False,
         mdblist_api_key="mdblist-key",
+        simkl_push_watched=False,
         simkl_push_ratings=False,
         simkl_access_token=None,
         simkl_client_id=None,

--- a/backend/tests/test_trakt.py
+++ b/backend/tests/test_trakt.py
@@ -1,10 +1,22 @@
 import json
+import os
 import unittest
-from unittest.mock import patch
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+os.environ.setdefault("SECRET_KEY", "test-secret")
+os.environ.setdefault(
+    "DATABASE_URL",
+    "postgresql+asyncpg://test:test@localhost/test",
+)
 
 import httpx
 
 from core import trakt
+from models.base import MediaType
+from models.media import Media
+from routers import trakt as trakt_router
 
 
 _REAL_ASYNC_CLIENT = httpx.AsyncClient
@@ -175,6 +187,68 @@ class TraktClientTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(len(ratings["seasons"]), 2)
         self.assertEqual(ratings["seasons"][1]["season"]["number"], 2)
 
+    async def test_history_time_window_is_forwarded(self) -> None:
+        requests: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            requests.append(request)
+            return httpx.Response(
+                200,
+                json=[],
+                headers={"X-Pagination-Page-Count": "1"},
+            )
+
+        transport = httpx.MockTransport(handler)
+        with patch.object(
+            trakt.httpx,
+            "AsyncClient",
+            side_effect=lambda **kwargs: _REAL_ASYNC_CLIENT(transport=transport, **kwargs),
+        ):
+            await trakt.get_history_movies(
+                "client-id",
+                "access-token",
+                start_at=datetime(2026, 7, 20, 10, 0, 0),
+                end_at=datetime(2026, 7, 21, 10, 0, 0, tzinfo=timezone.utc),
+            )
+
+        self.assertEqual(
+            requests[0].url.params["start_at"],
+            "2026-07-20T10:00:00.000Z",
+        )
+        self.assertEqual(
+            requests[0].url.params["end_at"],
+            "2026-07-21T10:00:00.000Z",
+        )
+
+    async def test_history_batch_preserves_each_watched_at(self) -> None:
+        payloads: list[dict] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            payloads.append(json.loads(request.content))
+            return httpx.Response(201, json={"added": {"movies": 1, "episodes": 1}})
+
+        transport = httpx.MockTransport(handler)
+        with patch.object(
+            trakt.httpx,
+            "AsyncClient",
+            side_effect=lambda **kwargs: _REAL_ASYNC_CLIENT(transport=transport, **kwargs),
+        ):
+            await trakt.add_to_history_batch(
+                "client-id",
+                "access-token",
+                [(550, datetime(2024, 3, 28, 6, 40, 0, 123456))],
+                [(1396, 1, 3, datetime(2024, 3, 29, 8, 13, 20))],
+            )
+
+        self.assertEqual(
+            payloads[0]["movies"],
+            [{"ids": {"tmdb": 550}, "watched_at": "2024-03-28T06:40:00.123Z"}],
+        )
+        self.assertEqual(
+            payloads[0]["shows"][0]["seasons"][0]["episodes"],
+            [{"number": 3, "watched_at": "2024-03-29T08:13:20.000Z"}],
+        )
+
     async def test_rating_batches_preserve_season_tmdb_ids(self) -> None:
         requests: list[tuple[str, dict]] = []
 
@@ -213,6 +287,315 @@ class TraktClientTests(unittest.IsolatedAsyncioTestCase):
             requests[1][1]["seasons"],
             [{"ids": {"tmdb": 3572}}],
         )
+
+
+class _Result:
+    def __init__(self, *, scalar=None, scalars=None, rows=None):
+        self._scalar = scalar
+        self._scalars = scalars or []
+        self._rows = rows or []
+
+    def scalar_one_or_none(self):
+        return self._scalar
+
+    def scalars(self):
+        return self
+
+    def all(self):
+        return self._scalars or self._rows
+
+
+    def __iter__(self):
+        return iter(self._rows)
+
+class _FakeSession:
+    def __init__(self, settings, watch_rows, media, shows, incomplete_watch_rows=()):
+        self.settings = settings
+        self.watch_rows = watch_rows
+        self.incomplete_watch_rows = incomplete_watch_rows
+        self.media = media
+        self.shows = shows
+        self.commit = AsyncMock()
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        return False
+
+    async def execute(self, statement):
+        sql = str(statement)
+        if "FROM user_settings" in sql:
+            return _Result(scalar=self.settings)
+        if "FROM watch_events" in sql:
+            rows = self.watch_rows
+            if "watch_events.completed" not in sql:
+                rows = [*rows, *self.incomplete_watch_rows]
+            return _Result(rows=rows)
+        if "FROM media" in sql:
+            return _Result(scalars=self.media)
+        if "FROM shows" in sql:
+            return _Result(scalars=self.shows)
+        return _Result()
+
+
+class TraktHistorySafetyTests(unittest.IsolatedAsyncioTestCase):
+    def test_incremental_window_overlaps_cursor(self) -> None:
+        cursor = datetime(2026, 7, 21, 10, 0, 0)
+        cutoff = datetime(2026, 7, 21, 11, 0, 0)
+
+        start_at, end_at = trakt_router._history_window(cursor, False, cutoff)
+        self.assertEqual(start_at, cursor - timedelta(minutes=5))
+        self.assertEqual(end_at, cutoff)
+        self.assertEqual(
+            trakt_router._history_window(cursor, True, cutoff),
+            (None, cutoff),
+        )
+
+    async def test_incremental_pull_advances_cursor_only_after_success(self) -> None:
+        original_cursor = datetime(2026, 7, 21, 10, 0, 0)
+        settings = SimpleNamespace(
+            trakt_access_token="access-token",
+            trakt_client_id="client-id",
+            trakt_client_secret=None,
+            trakt_refresh_token=None,
+            trakt_history_cursor_at=original_cursor,
+            trakt_sync_watched=True,
+            trakt_sync_ratings=False,
+            trakt_sync_lists=False,
+            tmdb_api_key="tmdb-token",
+        )
+        session = _FakeSession(settings, [], [], [])
+        get_movies = AsyncMock(return_value=[])
+        get_episodes = AsyncMock(return_value=[])
+
+        with (
+            patch.object(
+                trakt_router,
+                "async_sessionmaker",
+                return_value=lambda: session,
+            ),
+            patch.object(
+                trakt_router.trakt_client,
+                "validate_token",
+                AsyncMock(return_value=True),
+            ),
+            patch.object(
+                trakt_router.trakt_client,
+                "get_history_movies",
+                get_movies,
+            ),
+            patch.object(
+                trakt_router.trakt_client,
+                "get_history_episodes",
+                get_episodes,
+            ),
+            patch(
+                "routers.sync._fan_out_changes_to_other_connections",
+                AsyncMock(),
+            ),
+        ):
+            await trakt_router.run_trakt_sync(user_id=1, job_id=21)
+
+        self.assertGreater(settings.trakt_history_cursor_at, original_cursor)
+        self.assertEqual(
+            get_movies.await_args.kwargs["start_at"],
+            original_cursor - timedelta(minutes=5),
+        )
+        self.assertEqual(
+            get_movies.await_args.kwargs["end_at"],
+            settings.trakt_history_cursor_at,
+        )
+        self.assertEqual(
+            get_episodes.await_args.kwargs,
+            get_movies.await_args.kwargs,
+        )
+
+    async def test_failed_incremental_pull_does_not_advance_cursor(self) -> None:
+        original_cursor = datetime(2026, 7, 21, 10, 0, 0)
+        settings = SimpleNamespace(
+            trakt_access_token="access-token",
+            trakt_client_id="client-id",
+            trakt_client_secret=None,
+            trakt_refresh_token=None,
+            trakt_history_cursor_at=original_cursor,
+            trakt_sync_watched=True,
+            trakt_sync_ratings=False,
+            trakt_sync_lists=False,
+            tmdb_api_key="tmdb-token",
+        )
+        session = _FakeSession(settings, [], [], [])
+
+        with (
+            patch.object(
+                trakt_router,
+                "async_sessionmaker",
+                return_value=lambda: session,
+            ),
+            patch.object(
+                trakt_router.trakt_client,
+                "validate_token",
+                AsyncMock(return_value=True),
+            ),
+            patch.object(
+                trakt_router.trakt_client,
+                "get_history_movies",
+                AsyncMock(side_effect=RuntimeError("Trakt unavailable")),
+            ),
+        ):
+            await trakt_router.run_trakt_sync(user_id=1, job_id=22)
+
+        self.assertEqual(settings.trakt_history_cursor_at, original_cursor)
+
+    async def test_full_push_skips_remote_event_after_timestamped_push(self) -> None:
+        watched_at = datetime(2024, 3, 28, 6, 40, 0)
+        settings = SimpleNamespace(
+            trakt_access_token="access-token",
+            trakt_client_id="client-id",
+            trakt_push_watched=True,
+            trakt_push_collection=False,
+            trakt_push_ratings=False,
+        )
+        movie = Media(
+            id=10,
+            tmdb_id=550,
+            media_type=MediaType.movie,
+            title="Fight Club",
+        )
+        session = _FakeSession(settings, [(movie.id, watched_at)], [movie], [])
+        add_batch = AsyncMock(return_value=None)
+        remote_movie = {
+            "id": 987,
+            "watched_at": "2024-03-28T06:40:00.000Z",
+            "movie": {"ids": {"tmdb": 550}},
+        }
+
+        with (
+            patch.object(
+                trakt_router,
+                "async_sessionmaker",
+                return_value=lambda: session,
+            ),
+            patch.object(
+                trakt_router.trakt_client,
+                "get_history_movies",
+                AsyncMock(side_effect=[[], [remote_movie]]),
+            ),
+            patch.object(
+                trakt_router.trakt_client,
+                "get_history_episodes",
+                AsyncMock(side_effect=[[], []]),
+            ),
+            patch.object(
+                trakt_router.trakt_client,
+                "add_to_history_batch",
+                add_batch,
+            ),
+        ):
+            await trakt_router._run_trakt_push(user_id=1, job_id=11)
+            await trakt_router._run_trakt_push(user_id=1, job_id=12)
+
+        add_batch.assert_awaited_once_with(
+            "client-id",
+            "access-token",
+            [(550, watched_at)],
+            [],
+        )
+
+    async def test_full_push_preserves_multiple_completed_plays(self) -> None:
+        earlier = datetime(2024, 3, 28, 6, 40, 0)
+        latest = datetime(2024, 4, 2, 20, 0, 0)
+        settings = SimpleNamespace(
+            trakt_access_token="access-token",
+            trakt_client_id="client-id",
+            trakt_push_watched=True,
+            trakt_push_collection=False,
+            trakt_push_ratings=False,
+        )
+        movie = Media(
+            id=10,
+            tmdb_id=550,
+            media_type=MediaType.movie,
+            title="Fight Club",
+        )
+        session = _FakeSession(
+            settings,
+            [(movie.id, earlier), (movie.id, latest)],
+            [movie],
+            [],
+        )
+        add_batch = AsyncMock(return_value=None)
+
+        with (
+            patch.object(
+                trakt_router,
+                "async_sessionmaker",
+                return_value=lambda: session,
+            ),
+            patch.object(
+                trakt_router.trakt_client,
+                "get_history_movies",
+                AsyncMock(return_value=[]),
+            ),
+            patch.object(
+                trakt_router.trakt_client,
+                "get_history_episodes",
+                AsyncMock(return_value=[]),
+            ),
+            patch.object(
+                trakt_router.trakt_client,
+                "add_to_history_batch",
+                add_batch,
+            ),
+        ):
+            await trakt_router._run_trakt_push(user_id=1, job_id=13)
+
+        add_batch.assert_awaited_once_with(
+            "client-id",
+            "access-token",
+            [(550, earlier), (550, latest)],
+            [],
+        )
+
+    async def test_full_push_ignores_incomplete_watch_events(self) -> None:
+        watched_at = datetime(2024, 3, 28, 6, 40, 0)
+        settings = SimpleNamespace(
+            trakt_access_token="access-token",
+            trakt_client_id="client-id",
+            trakt_push_watched=True,
+            trakt_push_collection=False,
+            trakt_push_ratings=False,
+        )
+        movie = Media(
+            id=10,
+            tmdb_id=550,
+            media_type=MediaType.movie,
+            title="Fight Club",
+        )
+        session = _FakeSession(
+            settings,
+            [],
+            [movie],
+            [],
+            incomplete_watch_rows=[(movie.id, watched_at)],
+        )
+        add_batch = AsyncMock(return_value=None)
+
+        with (
+            patch.object(
+                trakt_router,
+                "async_sessionmaker",
+                return_value=lambda: session,
+            ),
+            patch.object(
+                trakt_router.trakt_client,
+                "add_to_history_batch",
+                add_batch,
+            ),
+        ):
+            await trakt_router._run_trakt_push(user_id=1, job_id=14)
+
+        add_batch.assert_not_awaited()
 
 if __name__ == "__main__":
     unittest.main()

--- a/frontend/src/pages/settings.astro
+++ b/frontend/src/pages/settings.astro
@@ -789,13 +789,22 @@ if (me.totp_enabled) {
                             </label>
                           </div>
                         </div>
-                        <button
-                          type="button"
-                          data-action="sync_trakt"
-                          disabled={!hasTmdbKey}
-                          title={!hasTmdbKey ? "TMDB Read Access Token is required for sync" : "Pull watched history and ratings from Trakt"}
-                          class={`js-action-btn text-sm px-3 py-1.5 rounded-lg transition-colors cursor-pointer disabled:opacity-50 ${hasTmdbKey ? "bg-red-500/10 hover:bg-red-500/20 text-red-400 border border-red-500/30" : "bg-zinc-800 text-zinc-400 border border-zinc-700 opacity-50"}`}
-                        >Pull</button>
+                        <div class="flex flex-wrap gap-2">
+                          <button
+                            type="button"
+                            data-action="sync_trakt"
+                            disabled={!hasTmdbKey}
+                            title={!hasTmdbKey ? "TMDB Read Access Token is required for sync" : "Pull new Trakt history since the last successful sync"}
+                            class={`js-action-btn text-sm px-3 py-1.5 rounded-lg transition-colors cursor-pointer disabled:opacity-50 ${hasTmdbKey ? "bg-red-500/10 hover:bg-red-500/20 text-red-400 border border-red-500/30" : "bg-zinc-800 text-zinc-400 border border-zinc-700 opacity-50"}`}
+                          >Pull</button>
+                          <button
+                            type="button"
+                            data-action="full_sync_trakt"
+                            disabled={!hasTmdbKey}
+                            title={!hasTmdbKey ? "TMDB Read Access Token is required for sync" : "Scan all Trakt watch history again"}
+                            class="js-action-btn text-sm px-3 py-1.5 rounded-lg transition-colors cursor-pointer disabled:opacity-50 bg-zinc-900 hover:bg-zinc-800 text-zinc-400 border border-zinc-700"
+                          >Full resync</button>
+                        </div>
                       </div>
                       <div class="bg-zinc-950 rounded-xl p-4 space-y-3">
                         <p class="text-xs font-semibold uppercase tracking-wide text-zinc-500">Scrob → Trakt</p>
@@ -2927,7 +2936,8 @@ if (me.totp_enabled) {
             setConnStatus('sonarr-conn-status', 'connected');
             showMessage('Sonarr connection successful and profiles fetched!');
             return;
-          } else if (action === 'sync_trakt') {
+          } else if (action === 'sync_trakt' || action === 'full_sync_trakt') {
+            const fullResync = action === 'full_sync_trakt';
             const traktPullLabels: Record<string, string> = {
               trakt_sync_watched: 'watched history',
               trakt_sync_ratings: 'ratings',
@@ -2940,15 +2950,17 @@ if (me.totp_enabled) {
             });
             const noPull = pulling.length === 0;
             const ok = await showConfirmModal(
-              noPull ? 'Nothing to pull' : 'Pull from Trakt?',
+              noPull ? 'Nothing to pull' : fullResync ? 'Full resync from Trakt?' : 'Pull from Trakt?',
               noPull
                 ? 'Your current settings have nothing selected to pull from Trakt. Enable at least one option in the "Trakt → Scrob" section.'
-                : `This will import your ${formatList(pulling)} from Trakt into Scrob.`,
-              noPull ? 'Got it' : 'Pull',
+                : fullResync
+                  ? `This will scan your complete ${formatList(pulling)} on Trakt again. Existing Scrob events are retained and deduplicated.`
+                  : `This will import new ${formatList(pulling)} from Trakt since the last successful pull.`,
+              noPull ? 'Got it' : fullResync ? 'Full resync' : 'Pull',
               noPull
             );
             if (!ok) return;
-            url = `/api/proxy/trakt/sync`;
+            url = `/api/proxy/trakt/sync${fullResync ? '?full=true' : ''}`;
           } else if (action === 'sync_simkl') {
             const simklPullLabels: Record<string, string> = {
               simkl_sync_watched: 'watched history',
@@ -3068,12 +3080,12 @@ if (me.totp_enabled) {
 
           if (res.ok) {
             const showsProgressBar = !!syncConnId || [
-              'sync_trakt', 'push_trakt', 'sync_simkl', 'push_simkl', 'sync_mdblist', 'push_mdblist',
+              'sync_trakt', 'full_sync_trakt', 'push_trakt', 'sync_simkl', 'push_simkl', 'sync_mdblist', 'push_mdblist',
             ].includes(action);
             showMessage(data.message || 'Action successful!', 'success', { scroll: !showsProgressBar });
             if (syncConnId) startConnPoller(syncConnId);
             if (action === 'sync_simkl' || action === 'push_simkl') startSimklPoller();
-            if (action === 'sync_trakt' || action === 'push_trakt') startTraktPoller();
+            if (action === 'sync_trakt' || action === 'full_sync_trakt' || action === 'push_trakt') startTraktPoller();
             if (action === 'sync_mdblist' || action === 'push_mdblist') startMdblistPoller();
           } else {
             if (syncConnId) renderConnProgress(syncConnId, null);


### PR DESCRIPTION
## Summary
- preserve every local Trakt watch event and its original `watched_at` timestamp during full pushes
- compare timestamped local events with remote Trakt history before writing, making repeated full pushes idempotent
- add cursor-based incremental history pulls with a 5-minute overlap window; only advance the cursor after a successful sync
- keep the first pull and explicit `Full resync` exhaustive, while normal pulls fetch only recent history
- add a dedicated Full resync action in Settings

## Why
Issue #82 reports duplicate and incorrect Trakt history after pulls. The pull-to-push echo guard already exists, but the full push path still collapsed local history to one event per media and recreated events at push time. This change removes that destructive behavior and reduces recurring pulls to a bounded, overlap-safe window.

## Verification
- `python -m unittest discover -s tests -v` — 59 passed
- `python -m compileall -q core models routers tests`
- `python -m alembic heads` — `b6c7d8e9f0a1 (head)`
- `npm ci && npm run build` — Astro production build passed

Addresses #82.