### PR TITLE
feat(history): support watched items without dates

### DIFF
--- a/backend/core/trakt.py
+++ b/backend/core/trakt.py
@@ -33,6 +33,11 @@ def _iso_utc(value: datetime) -> str:
 
 
 
+def _history_watched_at(value: Optional[datetime]) -> str:
+    """Serialize a Trakt history date, preserving an explicitly unknown date."""
+    return _iso_utc(value) if value is not None else "unknown"
+
+
 async def _get_all_pages(
     client: httpx.AsyncClient,
     path: str,
@@ -240,15 +245,15 @@ async def add_to_history_batch(
 ) -> None:
     """Add multiple movies and/or episodes to Trakt history in a single API call.
 
-    movies: list of (tmdb_id, watched_at) — watched_at=None lets Trakt stamp the play as now.
-    episodes: list of (show_tmdb_id, season_number, episode_number, watched_at)
+    ``watched_at=None`` is serialized as Trakt's ``unknown`` sentinel so the
+    item is marked watched without inventing a watch date.
     """
     if not movies and not episodes:
         return
     body: dict = {}
     if movies:
         body["movies"] = [
-            {"ids": {"tmdb": tmdb_id}, **({"watched_at": _iso_utc(watched_at)} if watched_at else {})}
+            {"ids": {"tmdb": tmdb_id}, "watched_at": _history_watched_at(watched_at)}
             for tmdb_id, watched_at in movies
         ]
     if episodes:
@@ -262,7 +267,7 @@ async def add_to_history_batch(
                     {
                         "number": season,
                         "episodes": [
-                            {"number": n, **({"watched_at": _iso_utc(watched_at)} if watched_at else {})}
+                            {"number": n, "watched_at": _history_watched_at(watched_at)}
                             for n, watched_at in eps
                         ],
                     }
@@ -423,12 +428,17 @@ async def remove_ratings_batch(
         resp.raise_for_status()
 
 
-async def add_movie_to_history(client_id: str, access_token: str, tmdb_id: int) -> None:
-    """Mark a movie as watched on Trakt."""
+async def add_movie_to_history(
+    client_id: str,
+    access_token: str,
+    tmdb_id: int,
+    watched_at: Optional[datetime] = None,
+) -> None:
+    """Mark a movie as watched on Trakt, optionally without a known date."""
     async with httpx.AsyncClient(timeout=TIMEOUT) as client:
         resp = await client.post(
             f"{TRAKT_BASE}/sync/history",
-            json={"movies": [{"ids": {"tmdb": tmdb_id}}]},
+            json={"movies": [{"ids": {"tmdb": tmdb_id}, "watched_at": _history_watched_at(watched_at)}]},
             headers=_headers(client_id, access_token),
         )
         resp.raise_for_status()
@@ -451,8 +461,9 @@ async def add_episode_to_history(
     show_tmdb_id: int,
     season_number: int,
     episode_number: int,
+    watched_at: Optional[datetime] = None,
 ) -> None:
-    """Mark an episode as watched on Trakt."""
+    """Mark an episode as watched on Trakt, optionally without a known date."""
     async with httpx.AsyncClient(timeout=TIMEOUT) as client:
         resp = await client.post(
             f"{TRAKT_BASE}/sync/history",
@@ -461,7 +472,10 @@ async def add_episode_to_history(
                     "ids": {"tmdb": show_tmdb_id},
                     "seasons": [{
                         "number": season_number,
-                        "episodes": [{"number": episode_number}],
+                        "episodes": [{
+                            "number": episode_number,
+                            "watched_at": _history_watched_at(watched_at),
+                        }],
                     }],
                 }]
             },

--- a/backend/migrations/versions/b7c8d9e0f1a2_allow_unknown_watch_dates.py
+++ b/backend/migrations/versions/b7c8d9e0f1a2_allow_unknown_watch_dates.py
@@ -1,0 +1,35 @@
+"""Allow watch events without a known date
+
+Revision ID: b7c8d9e0f1a2
+Revises: b6c7d8e9f0a1
+Create Date: 2026-07-28
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "b7c8d9e0f1a2"
+down_revision: Union[str, Sequence[str], None] = "b6c7d8e9f0a1"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "watch_events",
+        "watched_at",
+        existing_type=sa.DateTime(),
+        nullable=True,
+    )
+
+
+def downgrade() -> None:
+    op.execute("UPDATE watch_events SET watched_at = NOW() WHERE watched_at IS NULL")
+    op.alter_column(
+        "watch_events",
+        "watched_at",
+        existing_type=sa.DateTime(),
+        nullable=False,
+    )

--- a/backend/models/events.py
+++ b/backend/models/events.py
@@ -17,7 +17,7 @@ class WatchEvent(Base):
     id               : Mapped[int]             = mapped_column(Integer, primary_key=True)
     user_id          : Mapped[int]             = mapped_column(ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
     media_id         : Mapped[int]             = mapped_column(ForeignKey("media.id", ondelete="CASCADE"), nullable=False)
-    watched_at       : Mapped[datetime]        = mapped_column(DateTime, nullable=False)
+    watched_at       : Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
     progress_seconds : Mapped[Optional[int]]   = mapped_column(Integer)
     progress_percent : Mapped[Optional[float]] = mapped_column(Float)
     completed        : Mapped[bool]            = mapped_column(Boolean, default=False, nullable=False)

--- a/backend/routers/history.py
+++ b/backend/routers/history.py
@@ -36,6 +36,7 @@ async def _push_watch_state(
     user_id: int,
     media_ids: list[int],
     watched: bool,
+    watched_at_by_media: dict[int, datetime | None] | None = None,
 ) -> None:
     """Fan-out watched/unwatched state to all connections with push_watched enabled."""
     if not media_ids:
@@ -54,6 +55,11 @@ async def _push_watch_state(
     push_trakt = settings and settings.trakt_push_watched and settings.trakt_access_token
     push_mdblist = settings and settings.mdblist_push_watched and settings.mdblist_api_key
 
+
+    if watched and watched_at_by_media is None:
+        from routers.sync import _latest_watched_at
+
+        watched_at_by_media = await _latest_watched_at(db, user_id, media_ids)
     tasks = []
 
     if connections:
@@ -102,7 +108,14 @@ async def _push_watch_state(
                 continue
             if media.media_type == MediaType.movie:
                 if watched:
-                    tasks.append(simkl_client.add_movie_to_history(settings.simkl_client_id, settings.simkl_access_token, media.tmdb_id))
+                    watched_at = (watched_at_by_media or {}).get(media.id)
+                    if watched_at is not None:
+                        tasks.append(simkl_client.add_movie_to_history(
+                            settings.simkl_client_id,
+                            settings.simkl_access_token,
+                            media.tmdb_id,
+                            watched_at,
+                        ))
                 else:
                     tasks.append(simkl_client.remove_movie_from_history(settings.simkl_client_id, settings.simkl_access_token, media.tmdb_id))
             elif media.media_type == MediaType.episode and media.show_id and media.season_number is not None and media.episode_number is not None:
@@ -110,7 +123,16 @@ async def _push_watch_state(
                 show = show_res.scalar_one_or_none()
                 if show and show.tmdb_id:
                     if watched:
-                        tasks.append(simkl_client.add_episode_to_history(settings.simkl_client_id, settings.simkl_access_token, show.tmdb_id, media.season_number, media.episode_number))
+                        watched_at = (watched_at_by_media or {}).get(media.id)
+                        if watched_at is not None:
+                            tasks.append(simkl_client.add_episode_to_history(
+                                settings.simkl_client_id,
+                                settings.simkl_access_token,
+                                show.tmdb_id,
+                                media.season_number,
+                                media.episode_number,
+                                watched_at,
+                            ))
                     else:
                         tasks.append(simkl_client.remove_episode_from_history(settings.simkl_client_id, settings.simkl_access_token, show.tmdb_id, media.season_number, media.episode_number))
 
@@ -124,7 +146,12 @@ async def _push_watch_state(
                 continue
             if media.media_type == MediaType.movie:
                 if watched:
-                    tasks.append(trakt_client.add_movie_to_history(settings.trakt_client_id, settings.trakt_access_token, media.tmdb_id))
+                    tasks.append(trakt_client.add_movie_to_history(
+                        settings.trakt_client_id,
+                        settings.trakt_access_token,
+                        media.tmdb_id,
+                        watched_at_by_media.get(media.id) if watched_at_by_media else None,
+                    ))
                 else:
                     tasks.append(trakt_client.remove_movie_from_history(settings.trakt_client_id, settings.trakt_access_token, media.tmdb_id))
             elif media.media_type == MediaType.episode and media.show_id and media.season_number is not None and media.episode_number is not None:
@@ -132,7 +159,14 @@ async def _push_watch_state(
                 show = show_res.scalar_one_or_none()
                 if show and show.tmdb_id:
                     if watched:
-                        tasks.append(trakt_client.add_episode_to_history(settings.trakt_client_id, settings.trakt_access_token, show.tmdb_id, media.season_number, media.episode_number))
+                        tasks.append(trakt_client.add_episode_to_history(
+                            settings.trakt_client_id,
+                            settings.trakt_access_token,
+                            show.tmdb_id,
+                            media.season_number,
+                            media.episode_number,
+                            watched_at_by_media.get(media.id) if watched_at_by_media else None,
+                        ))
                     else:
                         tasks.append(trakt_client.remove_episode_from_history(settings.trakt_client_id, settings.trakt_access_token, show.tmdb_id, media.season_number, media.episode_number))
 
@@ -141,8 +175,8 @@ async def _push_watch_state(
         from routers.mdblist import _empty_payload, _merge_show_entries, _payload_item
         from routers.sync import _latest_watched_at
 
-        mdblist_watched_at: dict[int, datetime] = {}
-        if watched:
+        mdblist_watched_at = watched_at_by_media
+        if watched and mdblist_watched_at is None:
             mdblist_watched_at = await _latest_watched_at(db, user_id, media_ids)
 
         mdblist_payload = _empty_payload()
@@ -156,7 +190,7 @@ async def _push_watch_state(
         for media in media_list:
             show = mdblist_shows_by_id.get(media.show_id)
             item = (
-                _payload_item(media, show=show, watched_at=mdblist_watched_at.get(media.id, datetime.utcnow()))
+                _payload_item(media, show=show, watched_at=(mdblist_watched_at or {}).get(media.id))
                 if watched
                 else _payload_item(media, show=show)
             )
@@ -183,16 +217,16 @@ async def _push_watch_state(
         api_key = await get_user_tmdb_key(db, user_id)
         await _ensure_nuvio_imdb_ids(media_items, shows_by_id, api_key)
 
-        watched_at_by_media: dict[int, datetime] = {}
-        if watched:
-            watched_at_by_media = await _latest_watched_at(db, user_id, media_ids)
+        nuvio_watched_at = watched_at_by_media
+        if watched and nuvio_watched_at is None:
+            nuvio_watched_at = await _latest_watched_at(db, user_id, media_ids)
 
         nuvio_items: list[dict] = []
         nuvio_keys: list[dict] = []
         for media in media_items:
             payload = _nuvio_watched_item(
                 media,
-                watched_at_by_media.get(media.id, datetime.utcnow()),
+                (nuvio_watched_at or {}).get(media.id) if watched else datetime.utcnow(),
                 shows_by_id.get(media.show_id),
             )
             if not payload:
@@ -228,9 +262,9 @@ async def _push_watch_state(
 
 
 def format_event(event: WatchEvent | PlaybackProgress, media: Media) -> dict:
-    # Handle both WatchEvent (history) and PlaybackProgress (continue watching)
-    watched_at = getattr(event, "watched_at", None) or getattr(event, "updated_at", datetime.utcnow())
-    
+    # Playback progress has no watched_at; its updated_at remains the display timestamp.
+    watched_at = event.watched_at if isinstance(event, WatchEvent) else event.updated_at
+
     data = {
         "id": event.id,
         "media": {
@@ -251,7 +285,7 @@ def format_event(event: WatchEvent | PlaybackProgress, media: Media) -> dict:
             "genres": (media.tmdb_data or {}).get("genres", []),
         },
         "user_id": event.user_id,
-        "watched_at": watched_at.isoformat(),
+        "watched_at": watched_at.isoformat() if watched_at else None,
         "progress_seconds": event.progress_seconds,
         "progress_percent": event.progress_percent,
         "completed": getattr(event, "completed", False),
@@ -297,7 +331,7 @@ async def get_history(
         .options(selectinload(WatchEvent.media).selectinload(Media.show))
         .where(WatchEvent.user_id == current_user.id)
         .where(WatchEvent.completed == True)
-        .order_by(desc(WatchEvent.watched_at))
+        .order_by(WatchEvent.watched_at.desc().nulls_last(), WatchEvent.id.desc())
     )
     if type and type in ("movie", "episode"):
         query = query.where(Media.media_type == type)
@@ -783,11 +817,18 @@ async def mark_as_watched(
         except Exception as e:
             raise HTTPException(status_code=404, detail=f"TMDB Media not found: {e}")
 
-    # 3. Create WatchEvent
+    # Omitted watched_at retains the existing API default ("now"); explicit
+    # null marks the play watched without a known date.
+    watched_at = (
+        event_in.watched_at.replace(tzinfo=None)
+        if event_in.watched_at is not None
+        else None if "watched_at" in event_in.model_fields_set
+        else datetime.utcnow()
+    )
     event = WatchEvent(
         user_id=current_user.id,
         media_id=media.id,
-        watched_at=(event_in.watched_at.replace(tzinfo=None) if event_in.watched_at else datetime.utcnow()),
+        watched_at=watched_at,
         completed=event_in.completed,
         play_count=1,
         progress_percent=1.0 if event_in.completed else 0.0,
@@ -804,7 +845,13 @@ async def mark_as_watched(
 
     # 4. Push to media servers if outbound push is enabled
     if event_in.completed:
-        await _push_watch_state(db, current_user.id, [media.id], watched=True)
+        await _push_watch_state(
+            db,
+            current_user.id,
+            [media.id],
+            watched=True,
+            watched_at_by_media={media.id: watched_at},
+        )
 
     return {"status": "ok", "message": f"Marked {media.title} as watched"}
 
@@ -826,11 +873,14 @@ async def get_item_events(
             Media.tmdb_id == tmdb_id,
             Media.media_type == media_type,
         )
-        .order_by(desc(WatchEvent.watched_at))
+        .order_by(WatchEvent.watched_at.desc().nulls_last(), WatchEvent.id.desc())
     )
     result = await db.execute(query)
     events = result.scalars().all()
-    return [{"id": e.id, "watched_at": e.watched_at.isoformat()} for e in events]
+    return [
+        {"id": event.id, "watched_at": event.watched_at.isoformat() if event.watched_at else None}
+        for event in events
+    ]
 
 
 @router.delete("/event/{event_id}")

--- a/backend/routers/profile.py
+++ b/backend/routers/profile.py
@@ -539,6 +539,7 @@ async def get_public_profile(
         select(WatchEvent, Media)
         .join(Media, WatchEvent.media_id == Media.id)
         .where(WatchEvent.user_id == user_id, WatchEvent.completed == True, Media.media_type == "movie")
+        .where(WatchEvent.watched_at.isnot(None))
         .order_by(WatchEvent.watched_at.desc())
         .limit(12)
     )
@@ -559,6 +560,7 @@ async def get_public_profile(
         .join(Media, WatchEvent.media_id == Media.id)
         .outerjoin(ShowModel, Media.show_id == ShowModel.id)
         .where(WatchEvent.user_id == user_id, WatchEvent.completed == True, Media.media_type == "episode")
+        .where(WatchEvent.watched_at.isnot(None))
         .order_by(WatchEvent.watched_at.desc())
         .limit(12)
     )
@@ -840,6 +842,7 @@ async def get_user_stats(
         date_filters.append(WatchEvent.watched_at >= since)
     if until:
         date_filters.append(WatchEvent.watched_at < until + TimeDelta(days=1))
+    dated_event_filters = [*date_filters, WatchEvent.watched_at.isnot(None)]
 
     # Activity granularity: daily for ranges ≤ 62 days, monthly otherwise
     if since and until:
@@ -910,7 +913,7 @@ async def get_user_stats(
             func.count(func.distinct(WatchEvent.media_id)).label("cnt"),
         )
         .join(Media, WatchEvent.media_id == Media.id)
-        .where(WatchEvent.user_id == user_id, Media.media_type.in_(["movie", "episode"]), *date_filters)
+        .where(WatchEvent.user_id == user_id, Media.media_type.in_(["movie", "episode"]), *dated_event_filters)
         .group_by(activity_expr, Media.media_type)
         .order_by(activity_expr)
     )
@@ -933,7 +936,7 @@ async def get_user_stats(
             func.coalesce(func.sum(effective_runtime), 0).label("minutes"),
         )
         .join(WatchEvent, WatchEvent.media_id == Media.id)
-        .where(WatchEvent.user_id == user_id, Media.media_type.in_(["movie", "episode"]), *date_filters)
+        .where(WatchEvent.user_id == user_id, Media.media_type.in_(["movie", "episode"]), *dated_event_filters)
         .group_by(activity_expr, Media.media_type)
         .order_by(activity_expr)
     )
@@ -956,7 +959,7 @@ async def get_user_stats(
             func.count(func.distinct(WatchEvent.media_id)).label("cnt"),
         )
         .join(Media, WatchEvent.media_id == Media.id)
-        .where(WatchEvent.user_id == user_id, Media.media_type.in_(["movie", "episode"]), *date_filters)
+        .where(WatchEvent.user_id == user_id, Media.media_type.in_(["movie", "episode"]), *dated_event_filters)
         .group_by(dow_expr)
         .order_by(dow_expr)
     )
@@ -966,7 +969,7 @@ async def get_user_stats(
     weeks_q = await db.execute(
         select(func.count(func.distinct(func.to_char(WatchEvent.watched_at, "IYYY-IW"))))
         .join(Media, WatchEvent.media_id == Media.id)
-        .where(WatchEvent.user_id == user_id, Media.media_type.in_(["movie", "episode"]), *date_filters)
+        .where(WatchEvent.user_id == user_id, Media.media_type.in_(["movie", "episode"]), *dated_event_filters)
     )
     total_weeks = max(weeks_q.scalar_one() or 1, 1)
     day_names = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]

--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -86,9 +86,13 @@ async def _select_in_chunks(db: AsyncSession, stmt_builder, ids: list):
     return results
 
 
-async def _latest_watched_at(db: AsyncSession, user_id: int, media_ids: list) -> dict:
-    """Latest completed WatchEvent.watched_at per media_id, chunked to avoid the 32767-parameter limit."""
-    watched_at_by_media: dict[int, datetime] = {}
+async def _latest_watched_at(
+    db: AsyncSession,
+    user_id: int,
+    media_ids: list,
+) -> dict[int, datetime | None]:
+    """Latest known completed watch date per media, or ``None`` if every date is unknown."""
+    watched_at_by_media: dict[int, datetime | None] = {}
     for i in range(0, len(media_ids), _MAX_IN_PARAMS):
         chunk = media_ids[i : i + _MAX_IN_PARAMS]
         result = await db.execute(
@@ -98,7 +102,7 @@ async def _latest_watched_at(db: AsyncSession, user_id: int, media_ids: list) ->
                 WatchEvent.media_id.in_(chunk),
                 WatchEvent.completed == True,
             )
-            .order_by(WatchEvent.watched_at.desc())
+            .order_by(WatchEvent.watched_at.desc().nulls_last())
         )
         for media_id, watched_at in result.all():
             watched_at_by_media.setdefault(media_id, watched_at)
@@ -605,9 +609,13 @@ async def _push_nuvio_library_delta(
 
 def _nuvio_watched_item(
     media: Media,
-    watched_at: datetime,
+    watched_at: datetime | None,
     show: Show | None = None,
 ) -> dict | None:
+    # Nuvio requires a timestamp for watched entries and has no unknown-date
+    # representation. Do not fabricate one for a date-less local event.
+    if watched_at is None:
+        return None
     if watched_at.tzinfo is None:
         watched_at = watched_at.replace(tzinfo=timezone.utc)
     watched_epoch_ms = int(watched_at.timestamp() * 1000)
@@ -652,14 +660,14 @@ async def _build_nuvio_watched_items(
     event_query = (
         select(WatchEvent.media_id, WatchEvent.watched_at)
         .where(WatchEvent.user_id == user_id, WatchEvent.completed == True)
-        .order_by(WatchEvent.watched_at.desc())
+        .order_by(WatchEvent.watched_at.desc().nulls_last())
     )
     if media_ids is not None:
         if not media_ids:
             return []
         event_query = event_query.where(WatchEvent.media_id.in_(media_ids))
     event_result = await db.execute(event_query)
-    latest_watched_at: dict[int, datetime] = {}
+    latest_watched_at: dict[int, datetime | None] = {}
     for media_id, watched_at in event_result.all():
         latest_watched_at.setdefault(media_id, watched_at)
     if not latest_watched_at:

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -244,7 +244,7 @@ class PasswordUpdate(BaseModel):
 class WatchEventCreate(BaseModel):
     tmdb_id: int
     media_type: MediaType
-    watched_at: Optional[datetime] = None
+    watched_at: Optional[datetime] = None  # omitted = now; explicit null = unknown
     completed: bool = True
     series_tmdb_id: Optional[int] = None
     season_number: Optional[int] = None

--- a/backend/tests/test_history.py
+++ b/backend/tests/test_history.py
@@ -1,12 +1,13 @@
 import os
 import unittest
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import ANY, AsyncMock, patch
 
 os.environ.setdefault("SECRET_KEY", "test-secret")
 os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://test:test@localhost/test")
 
 from models.base import MediaType
+from models.events import WatchEvent
 from models.media import Media
 from routers import history
 from schemas import WatchEventCreate
@@ -82,7 +83,13 @@ class ManualEpisodeWatchTests(unittest.IsolatedAsyncioTestCase):
         find_show.assert_awaited_once_with(db, 277439, "tmdb-key")
         get_episode.assert_awaited_once_with(277439, 1, 1, api_key="tmdb-key")
         enrich.assert_awaited_once_with(media, api_key="tmdb-key", series_tmdb_id=277439)
-        push_state.assert_awaited_once_with(db, 7, [media.id], watched=True)
+        push_state.assert_awaited_once_with(
+            db,
+            7,
+            [media.id],
+            watched=True,
+            watched_at_by_media={media.id: ANY},
+        )
         get_key.assert_awaited_once()
         db.commit.assert_awaited_once()
 
@@ -136,7 +143,79 @@ class ManualEpisodeWatchTests(unittest.IsolatedAsyncioTestCase):
         self.assertIsNone(mapped_media.tmdb_id)
         get_episode.assert_not_awaited()
         enrich.assert_not_awaited()
-        push_state.assert_awaited_once_with(db, 7, [303], watched=True)
+        push_state.assert_awaited_once_with(
+            db,
+            7,
+            [303],
+            watched=True,
+            watched_at_by_media={303: ANY},
+        )
+
+class _UnknownResult:
+    def __init__(self, value=None):
+        self.value = value
+
+    def scalars(self):
+        return _Scalars(self.value)
+
+
+class _Session:
+    def __init__(self, media: Media):
+        self.media = media
+        self.added = []
+        self.execute_count = 0
+        self.commit = AsyncMock()
+
+    async def execute(self, statement):
+        self.execute_count += 1
+        return _UnknownResult(self.media if self.execute_count == 1 else None)
+
+    def add(self, value):
+        self.added.append(value)
+
+
+class UnknownWatchDateTests(unittest.IsolatedAsyncioTestCase):
+    async def _mark(self, payload: dict):
+        media = Media(id=10, tmdb_id=550, media_type=MediaType.movie, title="Fight Club")
+        db = _Session(media)
+        with patch("routers.history._push_watch_state", new_callable=AsyncMock) as push:
+            await history.mark_as_watched(
+                WatchEventCreate(**payload),
+                db=db,
+                current_user=SimpleNamespace(id=7),
+            )
+        return db.added[0], push
+
+    async def test_explicit_null_marks_watched_without_a_date(self) -> None:
+        event, push = await self._mark({
+            "tmdb_id": 550,
+            "media_type": "movie",
+            "watched_at": None,
+        })
+
+        self.assertIsNone(event.watched_at)
+        self.assertEqual(push.await_args.kwargs["watched_at_by_media"], {10: None})
+
+    async def test_omitted_date_keeps_existing_now_default(self) -> None:
+        event, _ = await self._mark({
+            "tmdb_id": 550,
+            "media_type": "movie",
+        })
+
+        self.assertIsNotNone(event.watched_at)
+
+    def test_history_response_preserves_unknown_date(self) -> None:
+        media = Media(id=10, tmdb_id=550, media_type=MediaType.movie, title="Fight Club")
+        event = WatchEvent(
+            id=20,
+            user_id=7,
+            media_id=10,
+            watched_at=None,
+            completed=True,
+            play_count=1,
+        )
+
+        self.assertIsNone(history.format_event(event, media)["watched_at"])
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_nuvio.py
+++ b/backend/tests/test_nuvio.py
@@ -744,6 +744,7 @@ class NuvioNormalizationTests(unittest.TestCase):
                 "watched_at": int(watched_at.timestamp() * 1000),
             },
         )
+        self.assertIsNone(_nuvio_watched_item(movie, None))
 
         episode = Media(
             id=11,

--- a/backend/tests/test_profile.py
+++ b/backend/tests/test_profile.py
@@ -1,0 +1,73 @@
+import os
+import unittest
+from types import SimpleNamespace
+
+os.environ.setdefault("SECRET_KEY", "test-secret")
+os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://test:test@localhost/test")
+
+from routers.profile import get_user_stats
+
+
+class _Result:
+    def __init__(self, scalar=0):
+        self.scalar = scalar
+
+    def scalar_one_or_none(self):
+        return self.scalar
+
+    def scalar_one(self):
+        return self.scalar
+
+    def all(self):
+        return []
+
+
+class _StatsSession:
+    def __init__(self):
+        self.statements = []
+        self.execute_count = 0
+
+    async def execute(self, statement):
+        self.execute_count += 1
+        self.statements.append(statement)
+        if self.execute_count == 1:
+            return _Result(SimpleNamespace(id=7))
+        if self.execute_count == 2:
+            return _Result(None)
+        return _Result(0)
+
+
+class UnknownWatchDateStatsTests(unittest.IsolatedAsyncioTestCase):
+    async def test_date_based_stats_exclude_unknown_watch_dates(self) -> None:
+        db = _StatsSession()
+
+        stats = await get_user_stats(
+            7,
+            db=db,
+            current_user=SimpleNamespace(id=7, role="user"),
+        )
+
+        statements = [str(statement).lower() for statement in db.statements]
+        dated_queries = [
+            statement
+            for statement in statements
+            if "to_char(watch_events.watched_at" in statement
+            or "extract(dow from watch_events.watched_at" in statement
+        ]
+        self.assertEqual(len(dated_queries), 4)
+        self.assertTrue(all(
+            "watch_events.watched_at is not null" in statement
+            for statement in dated_queries
+        ))
+        self.assertEqual(stats["watch_activity"], [])
+        self.assertEqual(
+            stats["weekday_activity"],
+            [
+                {"day": day, "avg": 0.0}
+                for day in ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_trakt.py
+++ b/backend/tests/test_trakt.py
@@ -596,6 +596,54 @@ class TraktHistorySafetyTests(unittest.IsolatedAsyncioTestCase):
             await trakt_router._run_trakt_push(user_id=1, job_id=14)
 
         add_batch.assert_not_awaited()
+    async def test_history_batch_marks_missing_dates_as_unknown(self) -> None:
+        payloads: list[dict] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            payloads.append(json.loads(request.content))
+            return httpx.Response(201, json={"added": {"movies": 1, "episodes": 1}})
+
+        transport = httpx.MockTransport(handler)
+        with patch.object(
+            trakt.httpx,
+            "AsyncClient",
+            side_effect=lambda **kwargs: _REAL_ASYNC_CLIENT(transport=transport, **kwargs),
+        ):
+            await trakt.add_to_history_batch(
+                "client-id",
+                "access-token",
+                [(550, None)],
+                [(1396, 1, 2, None)],
+            )
+
+        self.assertEqual(payloads[0]["movies"][0]["watched_at"], "unknown")
+        self.assertEqual(
+            payloads[0]["shows"][0]["seasons"][0]["episodes"][0]["watched_at"],
+            "unknown",
+        )
+
+
+    async def test_single_history_writes_mark_missing_dates_as_unknown(self) -> None:
+        payloads: list[dict] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            payloads.append(json.loads(request.content))
+            return httpx.Response(201, json={"added": {}})
+
+        transport = httpx.MockTransport(handler)
+        with patch.object(
+            trakt.httpx,
+            "AsyncClient",
+            side_effect=lambda **kwargs: _REAL_ASYNC_CLIENT(transport=transport, **kwargs),
+        ):
+            await trakt.add_movie_to_history("client-id", "access-token", 550, None)
+            await trakt.add_episode_to_history("client-id", "access-token", 1396, 1, 2, None)
+
+        self.assertEqual(payloads[0]["movies"][0]["watched_at"], "unknown")
+        self.assertEqual(
+            payloads[1]["shows"][0]["seasons"][0]["episodes"][0]["watched_at"],
+            "unknown",
+        )
 
 if __name__ == "__main__":
     unittest.main()

--- a/frontend/src/components/HistoryCard.astro
+++ b/frontend/src/components/HistoryCard.astro
@@ -10,8 +10,9 @@ interface Props {
 const { event, use24h = false } = Astro.props;
 const { media, watched_at } = event;
 
-const date = new Date(watched_at + 'Z');
-const timeString = date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: !use24h });
+const timeString = watched_at
+  ? new Date(watched_at + 'Z').toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: !use24h })
+  : 'Unknown';
 
 const isEpisode = media.type === 'episode';
 const showOrMovieTitle = isEpisode ? (media.show_title || media.title) : media.title;

--- a/frontend/src/layouts/Base.astro
+++ b/frontend/src/layouts/Base.astro
@@ -308,6 +308,7 @@ const bottomNavItem = (active: boolean) =>
         <div class="flex gap-2">
           <button id="watch-history-now-btn" class="flex-1 px-3 py-2 rounded-xl text-sm font-bold transition-all cursor-pointer bg-blue-600 text-white">Just now</button>
           <button id="watch-history-custom-btn" class="flex-1 px-3 py-2 rounded-xl text-sm font-bold transition-all cursor-pointer bg-zinc-800 text-zinc-400 border border-zinc-700 hover:text-zinc-200">Custom</button>
+          <button id="watch-history-unknown-btn" class="flex-1 px-3 py-2 rounded-xl text-sm font-bold transition-all cursor-pointer bg-zinc-800 text-zinc-400 border border-zinc-700 hover:text-zinc-200">Unknown</button>
         </div>
         <input type="datetime-local" id="watch-history-date-input" class="hidden w-full px-3 py-2 bg-zinc-800 border border-zinc-700 rounded-xl text-sm text-zinc-200 focus:outline-none focus:border-green-500 [color-scheme:dark]" />
         <button id="watch-history-log-btn" class="w-full px-4 py-2.5 bg-green-600 hover:bg-green-500 text-white font-bold text-sm rounded-xl transition-all cursor-pointer active:scale-95">
@@ -984,7 +985,7 @@ const bottomNavItem = (active: boolean) =>
     // ── Watch history modal ────────────────────────────────────────────────────
     let _watchHistoryTmdbId = '';
     let _watchHistoryMediaType = '';
-    let _watchHistoryUseNow = true;
+    let _watchHistoryDateMode: 'now' | 'custom' | 'unknown' = 'now';
     let _watchHistoryShowTmdbId = '';
     let _watchHistorySeasonNumber = '';
     let _watchHistoryEpisodeNumber = '';
@@ -1007,14 +1008,16 @@ const bottomNavItem = (active: boolean) =>
       _watchHistoryEpisodeNumber = episodeNumber;
 
       // Reset "add play" form to "Just now"
-      _watchHistoryUseNow = true;
+      _watchHistoryDateMode = 'now';
       const nowBtn = document.getElementById('watch-history-now-btn')!;
       const customBtn = document.getElementById('watch-history-custom-btn')!;
+      const unknownBtn = document.getElementById('watch-history-unknown-btn')!;
       const dateInput = document.getElementById('watch-history-date-input') as HTMLInputElement;
       const activeClass = 'flex-1 px-3 py-2 rounded-xl text-sm font-bold transition-all cursor-pointer bg-blue-600 text-white';
       const inactiveClass = 'flex-1 px-3 py-2 rounded-xl text-sm font-bold transition-all cursor-pointer bg-zinc-800 text-zinc-400 border border-zinc-700 hover:text-zinc-200';
       nowBtn.className = activeClass;
       customBtn.className = inactiveClass;
+      unknownBtn.className = inactiveClass;
       dateInput.classList.add('hidden');
       dateInput.value = toLocal(new Date());
       dateInput.max = toLocal(new Date());
@@ -1030,15 +1033,16 @@ const bottomNavItem = (active: boolean) =>
       const unwatchBtn = document.getElementById('watch-history-unwatch-btn') as HTMLButtonElement;
       unwatchBtn.classList.add('hidden');
       try {
-        const events: Array<{ id: number; watched_at: string }> = await apiFetch(
+        const events: Array<{ id: number; watched_at: string | null }> = await apiFetch(
           `/history/item-events?tmdb_id=${_watchHistoryTmdbId}&media_type=${_watchHistoryMediaType}`
         );
         if (events.length === 0) {
           eventsEl.innerHTML = '<div class="px-4 py-3 text-sm text-zinc-500 italic">No plays recorded yet</div>';
         } else {
           eventsEl.innerHTML = events.map(ev => {
-            const d = new Date(ev.watched_at + 'Z');
-            const fmt = d.toLocaleString(undefined, { month: 'short', day: 'numeric', year: 'numeric', hour: 'numeric', minute: '2-digit', hour12: !(window as any).__USE_24H__ });
+            const fmt = ev.watched_at
+              ? new Date(ev.watched_at + 'Z').toLocaleString(undefined, { month: 'short', day: 'numeric', year: 'numeric', hour: 'numeric', minute: '2-digit', hour12: !(window as any).__USE_24H__ })
+              : 'Unknown date';
             return `<div class="flex items-center justify-between px-4 py-2.5 hover:bg-zinc-800/50 group">
               <span class="text-sm text-zinc-200">${esc(fmt)}</span>
               <button class="text-zinc-600 group-hover:text-zinc-400 hover:!text-red-400 transition-colors cursor-pointer" data-delete-event="${ev.id}" aria-label="Remove">
@@ -1106,25 +1110,39 @@ const bottomNavItem = (active: boolean) =>
       const inactiveClass = 'flex-1 px-3 py-2 rounded-xl text-sm font-bold transition-all cursor-pointer bg-zinc-800 text-zinc-400 border border-zinc-700 hover:text-zinc-200';
 
       document.getElementById('watch-history-now-btn')!.addEventListener('click', () => {
-        _watchHistoryUseNow = true;
+        _watchHistoryDateMode = 'now';
         (document.getElementById('watch-history-now-btn') as HTMLElement).className = activeClass;
         (document.getElementById('watch-history-custom-btn') as HTMLElement).className = inactiveClass;
+        (document.getElementById('watch-history-unknown-btn') as HTMLElement).className = inactiveClass;
         document.getElementById('watch-history-date-input')!.classList.add('hidden');
       });
 
       document.getElementById('watch-history-custom-btn')!.addEventListener('click', () => {
-        _watchHistoryUseNow = false;
+        _watchHistoryDateMode = 'custom';
         (document.getElementById('watch-history-now-btn') as HTMLElement).className = inactiveClass;
         (document.getElementById('watch-history-custom-btn') as HTMLElement).className = activeClass;
+        (document.getElementById('watch-history-unknown-btn') as HTMLElement).className = inactiveClass;
         const input = document.getElementById('watch-history-date-input') as HTMLInputElement;
         input.max = toLocal(new Date());
         input.classList.remove('hidden');
         input.focus();
       });
 
+      document.getElementById('watch-history-unknown-btn')!.addEventListener('click', () => {
+        _watchHistoryDateMode = 'unknown';
+        (document.getElementById('watch-history-now-btn') as HTMLElement).className = inactiveClass;
+        (document.getElementById('watch-history-custom-btn') as HTMLElement).className = inactiveClass;
+        (document.getElementById('watch-history-unknown-btn') as HTMLElement).className = activeClass;
+        document.getElementById('watch-history-date-input')!.classList.add('hidden');
+      });
+
       document.getElementById('watch-history-log-btn')!.addEventListener('click', async () => {
         const input = document.getElementById('watch-history-date-input') as HTMLInputElement;
-        const watchedAt = _watchHistoryUseNow ? toUTC(new Date()) : toUTC(new Date(input.value || toLocal(new Date())));
+        const watchedAt = _watchHistoryDateMode === 'unknown'
+          ? null
+          : _watchHistoryDateMode === 'now'
+            ? toUTC(new Date())
+            : toUTC(new Date(input.value || toLocal(new Date())));
         const logBtn = document.getElementById('watch-history-log-btn') as HTMLButtonElement;
         const idleLabel = logBtn.textContent || 'Mark as watched';
         logBtn.disabled = true;
@@ -1144,9 +1162,10 @@ const bottomNavItem = (active: boolean) =>
           await apiFetch('/history', 'POST', watchBody);
           await loadWatchHistoryEvents();
           // Reset to "Just now" after logging
-          _watchHistoryUseNow = true;
+          _watchHistoryDateMode = 'now';
           (document.getElementById('watch-history-now-btn') as HTMLElement).className = activeClass;
           (document.getElementById('watch-history-custom-btn') as HTMLElement).className = inactiveClass;
+          (document.getElementById('watch-history-unknown-btn') as HTMLElement).className = inactiveClass;
           input.classList.add('hidden');
         } catch { logBtn.textContent = idleLabel; }
         logBtn.disabled = false;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -222,7 +222,7 @@ export interface WatchEvent {
   id: number;
   media: MediaItem;
   user_id: number;
-  watched_at: string;
+  watched_at: string | null;
   completed: boolean;
   progress_percent: number | null;
 }
@@ -1181,7 +1181,7 @@ export const api = {
     list: (params?: { page?: number; page_size?: number; type?: string }, token?: string) =>
       get<{ page: number; page_size: number; total_pages: number; total_results: number; results: WatchEvent[] }>("/history", params, token),
 
-    markAsWatched: (body: { tmdb_id: number; media_type: string; watched_at?: string; completed?: boolean }, token: string) =>
+    markAsWatched: (body: { tmdb_id: number; media_type: string; watched_at?: string | null; completed?: boolean }, token: string) =>
       post<{ message: string }>("/history", body, token),
 
     unwatchItem: (tmdbId: number, mediaType: string, token: string) =>

--- a/frontend/src/pages/history.astro
+++ b/frontend/src/pages/history.astro
@@ -14,12 +14,14 @@ const history = await api.history.list({ page, page_size: 40, type }, token);
 
 // Grouping logic
 const groupedHistory = history.results.reduce<Record<string, WatchEvent[]>>((acc, event) => {
-  const dateStr = new Date(event.watched_at + 'Z').toLocaleDateString('en-US', {
-    weekday: 'long',
-    month: 'long',
-    day: 'numeric',
-    year: 'numeric'
-  });
+  const dateStr = event.watched_at
+    ? new Date(event.watched_at + 'Z').toLocaleDateString('en-US', {
+        weekday: 'long',
+        month: 'long',
+        day: 'numeric',
+        year: 'numeric'
+      })
+    : 'Date unknown';
   
   if (!acc[dateStr]) {
     acc[dateStr] = [];


### PR DESCRIPTION
## Summary
- add an **Unknown** date choice when logging a movie or episode and persist explicit `null` watch dates while keeping omitted dates backward-compatible as "now"
- render unknown dates safely in item history and Watch History, keep them out of recent/date-bucket statistics, and add the nullable `watch_events.watched_at` migration
- send Trakt's documented `watched_at: "unknown"` sentinel; avoid fabricating timestamps for providers that cannot represent unknown dates
- preserve the parent-show repair introduced by #86 after rebasing onto the latest `main`

## Validation
- `python -m unittest tests.test_history tests.test_profile tests.test_trakt tests.test_nuvio -v` — 40 passed
- `python -m unittest discover -s tests -v` — 82 passed
- `npm run build` — passed
- `python -m alembic heads` — single head `b7c8d9e0f1a2`
- Alembic upgrade SQL from `b6c7d8e9f0a1` to `b7c8d9e0f1a2` compiled successfully
- browser smoke: Unknown option is visible, becomes active, and hides the custom date input

Closes #87