### PR TITLE
fix(history): link manually watched episodes to shows

### DIFF
--- a/backend/routers/history.py
+++ b/backend/routers/history.py
@@ -699,33 +699,58 @@ async def mark_as_watched(
 ):
     # 1. Check if Media exists locally
     media = None
+    show = None
+    api_key = None
+    episode_has_context = (
+        event_in.media_type == MediaType.episode
+        and event_in.series_tmdb_id is not None
+        and event_in.season_number is not None
+        and event_in.episode_number is not None
+    )
 
-    if event_in.media_type == MediaType.episode and event_in.series_tmdb_id and event_in.season_number is not None and event_in.episode_number is not None:
-        # For episodes, prefer looking up by show + season + episode since tmdb_id
-        # may not be set on Media records created via TVDB or webhook paths.
-        show_result = await db.execute(select(Show).where(Show.tmdb_id == event_in.series_tmdb_id))
-        show = show_result.scalar_one_or_none()
-        if show:
-            ep_result = await db.execute(
-                select(Media)
-                .where(Media.media_type == MediaType.episode)
-                .where(Media.show_id == show.id)
-                .where(Media.season_number == event_in.season_number)
-                .where(Media.episode_number == event_in.episode_number)
-            )
-            media = ep_result.scalars().first()
+    if episode_has_context:
+        from routers.media import get_user_tmdb_key
+        from routers.webhooks import _find_or_create_show
+
+        api_key = await get_user_tmdb_key(db, current_user.id)
+        try:
+            show = await _find_or_create_show(db, event_in.series_tmdb_id, api_key)
+        except Exception as e:
+            raise HTTPException(status_code=404, detail=f"TMDB Media not found: {e}")
+
+        # Prefer looking up episodes by their show context since tmdb_id may not
+        # be set on Media records created via TVDB or webhook paths.
+        ep_result = await db.execute(
+            select(Media)
+            .where(Media.media_type == MediaType.episode)
+            .where(Media.show_id == show.id)
+            .where(Media.season_number == event_in.season_number)
+            .where(Media.episode_number == event_in.episode_number)
+        )
+        media = ep_result.scalars().first()
 
     if not media:
         result = await db.execute(
             select(Media).where(Media.tmdb_id == event_in.tmdb_id, Media.media_type == event_in.media_type)
         )
-        media = result.scalar_one_or_none()
+        media = result.scalars().first()
+
+    # A previous manual mark may have created the episode before its parent show
+    # existed locally. Adopt and re-enrich that orphan now that the UI supplied
+    # the complete episode context.
+    if media and show and not media.show_id:
+        media.show_id = show.id
+        media.season_number = event_in.season_number
+        media.episode_number = event_in.episode_number
+        if not media.poster_path or media.tmdb_data is None:
+            await enrich_media(media, api_key=api_key, series_tmdb_id=event_in.series_tmdb_id)
 
     # 2. If not, create Media record from TMDB
     if not media:
-        from routers.media import get_user_tmdb_key
+        if api_key is None:
+            from routers.media import get_user_tmdb_key
 
-        api_key = await get_user_tmdb_key(db, current_user.id)
+            api_key = await get_user_tmdb_key(db, current_user.id)
 
         try:
             if event_in.media_type == MediaType.movie:
@@ -736,19 +761,17 @@ async def mark_as_watched(
                 db.add(media)
                 await db.flush()
                 await enrich_media(media, api_key=api_key)
-            elif event_in.media_type == MediaType.episode and event_in.series_tmdb_id and event_in.season_number is not None and event_in.episode_number is not None:
+            elif episode_has_context:
                 ep_data = await tmdb.get_episode(
                     event_in.series_tmdb_id, event_in.season_number, event_in.episode_number, api_key=api_key
                 )
-                show_result = await db.execute(select(Show).where(Show.tmdb_id == event_in.series_tmdb_id))
-                show = show_result.scalar_one_or_none()
                 media = Media(
                     tmdb_id=ep_data.get("id"),
                     media_type=MediaType.episode,
                     title=ep_data.get("name"),
                     season_number=event_in.season_number,
                     episode_number=event_in.episode_number,
-                    show_id=show.id if show else None,
+                    show_id=show.id,
                 )
                 db.add(media)
                 await db.flush()

--- a/backend/tests/test_history.py
+++ b/backend/tests/test_history.py
@@ -1,0 +1,143 @@
+import os
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+os.environ.setdefault("SECRET_KEY", "test-secret")
+os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://test:test@localhost/test")
+
+from models.base import MediaType
+from models.media import Media
+from routers import history
+from schemas import WatchEventCreate
+
+
+class _Scalars:
+    def __init__(self, item=None):
+        self.item = item
+
+    def first(self):
+        return self.item
+
+
+class _Result:
+    def __init__(self, item=None):
+        self.item = item
+
+    def scalars(self):
+        return _Scalars(self.item)
+
+
+class _FakeSession:
+    def __init__(self, results):
+        self.added = []
+        self.execute = AsyncMock(side_effect=[_Result(item) for item in results])
+        self.flush = AsyncMock()
+        self.commit = AsyncMock()
+
+    def add(self, value):
+        if isinstance(value, Media) and value.id is None:
+            value.id = 101
+        self.added.append(value)
+
+
+class ManualEpisodeWatchTests(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.user = SimpleNamespace(id=7)
+        self.show = SimpleNamespace(id=55)
+        self.event = WatchEventCreate(
+            tmdb_id=5767197,
+            media_type=MediaType.episode,
+            series_tmdb_id=277439,
+            season_number=1,
+            episode_number=1,
+        )
+
+    def _patch_dependencies(self):
+        get_key = AsyncMock(return_value="tmdb-key")
+        find_show = AsyncMock(return_value=self.show)
+        get_episode = AsyncMock(return_value={"id": 5767197, "name": "Fingers & Toes"})
+        enrich = AsyncMock()
+        push_state = AsyncMock()
+        patches = (
+            patch("routers.media.get_user_tmdb_key", get_key),
+            patch("routers.webhooks._find_or_create_show", find_show),
+            patch("routers.history.tmdb.get_episode", get_episode),
+            patch("routers.history.enrich_media", enrich),
+            patch("routers.history._push_watch_state", push_state),
+        )
+        return patches, get_key, find_show, get_episode, enrich, push_state
+
+    async def test_manual_episode_creates_parent_show_before_media(self):
+        db = _FakeSession([None, None, None])
+        patches, get_key, find_show, get_episode, enrich, push_state = self._patch_dependencies()
+
+        with patches[0], patches[1], patches[2], patches[3], patches[4]:
+            response = await history.mark_as_watched(self.event, db, self.user)
+
+        media = next(value for value in db.added if isinstance(value, Media))
+        self.assertEqual(response["status"], "ok")
+        self.assertEqual(media.show_id, self.show.id)
+        self.assertEqual((media.season_number, media.episode_number), (1, 1))
+        find_show.assert_awaited_once_with(db, 277439, "tmdb-key")
+        get_episode.assert_awaited_once_with(277439, 1, 1, api_key="tmdb-key")
+        enrich.assert_awaited_once_with(media, api_key="tmdb-key", series_tmdb_id=277439)
+        push_state.assert_awaited_once_with(db, 7, [media.id], watched=True)
+        get_key.assert_awaited_once()
+        db.commit.assert_awaited_once()
+
+    async def test_manual_episode_repairs_existing_orphan(self):
+        orphan = Media(
+            id=202,
+            tmdb_id=5767197,
+            media_type=MediaType.episode,
+            title="Fingers & Toes",
+            season_number=1,
+            episode_number=1,
+            show_id=None,
+            poster_path=None,
+        )
+        db = _FakeSession([None, orphan, None])
+        patches, _, _, get_episode, enrich, _ = self._patch_dependencies()
+
+        with patches[0], patches[1], patches[2], patches[3], patches[4]:
+            await history.mark_as_watched(self.event, db, self.user)
+
+        self.assertEqual(orphan.show_id, self.show.id)
+        self.assertEqual((orphan.season_number, orphan.episode_number), (1, 1))
+        get_episode.assert_not_awaited()
+        enrich.assert_awaited_once_with(orphan, api_key="tmdb-key", series_tmdb_id=277439)
+
+    async def test_tvdb_mapping_uses_canonical_show_position(self):
+        mapped_media = Media(
+            id=303,
+            tmdb_id=None,
+            media_type=MediaType.episode,
+            title="TVDB-mapped episode",
+            season_number=2,
+            episode_number=3,
+            show_id=self.show.id,
+        )
+        event = WatchEventCreate(
+            tmdb_id=7654321,
+            media_type=MediaType.episode,
+            series_tmdb_id=277439,
+            season_number=2,
+            episode_number=3,
+        )
+        db = _FakeSession([mapped_media, None])
+        patches, _, _, get_episode, enrich, push_state = self._patch_dependencies()
+
+        with patches[0], patches[1], patches[2], patches[3], patches[4]:
+            response = await history.mark_as_watched(event, db, self.user)
+
+        self.assertEqual(response["status"], "ok")
+        self.assertEqual(mapped_media.id, 303)
+        self.assertIsNone(mapped_media.tmdb_id)
+        get_episode.assert_not_awaited()
+        enrich.assert_not_awaited()
+        push_state.assert_awaited_once_with(db, 7, [303], watched=True)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- create or resolve the parent `Show` before manually recording an episode play
- adopt and re-enrich existing orphan episode rows when the UI supplies full show context
- keep TVDB-order mappings working by resolving episodes through their canonical TMDB show/season/episode position
- avoid duplicate-row failures when falling back to an episode TMDB ID

## Root cause
The manual History endpoint accepted `series_tmdb_id`, season and episode context, but only linked the episode when the parent show already existed locally. Otherwise it stored `show_id = NULL`. History could then no longer build the episode route and `/media/episode/{id}` returned 404.

Toggling watched state did not repair the record because it deletes watch events, not the orphan Media row. This change adopts that row on the next manual mark.

## Validation
- `python -m unittest tests.test_history -v`: **3 passed**
  - creates and links a missing parent show
  - repairs an existing orphan episode
  - preserves TVDB-mapped canonical episode lookup
- all backend modules outside the pre-existing `test_season_ratings` fixture failure: **62 passed**
- full discovery: **64 passed, 4 pre-existing errors** (`test_season_ratings` fixtures lack `simkl_push_watched`; no changed file is involved)
- `python -m compileall -q core models routers tests`: passed
- `python -m alembic heads`: single head `a9b8c7d6e5f4`
- `npm run build`: passed

Closes #85