### PR TITLE
feat(sync): add Stremio synchronization

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 ---
 
-Scrob syncs your libraries from **Jellyfin**, **Plex**, **Emby**, and **Nuvio**, tracks your watch history, ratings, and personal lists, and can push watched activity back to connected providers - all from a clean, app-like web interface that installs as a PWA on any device.
+Scrob syncs your libraries from **Jellyfin**, **Plex**, **Emby**, **Nuvio**, and **Stremio**, tracks your watch history, ratings, and personal lists, and can push watched activity back to connected providers - all from a clean, app-like web interface that installs as a PWA on any device.
 
 ## Table of Contents
 
@@ -31,6 +31,10 @@ Scrob syncs your libraries from **Jellyfin**, **Plex**, **Emby**, and **Nuvio**,
   - [Synchronization Directions](#synchronization-directions)
   - [Scheduling and Limitations](#scheduling-and-limitations)
 - [Trakt Synchronization](#trakt-synchronization)
+- [Stremio Synchronization](#stremio-synchronization)
+  - [Connect Stremio](#connect-stremio)
+  - [Stremio Synchronization Directions](#stremio-synchronization-directions)
+  - [Scheduling, Full Resync, and Limitations](#scheduling-full-resync-and-limitations)
 - [MDBList Synchronization](#mdblist-synchronization)
 - [Webhooks](#webhooks-real-time-scrobbling)
   - [Jellyfin](#jellyfin)
@@ -46,8 +50,8 @@ Scrob syncs your libraries from **Jellyfin**, **Plex**, **Emby**, and **Nuvio**,
 
 ## Features
 
-- **Multi-source sync**: Import libraries and watch history from Jellyfin, Plex, Emby, and Nuvio. Nuvio also imports playback progress for Continue Watching.
-- **Keep providers in sync**: Keep watched status synchronized between your media servers and Nuvio. Supports multiple instances and Nuvio profiles.
+- **Multi-source sync**: Import libraries, watched status, and playback progress from Jellyfin, Plex, Emby, Nuvio, and Stremio.
+- **Keep providers in sync**: Keep collection membership, watched status, and playback progress synchronized between media servers, Nuvio, and Stremio. Supports multiple server instances and Nuvio profiles.
 - **Real-time scrobbling**: Webhooks from Jellyfin, Plex, Emby, and Kodi update your watch state as you play - no manual sync needed.
 - **Manual scrobble**: Start a watching session directly from any movie or episode page. Pause, resume, stop, or mark as watched - session progress shows live on the home screen.
 - **Trakt integration**: Sync your watched history, ratings, and lists from Trakt, and push Scrob activity back to Trakt automatically. Connecting live requires a Trakt VIP subscription (a recent Trakt-side restriction) — everyone else can still import via a Trakt data export, no VIP needed. See [Trakt Synchronization](#trakt-synchronization).
@@ -256,10 +260,10 @@ docker run -d \
 ### First Setup
 
 1. Open `http://localhost:7330` and create your account.
-2. Go to **Settings → Integrations** to add your TMDB Read Access Token and connect Jellyfin, Plex, Emby, or Nuvio.
-3. Select which media-server libraries to sync, or select a Nuvio profile, then trigger your first sync.
+2. Go to **Settings → Integrations** to add your TMDB Read Access Token, then open **Settings → Media & Cloud Connections** to connect Jellyfin, Plex, Emby, Nuvio, or Stremio.
+3. Select which libraries and synchronization directions to enable, then trigger your first sync.
 
-For Nuvio, choose **Nuvio** as the provider, sign in, and select one of the returned profiles. See [Nuvio Cloud Synchronization](#nuvio-cloud-synchronization) for credential handling, sync directions, scheduling, and current limitations.
+For Nuvio, sign in and select one of the returned profiles. For Stremio, select **Connect Stremio**, then authorize the generated Link code or QR code in your Stremio account. See [Nuvio Cloud Synchronization](#nuvio-cloud-synchronization) and [Stremio Synchronization](#stremio-synchronization) for provider-specific behavior and limitations.
 
 ### Updating
 
@@ -327,16 +331,17 @@ Each connection targets one Nuvio profile. Add another connection if you need to
 | Nuvio → Scrob | **Collection status** | Imports the profile's library movies and series. |
 | Nuvio → Scrob | **Watched status** | Imports watched movies and episodes with their latest watch timestamps. |
 | Nuvio → Scrob | **Playback progress** | Imports position and duration into Continue Watching. |
+| Scrob → Nuvio | **Collection status** | Adds or removes library membership while preserving unrelated Nuvio items. |
 | Scrob → Nuvio | **Watched status** | Pushes watched and unwatched changes made in Scrob or imported from another connected provider. |
 | Scrob → Nuvio | **Playback progress** | Pushes current playback positions into Nuvio's Continue Watching state as non-destructive upserts. |
 
-**Sync now** runs an inbound synchronization using the enabled Nuvio → Scrob settings. **Push** sends the enabled watched-history and playback-progress data from Scrob to Nuvio. Both operations use non-destructive upserts; items absent from Scrob are not removed from Nuvio.
+**Sync now** runs an inbound synchronization using the enabled Nuvio → Scrob settings. **Push** sends the enabled collection, watched-history, and playback-progress data from Scrob to Nuvio. Pushes use merge semantics and preserve unrelated remote items.
 
-Library membership is currently pull-only. Ratings are not synchronized with Nuvio.
+Ratings are not synchronized with Nuvio.
 
 ### Scheduling and Limitations
 
-**Auto Pull** repeats the enabled inbound synchronization every 15 minutes, 30 minutes, 1 hour, 3 hours, 6 hours, 12 hours, 24 hours, or 48 hours. Nuvio synchronization is polling-based; Nuvio does not use the media-server webhook URLs documented below.
+**Auto Pull** and **Auto Push** can run independently every 15 minutes, 30 minutes, 1 hour, 3 hours, 6 hours, 12 hours, 24 hours, or 48 hours. Nuvio synchronization is polling-based; Nuvio does not use the media-server webhook URLs documented below.
 
 Inbound Nuvio identifiers are normalized to TMDB for Scrob's internal matching. Before an outbound push, Scrob resolves those TMDB identifiers to Nuvio-compatible bare IMDb identifiers (`tt...`) and caches the mapping. Unsupported identifiers are skipped rather than attached to the wrong title.
 
@@ -364,6 +369,43 @@ Trakt now requires a **Trakt VIP** subscription to create a new API application 
 3. Choose what to import — Watched History, Ratings (including per-episode), and/or Lists, all preselected by default — then confirm. This is a one-shot, per-upload choice, independent of the **Trakt → Scrob** preferences used by the OAuth pull.
 
 Re-uploading a newer export is safe to do any time you want to catch up on new activity — imported watch plays and ratings are deduplicated, so nothing is imported twice.
+## Stremio Synchronization
+
+Scrob uses Stremio's account datastore API at `https://api.strem.io`, the official Link flow at `https://link.stremio.com`, and Cinemeta episode metadata. Configure a TMDB Read Access Token in Scrob before synchronizing so Stremio IMDb identifiers can be mapped to Scrob media.
+
+### Connect Stremio
+
+1. Open **Settings → Media & Cloud Connections** and select **Add Connection**.
+2. Choose **Stremio**, enter a connection name, and select **Connect Stremio**.
+3. Open the generated authorization link or scan its QR code, then approve the connection in Stremio.
+4. Return to Scrob. The page detects the authorization and creates the connection automatically.
+
+Scrob never asks for or stores your Stremio password. The Link flow returns an account authorization key, which is stored server-side and redacted from frontend API responses. Deleting the connection logs out that Stremio session. Each Scrob user can have one Stremio connection.
+
+Authorization links expire in the Scrob interface after 10 minutes. Select **Connect Stremio** again to generate a fresh code.
+
+### Stremio Synchronization Directions
+
+| Direction | Setting | Behavior |
+|---|---|---|
+| Stremio → Scrob | **Collection status** | Imports active Stremio library movies and series. |
+| Stremio → Scrob | **Watched status** | Imports watched movies and episodes. Series episode state is decoded from Stremio's watched bitfield using Cinemeta episode order. |
+| Stremio → Scrob | **Playback progress** | Imports the current movie or episode position and duration into Continue Watching. |
+| Scrob → Stremio | **Collection status** | Adds local collection items and removes only items previously pushed by this Scrob connection. Items created directly in Stremio are preserved. |
+| Scrob → Stremio | **Watched status** | Merges movie and episode watched state into the existing Stremio record. |
+| Scrob → Stremio | **Playback progress** | Merges the current playback position, duration, and episode identifier into Stremio. |
+
+**Sync now** performs an inbound pull. The first pull reads the complete Stremio library; later pulls use Stremio modification metadata with a five-minute overlap window. **Push** sends the complete set of enabled outbound data. Changes imported from another provider are also forwarded to Stremio when the corresponding outbound option is enabled.
+
+Outbound writes first fetch the current Stremio record and preserve unknown fields, addon metadata, and unrelated remote items. No-op records are skipped. Ratings and Stremio addons are not synchronized.
+
+### Scheduling, Full Resync, and Limitations
+
+**Auto Pull** and **Auto Push** use separate schedules and can run every 15 minutes, 30 minutes, 1 hour, 3 hours, 6 hours, 12 hours, 24 hours, or 48 hours.
+
+Use **Full resync** when the incremental cursor must be rebuilt. It reads the complete Stremio library and reconciles only collection sources owned by that Stremio connection; collection entries still backed by Jellyfin, Plex, Emby, Nuvio, or another source remain in Scrob.
+
+Stremio exposes a current watched state rather than Scrob's complete per-play history. For series, Stremio stores a watched-episode bitfield and one `lastWatched` timestamp for the item, so repeated episode plays and their individual timestamps cannot be reconstructed exactly. Playback progress represents one current movie or episode per library item.
 
 ## MDBList Synchronization
 

--- a/backend/core/stremio.py
+++ b/backend/core/stremio.py
@@ -1,0 +1,210 @@
+import base64
+import zlib
+from typing import Any
+
+import httpx
+
+
+DEFAULT_URL = "https://api.strem.io"
+API_URL = f"{DEFAULT_URL}/api"
+LINK_URL = "https://link.stremio.com/api/v2"
+CINEMETA_URL = "https://v3-cinemeta.strem.io"
+LIBRARY_COLLECTION = "libraryItem"
+_TIMEOUT = 30.0
+
+
+class StremioAPIError(RuntimeError):
+    def __init__(self, message: str, *, code: int | None = None):
+        super().__init__(message)
+        self.code = code
+
+
+def _result(payload: Any, operation: str) -> Any:
+    if not isinstance(payload, dict):
+        raise StremioAPIError(f"Stremio {operation} returned an invalid response")
+    error = payload.get("error")
+    if error:
+        if isinstance(error, dict):
+            message = str(error.get("message") or "Unknown API error")
+            code = error.get("code")
+            try:
+                parsed_code = int(code) if code is not None else None
+            except (TypeError, ValueError):
+                parsed_code = None
+            raise StremioAPIError(f"Stremio {operation} failed: {message}", code=parsed_code)
+        raise StremioAPIError(f"Stremio {operation} failed: {error}")
+    if "result" not in payload:
+        raise StremioAPIError(f"Stremio {operation} returned no result")
+    return payload["result"]
+
+
+async def _json(response: httpx.Response, operation: str) -> Any:
+    try:
+        response.raise_for_status()
+    except httpx.HTTPStatusError as exc:
+        raise StremioAPIError(
+            f"Stremio {operation} failed ({response.status_code})"
+        ) from exc
+    try:
+        return response.json()
+    except ValueError as exc:
+        raise StremioAPIError(
+            f"Stremio {operation} returned invalid JSON"
+        ) from exc
+
+
+async def create_link_code() -> dict[str, Any]:
+    async with httpx.AsyncClient(timeout=_TIMEOUT, follow_redirects=False) as client:
+        response = await client.get(f"{LINK_URL}/create", params={"type": "Create"})
+    result = _result(await _json(response, "link creation"), "link creation")
+    if not isinstance(result, dict) or not all(result.get(key) for key in ("code", "link", "qrcode")):
+        raise StremioAPIError("Stremio link creation returned incomplete data")
+    return result
+
+
+async def read_link_code(code: str) -> str | None:
+    normalized = code.strip().upper()
+    if not normalized:
+        raise StremioAPIError("Stremio link code is required")
+    async with httpx.AsyncClient(timeout=_TIMEOUT, follow_redirects=False) as client:
+        response = await client.get(
+            f"{LINK_URL}/read",
+            params={"type": "Read", "code": normalized},
+        )
+    payload = await _json(response, "link authorization")
+    try:
+        result = _result(payload, "link authorization")
+    except StremioAPIError as exc:
+        if exc.code == 101:
+            return None
+        raise
+    auth_key = result.get("authKey") if isinstance(result, dict) else None
+    if not auth_key:
+        raise StremioAPIError("Stremio link authorization returned no auth key")
+    return str(auth_key)
+
+
+async def _api_request(path: str, body: dict[str, Any], operation: str) -> Any:
+    async with httpx.AsyncClient(timeout=_TIMEOUT, follow_redirects=False) as client:
+        response = await client.post(
+            f"{API_URL}/{path}",
+            headers={"Content-Type": "application/json"},
+            json=body,
+        )
+    return _result(await _json(response, operation), operation)
+
+
+async def get_user(auth_key: str) -> dict[str, Any]:
+    result = await _api_request(
+        "getUser",
+        {"type": "GetUser", "authKey": auth_key},
+        "account validation",
+    )
+    if not isinstance(result, dict) or not result.get("_id"):
+        raise StremioAPIError("Stremio account validation returned incomplete data")
+    return result
+
+
+async def validate_auth_key(auth_key: str) -> dict[str, Any]:
+    return await get_user(auth_key)
+
+
+async def datastore_meta(auth_key: str) -> list[list[Any]]:
+    result = await _api_request(
+        "datastoreMeta",
+        {"authKey": auth_key, "collection": LIBRARY_COLLECTION},
+        "library metadata pull",
+    )
+    return result if isinstance(result, list) else []
+
+
+async def datastore_get(
+    auth_key: str,
+    *,
+    ids: list[str] | None = None,
+    all_items: bool = False,
+) -> list[dict[str, Any]]:
+    result = await _api_request(
+        "datastoreGet",
+        {
+            "authKey": auth_key,
+            "collection": LIBRARY_COLLECTION,
+            "ids": ids or [],
+            "all": all_items,
+        },
+        "library pull",
+    )
+    return [item for item in result if isinstance(item, dict)] if isinstance(result, list) else []
+
+
+async def datastore_put(auth_key: str, changes: list[dict[str, Any]]) -> None:
+    if not changes:
+        return
+    result = await _api_request(
+        "datastorePut",
+        {
+            "authKey": auth_key,
+            "collection": LIBRARY_COLLECTION,
+            "changes": changes,
+        },
+        "library push",
+    )
+    if not isinstance(result, dict) or result.get("success") is not True:
+        raise StremioAPIError("Stremio library push was not acknowledged")
+
+
+async def logout(auth_key: str) -> None:
+    await _api_request(
+        "logout",
+        {"type": "Logout", "authKey": auth_key},
+        "logout",
+    )
+
+
+async def get_cinemeta_series(imdb_id: str) -> dict[str, Any]:
+    async with httpx.AsyncClient(timeout=_TIMEOUT, follow_redirects=False) as client:
+        response = await client.get(f"{CINEMETA_URL}/meta/series/{imdb_id}.json")
+    payload = await _json(response, "Cinemeta lookup")
+    meta = payload.get("meta") if isinstance(payload, dict) else None
+    if not isinstance(meta, dict):
+        raise StremioAPIError(f"Cinemeta series {imdb_id} was not found")
+    return meta
+
+
+def decode_watched_bitfield(serialized: str | None, video_ids: list[str]) -> set[str]:
+    if not serialized or not video_ids:
+        return set()
+    try:
+        anchor_video_id, anchor_length_raw, packed = serialized.rsplit(":", 2)
+        anchor_length = int(anchor_length_raw)
+        anchor_index = video_ids.index(anchor_video_id)
+        previous = zlib.decompress(base64.b64decode(packed))
+    except (ValueError, TypeError, zlib.error, base64.binascii.Error):
+        return set()
+    if anchor_length <= 0:
+        return set()
+
+    offset = (anchor_length - 1) - anchor_index
+    watched: set[str] = set()
+    for index, video_id in enumerate(video_ids):
+        previous_index = index + offset
+        if previous_index < 0 or previous_index >= anchor_length:
+            continue
+        byte_index, bit_index = divmod(previous_index, 8)
+        if byte_index < len(previous) and previous[byte_index] & (1 << bit_index):
+            watched.add(video_id)
+    return watched
+
+
+def encode_watched_bitfield(watched_ids: set[str], video_ids: list[str]) -> str | None:
+    if not video_ids:
+        return None
+    values = bytearray((len(video_ids) + 7) // 8)
+    last_watched_index = 0
+    for index, video_id in enumerate(video_ids):
+        if video_id in watched_ids:
+            byte_index, bit_index = divmod(index, 8)
+            values[byte_index] |= 1 << bit_index
+            last_watched_index = index
+    packed = base64.b64encode(zlib.compress(bytes(values))).decode("ascii")
+    return f"{video_ids[last_watched_index]}:{last_watched_index + 1}:{packed}"

--- a/backend/main.py
+++ b/backend/main.py
@@ -29,6 +29,7 @@ async def _auto_sync_scheduler():
         run_emby_sync,
         run_jellyfin_sync,
         run_nuvio_sync,
+        run_stremio_sync,
         run_plex_sync,
     )
 
@@ -38,12 +39,14 @@ async def _auto_sync_scheduler():
         "emby": CollectionSource.emby,
         "plex": CollectionSource.plex,
         "nuvio": CollectionSource.nuvio,
+        "stremio": CollectionSource.stremio,
     }
     runner_map = {
         "jellyfin": run_jellyfin_sync,
         "emby": run_emby_sync,
         "plex": run_plex_sync,
         "nuvio": run_nuvio_sync,
+        "stremio": run_stremio_sync,
     }
 
     while True:

--- a/backend/migrations/versions/d7e8f9a0b1c2_add_stremio_provider.py
+++ b/backend/migrations/versions/d7e8f9a0b1c2_add_stremio_provider.py
@@ -1,0 +1,52 @@
+"""add Stremio provider
+
+Revision ID: d7e8f9a0b1c2
+Revises: c7d8e9f0a1b2
+Create Date: 2026-07-26
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+
+revision = "d7e8f9a0b1c2"
+down_revision = "c7d8e9f0a1b2"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute("ALTER TYPE collectionsource ADD VALUE IF NOT EXISTS 'stremio'")
+    op.drop_constraint("ck_msc_type", "media_server_connections", type_="check")
+    op.create_check_constraint(
+        "ck_msc_type",
+        "media_server_connections",
+        "type IN ('plex', 'jellyfin', 'emby', 'nuvio', 'stremio')",
+    )
+    op.add_column(
+        "media_server_connections",
+        sa.Column("stremio_pull_cursor_at", sa.DateTime(), nullable=True),
+    )
+    op.add_column(
+        "media_server_connections",
+        sa.Column(
+            "stremio_full_sync_done",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+    op.add_column(
+        "media_server_connections",
+        sa.Column("stremio_pushed_library_ids", JSONB(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("media_server_connections", "stremio_pushed_library_ids")
+    op.drop_column("media_server_connections", "stremio_full_sync_done")
+    op.drop_column("media_server_connections", "stremio_pull_cursor_at")
+    # PostgreSQL enum values cannot be removed safely in-place. Keep the value and
+    # compatible constraint; older application versions do not create Stremio rows.

--- a/backend/models/base.py
+++ b/backend/models/base.py
@@ -20,6 +20,7 @@ class CollectionSource(str, enum.Enum):
     emby     = "emby"
     plex     = "plex"
     nuvio    = "nuvio"
+    stremio  = "stremio"
     trakt    = "trakt"
     simkl    = "simkl"
     mdblist  = "mdblist"

--- a/backend/models/connections.py
+++ b/backend/models/connections.py
@@ -13,7 +13,7 @@ class MediaServerConnection(Base):
 
     id               : Mapped[int]           = mapped_column(Integer, primary_key=True)
     user_id          : Mapped[int]           = mapped_column(Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True)
-    type             : Mapped[str]           = mapped_column(String(50), nullable=False)   # plex | jellyfin | emby
+    type             : Mapped[str]           = mapped_column(String(50), nullable=False)   # plex | jellyfin | emby | nuvio | stremio
     name             : Mapped[str]           = mapped_column(String(255), nullable=False)
     url              : Mapped[str]           = mapped_column(String(500), nullable=False)
     token            : Mapped[str]           = mapped_column(String(500), nullable=False)
@@ -42,6 +42,11 @@ class MediaServerConnection(Base):
     watchlist_all_users       : Mapped[bool]           = mapped_column(Boolean, nullable=False, default=False, server_default="false")
     watchlist_monitored_users : Mapped[Optional[list]] = mapped_column(JSONB, nullable=True)
     watchlist_synced_ids      : Mapped[Optional[list]] = mapped_column(JSONB, nullable=True)
+
+    # Stremio account datastore sync state
+    stremio_pull_cursor_at     : Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+    stremio_full_sync_done     : Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="false")
+    stremio_pushed_library_ids : Mapped[Optional[list]] = mapped_column(JSONB, nullable=True)
 
     # Plex watchlist ↔ Scrob list sync (Plex connections only)
     plex_sync_watchlist : Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="false")

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -444,12 +444,38 @@ async def create_connection(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    if body.type not in ("plex", "jellyfin", "emby", "nuvio"):
-        raise HTTPException(status_code=400, detail="type must be plex, jellyfin, emby, or nuvio")
-    validated_url = await validate_service_url(body.url, f"{body.type.capitalize()} URL")
+    if body.type not in ("plex", "jellyfin", "emby", "nuvio", "stremio"):
+        raise HTTPException(
+            status_code=400,
+            detail="type must be plex, jellyfin, emby, nuvio, or stremio",
+        )
+    validated_url = body.url
     connection_token = body.token
     server_user_id = body.server_user_id
     server_username = body.server_username
+    if body.type == "stremio":
+        from core import stremio
+
+        existing_result = await db.execute(
+            select(MediaServerConnection).where(
+                MediaServerConnection.user_id == current_user.id,
+                MediaServerConnection.type == "stremio",
+            )
+        )
+        if existing_result.scalar_one_or_none():
+            raise HTTPException(status_code=409, detail="Stremio is already connected")
+        try:
+            account = await stremio.validate_auth_key(connection_token)
+        except stremio.StremioAPIError as exc:
+            raise HTTPException(status_code=400, detail=str(exc))
+        validated_url = stremio.DEFAULT_URL
+        server_user_id = str(account["_id"])
+        server_username = str(account.get("email") or "Stremio")
+    else:
+        validated_url = await validate_service_url(
+            body.url,
+            f"{body.type.capitalize()} URL",
+        )
     if body.type == "nuvio":
         from core import nuvio
 
@@ -462,6 +488,7 @@ async def create_connection(
         server_user_id = str(profile_id)
         server_username = _nuvio_profile_name(profiles, profile_id)
 
+    cloud_media_provider = body.type in ("nuvio", "stremio")
     conn = MediaServerConnection(
         user_id=current_user.id,
         type=body.type,
@@ -472,12 +499,12 @@ async def create_connection(
         server_username=server_username,
         sync_collection=body.sync_collection,
         sync_watched=body.sync_watched,
-        sync_ratings=body.sync_ratings if body.type != "nuvio" else False,
+        sync_ratings=body.sync_ratings if not cloud_media_provider else False,
         sync_playback=body.sync_playback,
         push_watched=body.push_watched,
-        push_collection=body.push_collection if body.type == "nuvio" else False,
-        push_playback=body.push_playback if body.type == "nuvio" else False,
-        push_ratings=body.push_ratings if body.type != "nuvio" else False,
+        push_collection=body.push_collection if cloud_media_provider else False,
+        push_playback=body.push_playback if cloud_media_provider else False,
+        push_ratings=body.push_ratings if not cloud_media_provider else False,
         auto_sync_interval=body.auto_sync_interval,
         auto_push_interval=body.auto_push_interval,
     )
@@ -505,29 +532,51 @@ async def update_connection(
         raise HTTPException(status_code=404, detail="Connection not found")
 
     update_data = body.model_dump(exclude_unset=True)
-    if "url" in update_data and update_data["url"]:
-        update_data["url"] = await validate_service_url(update_data["url"], f"{conn.type.capitalize()} URL")
+    if conn.type == "stremio":
+        from core import stremio
 
-    if conn.type == "nuvio":
-        from core import nuvio
-
-        candidate_url = update_data.get("url", conn.url)
-        candidate_token = update_data.get("token", conn.token)
-        profile_id = _parse_nuvio_profile_id(update_data.get("server_user_id", conn.server_user_id))
-        try:
-            session, profiles = await nuvio.validate_connection(candidate_url, candidate_token, profile_id)
-        except nuvio.NuvioAPIError as exc:
-            raise HTTPException(status_code=400, detail=str(exc))
-        update_data["token"] = session.refresh_token
-        update_data["server_user_id"] = str(profile_id)
-        update_data["server_username"] = _nuvio_profile_name(profiles, profile_id)
+        update_data["url"] = stremio.DEFAULT_URL
+        candidate_token = update_data.get("token")
+        if candidate_token:
+            try:
+                account = await stremio.validate_auth_key(candidate_token)
+            except stremio.StremioAPIError as exc:
+                raise HTTPException(status_code=400, detail=str(exc))
+            update_data["server_user_id"] = str(account["_id"])
+            update_data["server_username"] = str(account.get("email") or "Stremio")
+        else:
+            update_data.pop("token", None)
         update_data["sync_ratings"] = False
         update_data["push_ratings"] = False
         update_data["push_playback"] = update_data.get("push_playback", conn.push_playback)
         update_data["push_collection"] = update_data.get("push_collection", conn.push_collection)
     else:
-        update_data["push_playback"] = False
-        update_data["push_collection"] = False
+        if "url" in update_data and update_data["url"]:
+            update_data["url"] = await validate_service_url(
+                update_data["url"],
+                f"{conn.type.capitalize()} URL",
+            )
+
+        if conn.type == "nuvio":
+            from core import nuvio
+
+            candidate_url = update_data.get("url", conn.url)
+            candidate_token = update_data.get("token", conn.token)
+            profile_id = _parse_nuvio_profile_id(update_data.get("server_user_id", conn.server_user_id))
+            try:
+                session, profiles = await nuvio.validate_connection(candidate_url, candidate_token, profile_id)
+            except nuvio.NuvioAPIError as exc:
+                raise HTTPException(status_code=400, detail=str(exc))
+            update_data["token"] = session.refresh_token
+            update_data["server_user_id"] = str(profile_id)
+            update_data["server_username"] = _nuvio_profile_name(profiles, profile_id)
+            update_data["sync_ratings"] = False
+            update_data["push_ratings"] = False
+            update_data["push_playback"] = update_data.get("push_playback", conn.push_playback)
+            update_data["push_collection"] = update_data.get("push_collection", conn.push_collection)
+        else:
+            update_data["push_playback"] = False
+            update_data["push_collection"] = False
 
     for field, value in update_data.items():
         setattr(conn, field, value)
@@ -552,6 +601,16 @@ async def delete_connection(
     conn = result.scalar_one_or_none()
     if not conn:
         raise HTTPException(status_code=404, detail="Connection not found")
+    if conn.type == "stremio":
+        from core import stremio
+
+        try:
+            await stremio.logout(conn.token)
+        except stremio.StremioAPIError:
+            logger.warning(
+                "Failed to revoke Stremio session for connection %s",
+                conn.id,
+            )
     await db.delete(conn)
     await db.commit()
     return {"status": "deleted"}
@@ -734,6 +793,76 @@ async def test_plex(
     return {"status": "ok"}
 
 
+@router.post("/stremio/link/start")
+async def start_stremio_link(
+    current_user: User = Depends(get_current_user),
+):
+    from core import stremio
+
+    try:
+        link = await stremio.create_link_code()
+    except stremio.StremioAPIError as exc:
+        raise HTTPException(status_code=502, detail=str(exc))
+    return {
+        "code": link["code"],
+        "link": link["link"],
+        "qrcode": link["qrcode"],
+    }
+
+
+@router.post("/stremio/link/poll")
+async def poll_stremio_link(
+    body: schemas.StremioLinkPollRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    from core import stremio
+
+    existing_result = await db.execute(
+        select(MediaServerConnection).where(
+            MediaServerConnection.user_id == current_user.id,
+            MediaServerConnection.type == "stremio",
+        )
+    )
+    if existing_result.scalar_one_or_none():
+        raise HTTPException(status_code=409, detail="Stremio is already connected")
+
+    try:
+        auth_key = await stremio.read_link_code(body.code)
+        if auth_key is None:
+            return {"status": "pending"}
+        account = await stremio.validate_auth_key(auth_key)
+    except stremio.StremioAPIError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+    connection = MediaServerConnection(
+        user_id=current_user.id,
+        type="stremio",
+        name=body.name.strip() or "Stremio",
+        url=stremio.DEFAULT_URL,
+        token=auth_key,
+        server_user_id=str(account["_id"]),
+        server_username=str(account.get("email") or "Stremio"),
+        sync_collection=body.sync_collection,
+        sync_watched=body.sync_watched,
+        sync_ratings=False,
+        sync_playback=body.sync_playback,
+        push_collection=body.push_collection,
+        push_watched=body.push_watched,
+        push_ratings=False,
+        push_playback=body.push_playback,
+        auto_sync_interval=body.auto_sync_interval,
+        auto_push_interval=body.auto_push_interval,
+    )
+    db.add(connection)
+    await db.commit()
+    await db.refresh(connection)
+    return {
+        "status": "connected",
+        "connection": schemas.MediaServerConnectionResponse.model_validate(connection),
+    }
+
+
 @router.post("/nuvio-login")
 async def login_nuvio(
     body: schemas.NuvioLoginRequest,
@@ -881,7 +1010,7 @@ async def get_connection_status(
         return {"configured": True, "connected": connected}
 
     async def check_media_server(conn):
-        from core import jellyfin, nuvio, plex
+        from core import jellyfin, nuvio, plex, stremio
 
         try:
             if conn.type == "plex":
@@ -891,6 +1020,11 @@ async def get_connection_status(
                 session, profiles = await nuvio.validate_connection(conn.url, conn.token, profile_id)
                 conn.token = session.refresh_token
                 conn.server_username = _nuvio_profile_name(profiles, profile_id)
+                connected = True
+            elif conn.type == "stremio":
+                account = await stremio.validate_auth_key(conn.token)
+                conn.server_user_id = str(account["_id"])
+                conn.server_username = str(account.get("email") or "Stremio")
                 connected = True
             else:
                 connected = await jellyfin.validate_connection(conn.url, conn.token, conn.server_user_id)
@@ -928,7 +1062,7 @@ async def get_connection_status(
     rdr_status, snr_status, trakt_status, simkl_status, mdblist_status, *ms_statuses = await asyncio.gather(
         check_radarr(), check_sonarr(), check_trakt(), check_simkl(), check_mdblist(), *media_server_tasks
     )
-    if any(conn.type == "nuvio" for conn in media_server_conns):
+    if any(conn.type in ("nuvio", "stremio") for conn in media_server_conns):
         await db.commit()
 
     return {"radarr": rdr_status, "sonarr": snr_status, "trakt": trakt_status, "simkl": simkl_status, "mdblist": mdblist_status, "connections": ms_statuses}

--- a/backend/routers/history.py
+++ b/backend/routers/history.py
@@ -230,6 +230,29 @@ async def _push_watch_state(
                 continue
         await db.commit()
 
+    stremio_connections = [conn for conn in connections if conn.type == "stremio"]
+    if stremio_connections:
+        from routers.sync import _get_effective_tmdb_key, _push_stremio_connection
+
+        api_key = await _get_effective_tmdb_key(db, settings)
+        watch_overrides = {media_id: watched for media_id in media_ids}
+        for conn in stremio_connections:
+            try:
+                await _push_stremio_connection(
+                    db,
+                    conn,
+                    user_id,
+                    api_key=api_key,
+                    changed_media_ids=set(media_ids),
+                    watch_overrides=watch_overrides,
+                )
+            except Exception:
+                logger.exception(
+                    "Failed to push watch state to Stremio connection %s",
+                    conn.id,
+                )
+        await db.commit()
+
 
 def format_event(event: WatchEvent | PlaybackProgress, media: Media) -> dict:
     # PlaybackProgress has no watched_at; its updated_at remains the display timestamp.

--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -3450,6 +3450,32 @@ async def _stremio_series_metadata(content_ids: set[str]) -> dict[str, dict]:
     }
 
 
+def _stremio_valid_content_id(content_id: object) -> bool:
+    value = str(content_id or "")
+    return bool(re.fullmatch(r"tt\d+", value, flags=re.IGNORECASE)) or _parse_nuvio_tmdb_id(value) is not None
+
+
+def _stremio_series_imdb_id(item: dict) -> str | None:
+    """Cinemeta only understands IMDb ids, but a series' own `_id` may be a
+    tmdb:<id> catalog id (e.g. items added via a TMDB-based addon). Episode
+    identifiers embedded in state always carry the IMDb-prefixed episode id
+    regardless of the catalog the series was added from, so fall back to
+    those to find an IMDb id to key the Cinemeta lookup by."""
+    content_id = str(item.get("_id") or "")
+    if re.fullmatch(r"tt\d+", content_id, flags=re.IGNORECASE):
+        return content_id
+    state = item.get("state") if isinstance(item.get("state"), dict) else {}
+    candidates = [str(state.get("video_id") or "")]
+    watched = str(state.get("watched") or "")
+    if watched:
+        candidates.append(watched.rsplit(":", 2)[0])
+    for candidate in candidates:
+        imdb_id = candidate.split(":", 1)[0]
+        if re.fullmatch(r"tt\d+", imdb_id, flags=re.IGNORECASE):
+            return imdb_id
+    return None
+
+
 async def _stremio_records(
     items: list[dict],
 ) -> tuple[list[dict], list[dict], list[dict], set[str]]:
@@ -3457,12 +3483,12 @@ async def _stremio_records(
         item
         for item in items
         if str(item.get("type") or "") in ("movie", "series")
-        and re.fullmatch(r"tt\d+", str(item.get("_id") or ""), flags=re.IGNORECASE)
+        and _stremio_valid_content_id(item.get("_id"))
     ]
     removed_ids = {
         str(item.get("_id"))
         for item in items
-        if item.get("removed") and re.fullmatch(r"tt\d+", str(item.get("_id") or ""), flags=re.IGNORECASE)
+        if item.get("removed") and _stremio_valid_content_id(item.get("_id"))
     }
     series_needing_meta = [
         item
@@ -3473,9 +3499,12 @@ async def _stremio_records(
             or (item.get("state") or {}).get("video_id")
         )
     ]
-    metas = await _stremio_series_metadata(
-        {str(item["_id"]) for item in series_needing_meta}
-    )
+    series_imdb_ids = {
+        str(item["_id"]): imdb_id
+        for item in series_needing_meta
+        if (imdb_id := _stremio_series_imdb_id(item)) is not None
+    }
+    metas = await _stremio_series_metadata(set(series_imdb_ids.values()))
 
     library_records: list[dict] = []
     watched_records: list[dict] = []
@@ -3517,7 +3546,7 @@ async def _stremio_records(
                 )
             continue
 
-        videos = _stremio_sorted_videos(metas.get(content_id, {}))
+        videos = _stremio_sorted_videos(metas.get(series_imdb_ids.get(content_id, content_id), {}))
         video_ids = [str(video["id"]) for video in videos]
         watched_ids = stremio.decode_watched_bitfield(state.get("watched"), video_ids)
         for video in videos:

--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -3453,12 +3453,10 @@ async def _stremio_series_metadata(content_ids: set[str]) -> dict[str, dict]:
 async def _stremio_records(
     items: list[dict],
 ) -> tuple[list[dict], list[dict], list[dict], set[str]]:
-    active = [
+    records = [
         item
         for item in items
-        if not item.get("removed")
-        and not item.get("temp")
-        and str(item.get("type") or "") in ("movie", "series")
+        if str(item.get("type") or "") in ("movie", "series")
         and re.fullmatch(r"tt\d+", str(item.get("_id") or ""), flags=re.IGNORECASE)
     ]
     removed_ids = {
@@ -3468,7 +3466,7 @@ async def _stremio_records(
     }
     series_needing_meta = [
         item
-        for item in active
+        for item in records
         if item.get("type") == "series"
         and (
             (item.get("state") or {}).get("watched")
@@ -3482,7 +3480,7 @@ async def _stremio_records(
     library_records: list[dict] = []
     watched_records: list[dict] = []
     progress_records: list[dict] = []
-    for item in active:
+    for item in records:
         content_id = str(item["_id"])
         content_type = str(item["type"])
         title = str(item.get("name") or content_id)
@@ -3492,7 +3490,8 @@ async def _stremio_records(
             "content_type": content_type,
             "title": title,
         }
-        library_records.append(base)
+        if not item.get("removed") and not item.get("temp"):
+            library_records.append(base)
         last_watched = _stremio_epoch_ms(state.get("lastWatched"))
 
         if content_type == "movie":

--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -21,11 +21,11 @@ from models.ratings import Rating, RatingChanges, RatingKey
 from models.playback_progress import PlaybackProgress
 from models.library_selections import JellyfinLibrarySelection, EmbyLibrarySelection, PlexLibrarySelection
 from models.season_override import ShowSeasonOverride
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from dateutil import parser
 from models.base import MediaType, CollectionSource
 from models.global_settings import GlobalSettings
-from core import jellyfin, emby, plex, nuvio, tmdb
+from core import jellyfin, emby, plex, nuvio, stremio, tmdb
 import core.trakt as trakt_client
 from core.enrichment import enrich_media
 from core.image_cache import pre_cache_all_collected_bg
@@ -66,12 +66,18 @@ router = APIRouter()
 # Global semaphore — at most one sync running at a time across all users
 _sync_semaphore = asyncio.Semaphore(1)
 _nuvio_push_locks: dict[int, asyncio.Lock] = {}
+_stremio_push_locks: dict[int, asyncio.Lock] = {}
 
 BATCH_SIZE = 500
 TMDB_CONCURRENCY = 5  # Max concurrent TMDB requests
 # asyncpg hard limit is 32767 parameters per query; stay well under it
 _MAX_IN_PARAMS = 30_000
-_MEDIA_BROWSER_ITEM_SOURCES = (CollectionSource.jellyfin, CollectionSource.emby, CollectionSource.nuvio)
+_MEDIA_BROWSER_ITEM_SOURCES = (
+    CollectionSource.jellyfin,
+    CollectionSource.emby,
+    CollectionSource.nuvio,
+    CollectionSource.stremio,
+)
 
 
 async def _select_in_chunks(db: AsyncSession, stmt_builder, ids: list):
@@ -609,14 +615,19 @@ def _nuvio_watched_item(
     media: Media,
     watched_at: datetime | None,
     show: Show | None = None,
+    *,
+    include_unknown_date: bool = False,
 ) -> dict | None:
-    # Nuvio requires a timestamp for watched entries and has no unknown-date
-    # representation. Do not fabricate one for a date-less local event.
     if watched_at is None:
-        return None
-    if watched_at.tzinfo is None:
-        watched_at = watched_at.replace(tzinfo=timezone.utc)
-    watched_epoch_ms = int(watched_at.timestamp() * 1000)
+        if not include_unknown_date:
+            # Nuvio cannot represent an unknown date. Stremio can still merge
+            # the watched state without replacing its last-watched timestamp.
+            return None
+        watched_epoch_ms = None
+    else:
+        if watched_at.tzinfo is None:
+            watched_at = watched_at.replace(tzinfo=timezone.utc)
+        watched_epoch_ms = int(watched_at.timestamp() * 1000)
 
     if media.media_type == MediaType.movie and (content_id := _nuvio_imdb_id(media)):
         return {
@@ -654,6 +665,8 @@ async def _build_nuvio_watched_items(
     user_id: int,
     media_ids: set[int] | None = None,
     api_key: str | None = None,
+    *,
+    include_unknown_dates: bool = False,
 ) -> list[dict]:
     event_query = (
         select(WatchEvent.media_id, WatchEvent.watched_at)
@@ -693,6 +706,7 @@ async def _build_nuvio_watched_items(
             media,
             latest_watched_at[media.id],
             shows_by_id.get(media.show_id),
+            include_unknown_date=include_unknown_dates,
         )
         if item:
             items.append(item)
@@ -843,7 +857,7 @@ async def _fan_out_changes_to_other_connections(
     push_candidates = [
         conn
         for conn in other_conns
-        if getattr(conn, "push_collection", False) or conn.push_watched or conn.push_ratings
+        if getattr(conn, "push_collection", False) or conn.push_watched or conn.push_ratings or conn.push_playback
     ]
 
     push_tasks = []
@@ -887,6 +901,11 @@ async def _fan_out_changes_to_other_connections(
                 conn.type == "nuvio" and (conn.push_watched or conn.push_collection)
                 for conn in push_candidates
             )
+            else None
+        )
+        stremio_api_key = (
+            await _get_effective_tmdb_key(db, settings)
+            if any(conn.type == "stremio" for conn in push_candidates)
             else None
         )
         collection_changed_ids = new_collected_ids | removed_collected_ids
@@ -954,6 +973,21 @@ async def _fan_out_changes_to_other_connections(
             return True
 
         for conn in push_candidates:
+            if conn.type == "stremio":
+                try:
+                    await _push_stremio_connection(
+                        db,
+                        conn,
+                        user_id,
+                        api_key=stremio_api_key,
+                        changed_media_ids=all_changed_ids,
+                    )
+                except Exception:
+                    logger.exception(
+                        "Stremio fan-out failed for connection %s",
+                        conn.id,
+                    )
+                continue
             if conn.type == "nuvio":
                 if conn.push_watched:
                     if nuvio_watched_items is None:
@@ -1378,8 +1412,8 @@ async def _fan_out_changes_to_other_connections(
         failed = sum(1 for r in results if isinstance(r, Exception))
         if failed:
             print(f"  {failed}/{len(push_tasks)} fan-out push tasks failed (non-fatal)")
-        if any(conn.type == "nuvio" for conn in push_candidates):
-            await db.commit()
+    if any(conn.type in ("nuvio", "stremio") for conn in push_candidates):
+        await db.commit()
 
 
 async def sync_items(
@@ -2784,6 +2818,7 @@ async def _resolve_nuvio_tmdb_ids(
     db: AsyncSession,
     user_id: int,
     api_key: str,
+    source: CollectionSource = CollectionSource.nuvio,
 ) -> dict[str, int]:
     content_types: dict[str, str] = {}
     resolved: dict[str, int] = {}
@@ -2804,7 +2839,7 @@ async def _resolve_nuvio_tmdb_ids(
             .join(Media, Media.id == Collection.media_id)
             .where(
                 Collection.user_id == user_id,
-                CollectionFile.source == CollectionSource.nuvio,
+                CollectionFile.source == source,
                 Media.tmdb_id.isnot(None),
             )
         )
@@ -2903,6 +2938,8 @@ async def _apply_nuvio_watch_history(
     rows: list[dict],
     show_map: dict[str, int],
     tmdb_ids: dict[str, int],
+    *,
+    include_unknown_dates: bool = False,
 ) -> set[int]:
     standalone_tmdb_ids = {
         tmdb_id
@@ -2944,12 +2981,12 @@ async def _apply_nuvio_watch_history(
             and media.episode_number is not None
         }
 
-    candidates: list[tuple[Media, datetime]] = []
+    candidates: list[tuple[Media, datetime | None]] = []
     for row in rows:
         content_id = str(row.get("content_id") or "")
         tmdb_id = tmdb_ids.get(content_id)
         watched_at = _nuvio_datetime(row.get("watched_at"))
-        if tmdb_id is None or watched_at is None:
+        if tmdb_id is None or (watched_at is None and not include_unknown_dates):
             continue
         content_type = str(row.get("content_type") or "").lower()
         season = row.get("season")
@@ -3366,6 +3403,477 @@ async def _run_nuvio_sync(
             await db.commit()
 
 
+def _stremio_epoch_ms(value: object) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return int(value)
+    try:
+        parsed = parser.isoparse(str(value))
+    except (TypeError, ValueError, OverflowError):
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return int(parsed.timestamp() * 1000)
+
+
+def _stremio_video_parts(video: dict) -> tuple[int, int] | None:
+    try:
+        return int(video["season"]), int(video["episode"])
+    except (KeyError, TypeError, ValueError):
+        video_id = str(video.get("id") or "")
+        parts = video_id.rsplit(":", 2)
+        if len(parts) != 3:
+            return None
+        try:
+            return int(parts[1]), int(parts[2])
+        except ValueError:
+            return None
+
+
+async def _stremio_series_metadata(content_ids: set[str]) -> dict[str, dict]:
+    semaphore = asyncio.Semaphore(TMDB_CONCURRENCY)
+
+    async def fetch(content_id: str) -> tuple[str, dict | None]:
+        try:
+            async with semaphore:
+                return content_id, await stremio.get_cinemeta_series(content_id)
+        except stremio.StremioAPIError:
+            logger.warning("Cinemeta metadata unavailable for %s", content_id)
+            return content_id, None
+
+    results = await asyncio.gather(*(fetch(content_id) for content_id in content_ids))
+    return {
+        content_id: metadata
+        for content_id, metadata in results
+        if metadata is not None
+    }
+
+
+async def _stremio_records(
+    items: list[dict],
+) -> tuple[list[dict], list[dict], list[dict], set[str]]:
+    active = [
+        item
+        for item in items
+        if not item.get("removed")
+        and not item.get("temp")
+        and str(item.get("type") or "") in ("movie", "series")
+        and re.fullmatch(r"tt\d+", str(item.get("_id") or ""), flags=re.IGNORECASE)
+    ]
+    removed_ids = {
+        str(item.get("_id"))
+        for item in items
+        if item.get("removed") and re.fullmatch(r"tt\d+", str(item.get("_id") or ""), flags=re.IGNORECASE)
+    }
+    series_needing_meta = [
+        item
+        for item in active
+        if item.get("type") == "series"
+        and (
+            (item.get("state") or {}).get("watched")
+            or (item.get("state") or {}).get("video_id")
+        )
+    ]
+    metas = await _stremio_series_metadata(
+        {str(item["_id"]) for item in series_needing_meta}
+    )
+
+    library_records: list[dict] = []
+    watched_records: list[dict] = []
+    progress_records: list[dict] = []
+    for item in active:
+        content_id = str(item["_id"])
+        content_type = str(item["type"])
+        title = str(item.get("name") or content_id)
+        state = item.get("state") if isinstance(item.get("state"), dict) else {}
+        base = {
+            "content_id": content_id,
+            "content_type": content_type,
+            "title": title,
+        }
+        library_records.append(base)
+        last_watched = _stremio_epoch_ms(state.get("lastWatched"))
+
+        if content_type == "movie":
+            try:
+                times_watched = int(state.get("timesWatched") or 0)
+            except (TypeError, ValueError):
+                times_watched = 0
+            if times_watched > 0:
+                watched_records.append({**base, "watched_at": last_watched})
+            try:
+                position = int(state.get("timeOffset") or 0)
+                duration = int(state.get("duration") or 0)
+            except (TypeError, ValueError):
+                position = duration = 0
+            if position > 0 and duration > 0:
+                progress_records.append(
+                    {
+                        **base,
+                        "position": position,
+                        "duration": duration,
+                        "last_watched": last_watched,
+                    }
+                )
+            continue
+
+        videos = _stremio_sorted_videos(metas.get(content_id, {}))
+        video_ids = [str(video["id"]) for video in videos]
+        watched_ids = stremio.decode_watched_bitfield(state.get("watched"), video_ids)
+        for video in videos:
+            video_id = str(video["id"])
+            if video_id not in watched_ids:
+                continue
+            parts = _stremio_video_parts(video)
+            if parts is None:
+                continue
+            season, episode = parts
+            watched_records.append(
+                {
+                    **base,
+                    "title": str(video.get("name") or title),
+                    "season": season,
+                    "episode": episode,
+                    "watched_at": last_watched,
+                }
+            )
+
+        current_video_id = str(state.get("video_id") or "")
+        current_video = next(
+            (video for video in videos if str(video.get("id")) == current_video_id),
+            {"id": current_video_id},
+        )
+        current_parts = _stremio_video_parts(current_video)
+        try:
+            position = int(state.get("timeOffset") or 0)
+            duration = int(state.get("duration") or 0)
+        except (TypeError, ValueError):
+            position = duration = 0
+        if current_parts and position > 0 and duration > 0:
+            season, episode = current_parts
+            progress_records.append(
+                {
+                    **base,
+                    "title": str(current_video.get("name") or title),
+                    "season": season,
+                    "episode": episode,
+                    "position": position,
+                    "duration": duration,
+                    "last_watched": last_watched,
+                }
+            )
+    return library_records, watched_records, progress_records, removed_ids
+
+
+async def _remove_stremio_collection_sources(
+    db: AsyncSession,
+    user_id: int,
+    connection_id: int,
+    *,
+    removed_ids: set[str],
+    complete_snapshot_ids: set[str] | None,
+) -> set[int]:
+    result = await db.execute(
+        select(CollectionFile, Collection.media_id)
+        .join(Collection, Collection.id == CollectionFile.collection_id)
+        .where(
+            Collection.user_id == user_id,
+            CollectionFile.source == CollectionSource.stremio,
+            CollectionFile.connection_id == connection_id,
+        )
+    )
+    removed_media_ids: set[int] = set()
+    expected = (
+        {f"{connection_id}:{content_id}" for content_id in complete_snapshot_ids}
+        if complete_snapshot_ids is not None
+        else None
+    )
+    explicit = {f"{connection_id}:{content_id}" for content_id in removed_ids}
+    for collection_file, media_id in result.all():
+        should_remove = collection_file.source_id in explicit
+        if expected is not None and collection_file.source_id not in expected:
+            should_remove = True
+        if not should_remove:
+            continue
+        collection_id = collection_file.collection_id
+        await db.delete(collection_file)
+        await db.flush()
+        remaining = await db.execute(
+            select(func.count(CollectionFile.id)).where(
+                CollectionFile.collection_id == collection_id
+            )
+        )
+        if remaining.scalar_one() == 0:
+            collection = await db.get(Collection, collection_id)
+            if collection:
+                await db.delete(collection)
+                removed_media_ids.add(media_id)
+    return removed_media_ids
+
+
+async def _pull_stremio_items(
+    conn: MediaServerConnection,
+    *,
+    full_resync: bool,
+) -> tuple[list[dict], bool, datetime]:
+    started_at = datetime.now(timezone.utc).replace(tzinfo=None)
+    complete_snapshot = full_resync or not conn.stremio_full_sync_done or conn.stremio_pull_cursor_at is None
+    if complete_snapshot:
+        return await stremio.datastore_get(conn.token, all_items=True), True, started_at
+
+    cutoff = conn.stremio_pull_cursor_at - timedelta(minutes=5)
+    meta = await stremio.datastore_meta(conn.token)
+    changed_ids = []
+    for row in meta:
+        if not isinstance(row, (list, tuple)) or len(row) < 2:
+            continue
+        item_id = str(row[0] or "")
+        modified_at = _nuvio_datetime(_stremio_epoch_ms(row[1]))
+        if item_id and modified_at is not None and modified_at >= cutoff:
+            changed_ids.append(item_id)
+    return await stremio.datastore_get(conn.token, ids=changed_ids), False, started_at
+
+
+async def run_stremio_sync(
+    user_id: int,
+    job_id: int,
+    movie_limit: int,
+    show_limit: int,
+    connection_id: int | None = None,
+    full_resync: bool = False,
+) -> None:
+    async with _sync_semaphore:
+        await _run_stremio_sync(
+            user_id,
+            job_id,
+            movie_limit,
+            show_limit,
+            connection_id,
+            full_resync,
+        )
+
+
+async def _run_stremio_sync(
+    user_id: int,
+    job_id: int,
+    movie_limit: int,
+    show_limit: int,
+    connection_id: int | None = None,
+    full_resync: bool = False,
+) -> None:
+    logger.info("Starting Stremio sync for user %s, job %s", user_id, job_id)
+    async_session = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+    async with async_session() as db:
+        try:
+            await db.execute(
+                update(SyncJob)
+                .where(SyncJob.id == job_id)
+                .values(status=SyncStatus.running, processed_items=0, total_items=0)
+            )
+            await db.commit()
+            settings_result = await db.execute(
+                select(UserSettings).where(UserSettings.user_id == user_id)
+            )
+            settings = settings_result.scalar_one_or_none()
+            tmdb_api_key = await _get_effective_tmdb_key(db, settings)
+            conn_query = select(MediaServerConnection).where(
+                MediaServerConnection.user_id == user_id,
+                MediaServerConnection.type == "stremio",
+            )
+            if connection_id:
+                conn_query = conn_query.where(MediaServerConnection.id == connection_id)
+            conn = (await db.execute(conn_query.limit(1))).scalar_one_or_none()
+            if not conn or not tmdb_api_key:
+                raise RuntimeError("Missing Stremio connection or TMDB API key")
+
+            items, complete_snapshot, pull_started_at = await _pull_stremio_items(
+                conn,
+                full_resync=full_resync,
+            )
+            library_records, watched_records, progress_records, removed_ids = await _stremio_records(items)
+            if not conn.sync_collection:
+                library_records = []
+                removed_ids = set()
+            if not conn.sync_watched:
+                watched_records = []
+            if not conn.sync_playback:
+                progress_records = []
+
+            all_records = [*library_records, *watched_records, *progress_records]
+            tmdb_ids = await _resolve_nuvio_tmdb_ids(
+                all_records,
+                db,
+                user_id,
+                tmdb_api_key,
+                source=CollectionSource.stremio,
+            )
+            normalized_library = [
+                normalized
+                for record in library_records
+                if (
+                    normalized := _normalize_nuvio_item(
+                        record,
+                        conn.id,
+                        tmdb_id=tmdb_ids.get(str(record.get("content_id") or "")),
+                    )
+                )
+            ]
+            normalized_watched = [
+                normalized
+                for record in watched_records
+                if (
+                    normalized := _normalize_nuvio_item(
+                        record,
+                        conn.id,
+                        watched=True,
+                        tmdb_id=tmdb_ids.get(str(record.get("content_id") or "")),
+                    )
+                )
+            ]
+            normalized_progress = [
+                normalized
+                for record in progress_records
+                if (
+                    normalized := _normalize_nuvio_item(
+                        record,
+                        conn.id,
+                        tmdb_id=tmdb_ids.get(str(record.get("content_id") or "")),
+                    )
+                )
+            ]
+            if movie_limit:
+                normalized_library = [
+                    *[entry for entry in normalized_library if entry[0] == MediaType.movie][:movie_limit],
+                    *[entry for entry in normalized_library if entry[0] != MediaType.movie],
+                ]
+            if show_limit:
+                normalized_library = [
+                    *[entry for entry in normalized_library if entry[0] != MediaType.series],
+                    *[entry for entry in normalized_library if entry[0] == MediaType.series][:show_limit],
+                ]
+
+            series_tmdb_map = {
+                str(record["content_id"]): tmdb_ids[str(record["content_id"])]
+                for record in all_records
+                if record.get("content_type") == "series"
+                and str(record.get("content_id")) in tmdb_ids
+            }
+            show_map, show_id_to_tmdb = (
+                await sync_shows_batch(series_tmdb_map, db, api_key=tmdb_api_key)
+                if series_tmdb_map
+                else ({}, {})
+            )
+            all_entries = [*normalized_library, *normalized_watched, *normalized_progress]
+            await db.execute(
+                update(SyncJob).where(SyncJob.id == job_id).values(total_items=len(all_entries))
+            )
+            await db.commit()
+
+            stats = {"movies": 0, "series": 0, "episodes": 0, "skipped": 0, "errors": 0}
+            warnings: list[dict] = []
+            new_watched_ids: set[int] = set()
+            new_collected_ids: set[int] = set()
+
+            async def sync_group(
+                entries: list[tuple[MediaType, dict]],
+                media_type: MediaType,
+                *,
+                sync_collection: bool,
+            ) -> None:
+                group = [item for item_type, item in entries if item_type == media_type]
+                if not group:
+                    return
+                warnings.extend(
+                    await sync_items(
+                        group,
+                        media_type,
+                        CollectionSource.stremio,
+                        db,
+                        stats,
+                        user_id,
+                        job_id,
+                        show_map if media_type == MediaType.episode else {},
+                        api_key=tmdb_api_key,
+                        show_id_to_tmdb=show_id_to_tmdb if media_type == MediaType.episode else {},
+                        sync_collection=sync_collection,
+                        sync_watched=False,
+                        sync_ratings=False,
+                        new_watched_ids=new_watched_ids,
+                        new_collected_ids=new_collected_ids,
+                        connection_id=conn.id,
+                    )
+                )
+
+            for media_type in (MediaType.movie, MediaType.series):
+                await sync_group(normalized_library, media_type, sync_collection=True)
+            for media_type in (MediaType.movie, MediaType.episode):
+                await sync_group(normalized_watched, media_type, sync_collection=False)
+                await sync_group(normalized_progress, media_type, sync_collection=False)
+
+            if watched_records:
+                new_watched_ids.update(
+                    await _apply_nuvio_watch_history(
+                        db,
+                        user_id,
+                        watched_records,
+                        show_map,
+                        tmdb_ids,
+                        include_unknown_dates=True,
+                    )
+                )
+            if progress_records:
+                await _apply_nuvio_progress(db, user_id, progress_records, show_map, tmdb_ids)
+
+            complete_snapshot_ids = (
+                {str(record["content_id"]) for record in library_records}
+                if complete_snapshot and conn.sync_collection
+                else None
+            )
+            removed_collected_ids = await _remove_stremio_collection_sources(
+                db,
+                user_id,
+                conn.id,
+                removed_ids=removed_ids,
+                complete_snapshot_ids=complete_snapshot_ids,
+            )
+            await _fan_out_changes_to_other_connections(
+                db,
+                user_id,
+                conn.id,
+                new_watched_ids,
+                {},
+                settings=settings,
+                exclude_cloud_source=CollectionSource.stremio,
+                new_collected_ids=new_collected_ids,
+                removed_collected_ids=removed_collected_ids,
+            )
+            conn.stremio_pull_cursor_at = pull_started_at
+            conn.stremio_full_sync_done = True
+            warnings = await _stamp_matched_show_warnings(db, user_id, warnings)
+            await db.execute(
+                update(SyncJob)
+                .where(SyncJob.id == job_id)
+                .values(
+                    status=SyncStatus.completed,
+                    stats=stats,
+                    warnings=warnings or None,
+                    updated_at=func.now(),
+                )
+            )
+            await db.commit()
+            asyncio.create_task(pre_cache_all_collected_bg())
+        except Exception as exc:
+            logger.exception("Stremio sync job %s failed", job_id)
+            await db.rollback()
+            await db.execute(
+                update(SyncJob)
+                .where(SyncJob.id == job_id)
+                .values(status=SyncStatus.failed, error_message=str(exc)[:900])
+            )
+            await db.commit()
+
+
 class LibrarySelectionBody(BaseModel):
     library_ids: list[str]
 
@@ -3446,7 +3954,7 @@ async def get_connection_libraries(
             ]
             return {"libraries": libraries, "all_selected": len(selected_keys) == 0}
 
-        elif conn.type == "nuvio":
+        elif conn.type in ("nuvio", "stremio"):
             return {"libraries": [], "all_selected": True}
 
         else:
@@ -3467,7 +3975,7 @@ async def trigger_library_scan(
     conn = await _get_connection_or_404(db, connection_id, current_user.id)
 
     try:
-        if conn.type == "nuvio":
+        if conn.type in ("nuvio", "stremio"):
             settings_result = await db.execute(
                 select(UserSettings).where(UserSettings.user_id == current_user.id)
             )
@@ -3488,11 +3996,11 @@ async def trigger_library_scan(
                 return {
                     "status": "started",
                     "job_id": active_job.id,
-                    "message": "Nuvio sync is already running",
+                    "message": f"{conn.type.capitalize()} sync is already running",
                 }
             job = SyncJob(
                 user_id=current_user.id,
-                source=CollectionSource.nuvio,
+                source=CollectionSource(conn.type),
                 status=SyncStatus.pending,
                 connection_id=conn.id,
                 job_type="pull",
@@ -3501,7 +4009,7 @@ async def trigger_library_scan(
             await db.commit()
             await db.refresh(job)
             background_tasks.add_task(
-                run_nuvio_sync,
+                run_nuvio_sync if conn.type == "nuvio" else run_stremio_sync,
                 current_user.id,
                 job.id,
                 0,
@@ -3511,7 +4019,7 @@ async def trigger_library_scan(
             return {
                 "status": "started",
                 "job_id": job.id,
-                "message": "Nuvio library, watch history, and playback progress sync started",
+                "message": f"{conn.type.capitalize()} library, watched status, and playback progress sync started",
             }
         if conn.type in ("jellyfin", "emby"):
             client = jellyfin if conn.type == "jellyfin" else emby
@@ -3577,7 +4085,7 @@ async def save_connection_libraries(
             await db.commit()
             return {"saved": len(library_keys)}
 
-        elif conn.type == "nuvio":
+        elif conn.type in ("nuvio", "stremio"):
             return {"saved": 0}
 
         else:
@@ -3594,6 +4102,7 @@ async def sync_connection(
     background_tasks: BackgroundTasks,
     movie_limit: int = Query(default=0),
     show_limit: int = Query(default=0),
+    full: bool = Query(default=False),
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
@@ -3604,7 +4113,13 @@ async def sync_connection(
     if not await _get_effective_tmdb_key(db, settings):
         raise HTTPException(status_code=400, detail="TMDB API key required")
 
-    source_map = {"jellyfin": CollectionSource.jellyfin, "emby": CollectionSource.emby, "plex": CollectionSource.plex, "nuvio": CollectionSource.nuvio}
+    source_map = {
+        "jellyfin": CollectionSource.jellyfin,
+        "emby": CollectionSource.emby,
+        "plex": CollectionSource.plex,
+        "nuvio": CollectionSource.nuvio,
+        "stremio": CollectionSource.stremio,
+    }
     source = source_map.get(conn.type)
     if not source:
         raise HTTPException(status_code=400, detail=f"Unknown connection type: {conn.type}")
@@ -3614,9 +4129,392 @@ async def sync_connection(
     await db.commit()
     await db.refresh(job)
 
-    runner_map = {"jellyfin": run_jellyfin_sync, "emby": run_emby_sync, "plex": run_plex_sync, "nuvio": run_nuvio_sync}
-    background_tasks.add_task(runner_map[conn.type], current_user.id, job.id, movie_limit, show_limit, connection_id)
+    runner_map = {
+        "jellyfin": run_jellyfin_sync,
+        "emby": run_emby_sync,
+        "plex": run_plex_sync,
+        "nuvio": run_nuvio_sync,
+        "stremio": run_stremio_sync,
+    }
+    runner_args = (current_user.id, job.id, movie_limit, show_limit, connection_id)
+    if conn.type == "stremio":
+        runner_args = (*runner_args, full)
+    background_tasks.add_task(runner_map[conn.type], *runner_args)
     return {"status": "started", "job_id": job.id, "message": f"{conn.type.capitalize()} sync is running in the background"}
+
+
+def _stremio_default_state() -> dict:
+    return {
+        "lastWatched": None,
+        "timeWatched": 0,
+        "timeOffset": 0,
+        "overallTimeWatched": 0,
+        "timesWatched": 0,
+        "flaggedWatched": 0,
+        "duration": 0,
+        "video_id": None,
+        "watched": None,
+        "noNotif": False,
+    }
+
+
+def _stremio_sorted_videos(meta: dict) -> list[dict]:
+    def sort_key(video: dict) -> tuple:
+        parts = _stremio_video_parts(video)
+        season, episode = parts if parts is not None else (-1, -1)
+        return season, episode, str(video.get("released") or "")
+
+    return sorted(
+        [
+            video
+            for video in (meta.get("videos") or [])
+            if isinstance(video, dict) and video.get("id")
+        ],
+        key=sort_key,
+    )
+
+
+def _stremio_new_library_item(
+    record: dict,
+    now: str,
+    *,
+    in_library: bool = True,
+) -> dict:
+    return {
+        "_id": record["content_id"],
+        "name": record.get("name") or record.get("title") or record["content_id"],
+        "type": record["content_type"],
+        "poster": record.get("poster"),
+        "posterShape": record.get("poster_shape") or "poster",
+        "removed": not in_library,
+        "temp": not in_library,
+        "_ctime": now,
+        "_mtime": now,
+        "state": _stremio_default_state(),
+        "behaviorHints": {},
+    }
+
+
+def _stremio_same_item(left: dict, right: dict) -> bool:
+    return (
+        {key: value for key, value in left.items() if key != "_mtime"}
+        == {key: value for key, value in right.items() if key != "_mtime"}
+    )
+
+
+async def _stremio_media_records(
+    db: AsyncSession,
+    media_ids: set[int],
+    api_key: str | None,
+) -> dict[int, dict]:
+    if not media_ids:
+        return {}
+    media_rows = await _select_in_chunks(
+        db,
+        lambda chunk: select(Media).where(Media.id.in_(chunk)),
+        list(media_ids),
+    )
+    show_ids = {media.show_id for media in media_rows if media.show_id is not None}
+    shows_by_id: dict[int, Show] = {}
+    if show_ids:
+        shows = await _select_in_chunks(
+            db,
+            lambda chunk: select(Show).where(Show.id.in_(chunk)),
+            list(show_ids),
+        )
+        shows_by_id = {show.id: show for show in shows}
+    await _ensure_nuvio_imdb_ids(media_rows, shows_by_id, api_key)
+
+    records: dict[int, dict] = {}
+    for media in media_rows:
+        show = shows_by_id.get(media.show_id)
+        content_id = _nuvio_imdb_id(show or media)
+        if not content_id:
+            continue
+        if (
+            media.media_type == MediaType.episode
+            and show is not None
+            and media.season_number is not None
+            and media.episode_number is not None
+        ):
+            records[media.id] = {
+                "content_id": content_id,
+                "content_type": "series",
+                "title": show.title,
+                "season": media.season_number,
+                "episode": media.episode_number,
+            }
+        elif media.media_type in (MediaType.movie, MediaType.series):
+            records[media.id] = {
+                "content_id": content_id,
+                "content_type": media.media_type.value,
+                "title": media.title,
+            }
+    return records
+
+
+async def _stremio_changed_content_ids(
+    db: AsyncSession,
+    media_ids: set[int],
+    api_key: str | None,
+) -> set[str]:
+    return {
+        record["content_id"]
+        for record in (await _stremio_media_records(db, media_ids, api_key)).values()
+    }
+
+
+async def _push_stremio_connection(
+    db: AsyncSession,
+    conn: MediaServerConnection,
+    user_id: int,
+    *,
+    api_key: str | None,
+    changed_media_ids: set[int] | None = None,
+    watch_overrides: dict[int, bool] | None = None,
+) -> int:
+    effective_changed_ids = (
+        set(changed_media_ids or set()) | set(watch_overrides or {})
+        if changed_media_ids is not None or watch_overrides
+        else None
+    )
+    all_library_records = (
+        await _build_nuvio_library_items(db, user_id, api_key=api_key)
+        if conn.push_collection
+        else []
+    )
+    library_records = list(all_library_records)
+    watched_records = (
+        await _build_nuvio_watched_items(
+            db,
+            user_id,
+            media_ids=effective_changed_ids,
+            api_key=api_key,
+            include_unknown_dates=True,
+        )
+        if conn.push_watched
+        else []
+    )
+    if watch_overrides and conn.push_watched:
+        override_media = await _stremio_media_records(
+            db,
+            set(watch_overrides),
+            api_key,
+        )
+        watched_at_by_media = await _latest_watched_at(
+            db,
+            user_id,
+            [media_id for media_id, watched in watch_overrides.items() if watched],
+        )
+
+        def watch_key(record: dict) -> tuple:
+            return (
+                record["content_id"],
+                record.get("season"),
+                record.get("episode"),
+            )
+
+        watched_by_key = {watch_key(record): record for record in watched_records}
+        for media_id, watched in watch_overrides.items():
+            record = override_media.get(media_id)
+            if record is None:
+                continue
+            watched_by_key[watch_key(record)] = {
+                **record,
+                "watched": watched,
+                "watched_at": watched_at_by_media.get(media_id),
+            }
+        watched_records = list(watched_by_key.values())
+    progress_records = (
+        await _build_nuvio_progress_items(db, user_id, api_key=api_key)
+        if conn.push_playback
+        else []
+    )
+    target_ids = (
+        await _stremio_changed_content_ids(db, effective_changed_ids, api_key)
+        if effective_changed_ids is not None
+        else None
+    )
+    if target_ids is not None:
+        library_records = [
+            record for record in library_records if record["content_id"] in target_ids
+        ]
+        watched_records = [
+            record for record in watched_records if record["content_id"] in target_ids
+        ]
+        progress_records = [
+            record for record in progress_records if record["content_id"] in target_ids
+        ]
+
+    current_library_ids = {
+        item["content_id"]
+        for item in all_library_records
+    }
+    previously_pushed_ids = set(conn.stremio_pushed_library_ids or [])
+    removed_library_ids = (
+        previously_pushed_ids - current_library_ids
+        if conn.push_collection and conn.stremio_pushed_library_ids is not None
+        else set()
+    )
+    if target_ids is not None:
+        removed_library_ids &= target_ids
+
+    lock = _stremio_push_locks.setdefault(conn.id, asyncio.Lock())
+    async with lock:
+        remote_items = await stremio.datastore_get(conn.token, all_items=True)
+        remote_by_id = {
+            str(item.get("_id")): item
+            for item in remote_items
+            if isinstance(item, dict) and item.get("_id")
+        }
+        now = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+        candidates: dict[str, dict] = {}
+
+        for record in library_records:
+            content_id = str(record["content_id"])
+            candidate = dict(
+                remote_by_id.get(content_id)
+                or _stremio_new_library_item(record, now)
+            )
+            candidate["removed"] = False
+            candidate["temp"] = False
+            candidate.setdefault("_ctime", now)
+            candidate.setdefault("state", _stremio_default_state())
+            candidates[content_id] = candidate
+
+        for content_id in removed_library_ids:
+            if content_id not in remote_by_id:
+                continue
+            candidate = dict(remote_by_id[content_id])
+            candidate["removed"] = True
+            candidate["temp"] = False
+            candidates[content_id] = candidate
+
+        records_by_series: dict[str, list[dict]] = {}
+        for record in [*watched_records, *progress_records]:
+            if record.get("content_type") == "series":
+                records_by_series.setdefault(str(record["content_id"]), []).append(record)
+        series_meta = await _stremio_series_metadata(set(records_by_series))
+
+        for record in watched_records:
+            content_id = str(record["content_id"])
+            is_watched = bool(record.get("watched", True))
+            base_item = candidates.get(content_id) or remote_by_id.get(content_id)
+            if base_item is None:
+                if not is_watched:
+                    continue
+                base_item = _stremio_new_library_item(
+                    record,
+                    now,
+                    in_library=False,
+                )
+            candidate = dict(base_item)
+            state = {**_stremio_default_state(), **(candidate.get("state") or {})}
+            watched_at_ms = record.get("watched_at")
+            watched_at = (
+                datetime.fromtimestamp(
+                    int(watched_at_ms) / 1000,
+                    tz=timezone.utc,
+                ).isoformat().replace("+00:00", "Z")
+                if watched_at_ms is not None
+                else None
+            )
+            season = record.get("season")
+            episode = record.get("episode")
+            if record.get("content_type") == "movie" or season is None or episode is None:
+                state["timesWatched"] = (
+                    max(1, int(state.get("timesWatched") or 0))
+                    if is_watched
+                    else 0
+                )
+                if not is_watched:
+                    state["flaggedWatched"] = 0
+                if is_watched and watched_at is not None:
+                    state["lastWatched"] = watched_at
+            else:
+                videos = _stremio_sorted_videos(series_meta.get(content_id, {}))
+                video_ids = [str(video["id"]) for video in videos]
+                watched_ids = stremio.decode_watched_bitfield(
+                    state.get("watched"),
+                    video_ids,
+                )
+                matching_video = next(
+                    (
+                        video
+                        for video in videos
+                        if _stremio_video_parts(video)
+                        == (int(season), int(episode))
+                    ),
+                    None,
+                )
+                if matching_video:
+                    video_id = str(matching_video["id"])
+                    if is_watched:
+                        watched_ids.add(video_id)
+                    else:
+                        watched_ids.discard(video_id)
+                    state["watched"] = stremio.encode_watched_bitfield(
+                        watched_ids,
+                        video_ids,
+                    )
+                    if is_watched and watched_at is not None:
+                        state["lastWatched"] = watched_at
+            candidate["state"] = state
+            candidates[content_id] = candidate
+
+        for record in progress_records:
+            content_id = str(record["content_id"])
+            base_item = (
+                candidates.get(content_id)
+                or remote_by_id.get(content_id)
+                or _stremio_new_library_item(record, now, in_library=False)
+            )
+            candidate = dict(base_item)
+            state = {**_stremio_default_state(), **(candidate.get("state") or {})}
+            state["timeOffset"] = int(record["position"])
+            state["duration"] = int(record["duration"])
+            if record.get("content_type") == "movie":
+                state["video_id"] = content_id
+            else:
+                videos = _stremio_sorted_videos(series_meta.get(content_id, {}))
+                matching_video = next(
+                    (
+                        video
+                        for video in videos
+                        if _stremio_video_parts(video)
+                        == (int(record["season"]), int(record["episode"]))
+                    ),
+                    None,
+                )
+                state["video_id"] = (
+                    str(matching_video["id"])
+                    if matching_video
+                    else str(record.get("video_id") or "")
+                )
+            last_watched_ms = record.get("last_watched")
+            if last_watched_ms:
+                state["lastWatched"] = datetime.fromtimestamp(
+                    int(last_watched_ms) / 1000,
+                    tz=timezone.utc,
+                ).isoformat().replace("+00:00", "Z")
+            candidate["state"] = state
+            candidates[content_id] = candidate
+
+        changes = []
+        for content_id, candidate in candidates.items():
+            candidate["_mtime"] = now
+            existing = remote_by_id.get(content_id)
+            if existing is None or not _stremio_same_item(existing, candidate):
+                changes.append(candidate)
+        for start in range(0, len(changes), BATCH_SIZE):
+            await stremio.datastore_put(
+                conn.token,
+                changes[start : start + BATCH_SIZE],
+            )
+
+    if conn.push_collection:
+        conn.stremio_pushed_library_ids = sorted(current_library_ids)
+    return len(changes)
 
 
 async def _run_full_push(user_id: int, connection_id: int, job_id: int) -> None:
@@ -3638,6 +4536,36 @@ async def _run_full_push(user_id: int, connection_id: int, job_id: int) -> None:
             if not conn:
                 await db.execute(update(SyncJob).where(SyncJob.id == job_id).values(status=SyncStatus.failed, error_message="Connection not found"))
                 await db.commit()
+                return
+
+            if conn.type == "stremio":
+                settings_result = await db.execute(
+                    select(UserSettings).where(UserSettings.user_id == user_id)
+                )
+                user_settings = settings_result.scalar_one_or_none()
+                api_key = await _get_effective_tmdb_key(db, user_settings)
+                changed = await _push_stremio_connection(
+                    db,
+                    conn,
+                    user_id,
+                    api_key=api_key,
+                )
+                await db.execute(
+                    update(SyncJob)
+                    .where(SyncJob.id == job_id)
+                    .values(
+                        status=SyncStatus.completed,
+                        total_items=changed,
+                        processed_items=changed,
+                        stats={"succeeded": changed, "failed": 0},
+                    )
+                )
+                await db.commit()
+                logger.info(
+                    "Full Stremio push for connection %s: %s changed items",
+                    connection_id,
+                    changed,
+                )
                 return
 
             if conn.type == "nuvio":
@@ -4069,7 +4997,13 @@ async def push_upstream(
             detail="Enable 'Scrob → Server' push flags for this connection first",
         )
 
-    source_map = {"jellyfin": CollectionSource.jellyfin, "emby": CollectionSource.emby, "plex": CollectionSource.plex, "nuvio": CollectionSource.nuvio}
+    source_map = {
+        "jellyfin": CollectionSource.jellyfin,
+        "emby": CollectionSource.emby,
+        "plex": CollectionSource.plex,
+        "nuvio": CollectionSource.nuvio,
+        "stremio": CollectionSource.stremio,
+    }
     source = source_map.get(conn.type, CollectionSource.jellyfin)
     job = SyncJob(user_id=current_user.id, source=source, status=SyncStatus.pending, connection_id=connection_id, job_type="push")
     db.add(job)

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, EmailStr, field_validator
+from pydantic import BaseModel, EmailStr, field_validator, model_validator
 from typing import Optional
 from datetime import datetime
 from models.base import UserRole, MediaType, PrivacyLevel
@@ -151,6 +151,19 @@ class NuvioConnectionTestRequest(BaseModel):
     profile_id: int
 
 
+class StremioLinkPollRequest(BaseModel):
+    code: str
+    name: str = "Stremio"
+    sync_collection: bool = True
+    sync_watched: bool = True
+    sync_playback: bool = True
+    push_collection: bool = False
+    push_watched: bool = False
+    push_playback: bool = False
+    auto_sync_interval: Optional[float] = None
+    auto_push_interval: Optional[float] = None
+
+
 class MediaServerConnectionBase(BaseModel):
     type: str
     name: str
@@ -208,6 +221,12 @@ class MediaServerConnectionResponse(MediaServerConnectionBase):
     id: int
     user_id: int
     created_at: datetime
+
+    @model_validator(mode="after")
+    def redact_stremio_auth_key(self):
+        if self.type == "stremio":
+            self.token = ""
+        return self
 
     class Config:
         from_attributes = True

--- a/backend/tests/test_stremio.py
+++ b/backend/tests/test_stremio.py
@@ -176,6 +176,78 @@ class StremioSyncTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(progress[0]["position"], 120_000)
         self.assertEqual(removed, set())
 
+    async def test_temporary_removed_movie_still_emits_watched_state(self) -> None:
+        item = {
+            "_id": "tt0133093",
+            "type": "movie",
+            "name": "The Matrix",
+            "removed": True,
+            "temp": True,
+            "state": {
+                "timesWatched": 1,
+                "lastWatched": "2026-07-31T20:00:00Z",
+            },
+        }
+
+        library, watched_records, progress, removed = await _stremio_records([item])
+
+        self.assertEqual(library, [])
+        self.assertEqual(
+            watched_records,
+            [
+                {
+                    "content_id": "tt0133093",
+                    "content_type": "movie",
+                    "title": "The Matrix",
+                    "watched_at": 1785528000000,
+                }
+            ],
+        )
+        self.assertEqual(progress, [])
+        self.assertEqual(removed, {"tt0133093"})
+
+    async def test_temporary_removed_series_still_emits_episode_state(self) -> None:
+        videos = [
+            {"id": "tt0944947:1:1", "season": 1, "episode": 1, "name": "S1E1"},
+            {"id": "tt0944947:1:2", "season": 1, "episode": 2, "name": "S1E2"},
+        ]
+        watched = stremio.encode_watched_bitfield(
+            {"tt0944947:1:1"},
+            [video["id"] for video in videos],
+        )
+        item = {
+            "_id": "tt0944947",
+            "type": "series",
+            "name": "Game of Thrones",
+            "removed": True,
+            "temp": True,
+            "state": {
+                "watched": watched,
+                "video_id": "tt0944947:1:2",
+                "timeOffset": 120_000,
+                "duration": 3_600_000,
+                "lastWatched": "2026-07-31T20:00:00Z",
+            },
+        }
+
+        with patch.object(
+            stremio,
+            "get_cinemeta_series",
+            AsyncMock(return_value={"videos": videos}),
+        ):
+            library, watched_records, progress, removed = await _stremio_records([item])
+
+        self.assertEqual(library, [])
+        self.assertEqual(
+            [(record["season"], record["episode"]) for record in watched_records],
+            [(1, 1)],
+        )
+        self.assertEqual(
+            [(record["season"], record["episode"]) for record in progress],
+            [(1, 2)],
+        )
+        self.assertEqual(removed, {"tt0944947"})
+
     def test_noop_comparison_ignores_only_mtime(self) -> None:
         left = {"_id": "tt0133093", "_mtime": "old", "state": {"timeOffset": 42}, "custom": True}
         same = {**left, "_mtime": "new"}

--- a/backend/tests/test_stremio.py
+++ b/backend/tests/test_stremio.py
@@ -1,0 +1,549 @@
+import json
+import os
+import unittest
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
+
+import httpx
+
+os.environ.setdefault("SECRET_KEY", "test-secret")
+os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://test:test@localhost/test")
+
+from core import stremio
+from models.base import MediaType
+from models.media import Media
+from schemas import MediaServerConnectionResponse
+from routers.history import _push_watch_state
+from routers.sync import (
+    _apply_nuvio_watch_history,
+    _pull_stremio_items,
+    _push_stremio_connection,
+    _stremio_records,
+    _stremio_same_item,
+    _stremio_sorted_videos,
+)
+
+
+_REAL_ASYNC_CLIENT = httpx.AsyncClient
+
+
+class StremioClientTests(unittest.IsolatedAsyncioTestCase):
+    async def test_link_poll_treats_code_101_as_pending(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            self.assertEqual(request.url.path, "/api/v2/read")
+            self.assertEqual(request.url.params["type"], "Read")
+            self.assertEqual(request.url.params["code"], "ABCD")
+            return httpx.Response(
+                200,
+                json={"error": {"code": 101, "message": "Invalid or expired token"}},
+            )
+
+        transport = httpx.MockTransport(handler)
+        with patch.object(
+            stremio.httpx,
+            "AsyncClient",
+            side_effect=lambda **kwargs: _REAL_ASYNC_CLIENT(transport=transport, **kwargs),
+        ):
+            auth_key = await stremio.read_link_code(" abcd ")
+
+        self.assertIsNone(auth_key)
+
+    async def test_datastore_put_uses_official_envelope(self) -> None:
+        requests: list[dict] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            requests.append(json.loads(request.content))
+            return httpx.Response(200, json={"result": {"success": True}})
+
+        transport = httpx.MockTransport(handler)
+        with patch.object(
+            stremio.httpx,
+            "AsyncClient",
+            side_effect=lambda **kwargs: _REAL_ASYNC_CLIENT(transport=transport, **kwargs),
+        ):
+            await stremio.datastore_put("secret-auth-key", [{"_id": "tt0133093"}])
+
+        self.assertEqual(
+            requests,
+            [
+                {
+                    "authKey": "secret-auth-key",
+                    "collection": "libraryItem",
+                    "changes": [{"_id": "tt0133093"}],
+                }
+            ],
+        )
+
+
+class StremioBitfieldTests(unittest.TestCase):
+    def test_watched_bitfield_round_trip_uses_little_endian_bits(self) -> None:
+        video_ids = [f"tt0944947:1:{episode}" for episode in range(1, 12)]
+        watched = {video_ids[0], video_ids[7], video_ids[8], video_ids[10]}
+
+        serialized = stremio.encode_watched_bitfield(watched, video_ids)
+
+        self.assertIsNotNone(serialized)
+        self.assertEqual(stremio.decode_watched_bitfield(serialized, video_ids), watched)
+
+    def test_watched_bitfield_keeps_alignment_when_episodes_are_prepended(self) -> None:
+        old_video_ids = ["tt1234567:1:2", "tt1234567:1:3"]
+        serialized = stremio.encode_watched_bitfield({old_video_ids[1]}, old_video_ids)
+        current_video_ids = ["tt1234567:1:1", *old_video_ids]
+
+        self.assertEqual(
+            stremio.decode_watched_bitfield(serialized, current_video_ids),
+            {"tt1234567:1:3"},
+        )
+
+    def test_malformed_watched_bitfield_is_ignored(self) -> None:
+        self.assertEqual(
+            stremio.decode_watched_bitfield("invalid", ["tt1234567:1:1"]),
+            set(),
+        )
+
+
+class StremioSyncTests(unittest.IsolatedAsyncioTestCase):
+    async def test_incremental_pull_consumes_datastore_meta_tuples(self) -> None:
+        cursor = datetime.now(timezone.utc).replace(tzinfo=None)
+        recent_ms = int((cursor - timedelta(minutes=1)).replace(tzinfo=timezone.utc).timestamp() * 1000)
+        old_ms = int((cursor - timedelta(minutes=10)).replace(tzinfo=timezone.utc).timestamp() * 1000)
+        connection = SimpleNamespace(
+            token="auth-key",
+            stremio_full_sync_done=True,
+            stremio_pull_cursor_at=cursor,
+        )
+
+        with (
+            patch.object(
+                stremio,
+                "datastore_meta",
+                AsyncMock(return_value=[["tt-recent", recent_ms], ["tt-old", old_ms], ["broken"]]),
+            ),
+            patch.object(
+                stremio,
+                "datastore_get",
+                AsyncMock(return_value=[{"_id": "tt-recent"}]),
+            ) as datastore_get,
+        ):
+            items, complete_snapshot, started_at = await _pull_stremio_items(
+                connection,
+                full_resync=False,
+            )
+
+        self.assertEqual(items, [{"_id": "tt-recent"}])
+        self.assertFalse(complete_snapshot)
+        self.assertGreaterEqual(started_at, cursor)
+        datastore_get.assert_awaited_once_with("auth-key", ids=["tt-recent"])
+
+    async def test_series_records_use_cinemeta_episode_order_and_progress(self) -> None:
+        videos = [
+            {"id": "tt0944947:2:1", "season": 2, "episode": 1, "name": "S2E1"},
+            {"id": "tt0944947:1:2", "season": 1, "episode": 2, "name": "S1E2"},
+            {"id": "tt0944947:1:1", "season": 1, "episode": 1, "name": "S1E1"},
+        ]
+        sorted_ids = [video["id"] for video in _stremio_sorted_videos({"videos": videos})]
+        watched = stremio.encode_watched_bitfield(
+            {"tt0944947:1:1", "tt0944947:2:1"},
+            sorted_ids,
+        )
+        item = {
+            "_id": "tt0944947",
+            "type": "series",
+            "name": "Game of Thrones",
+            "state": {
+                "watched": watched,
+                "video_id": "tt0944947:1:2",
+                "timeOffset": 120_000,
+                "duration": 3_600_000,
+                "lastWatched": "2026-07-26T12:00:00Z",
+            },
+        }
+
+        with patch.object(
+            stremio,
+            "get_cinemeta_series",
+            AsyncMock(return_value={"videos": videos}),
+        ):
+            library, watched_records, progress, removed = await _stremio_records([item])
+
+        self.assertEqual([record["content_id"] for record in library], ["tt0944947"])
+        self.assertEqual(
+            {(record["season"], record["episode"]) for record in watched_records},
+            {(1, 1), (2, 1)},
+        )
+        self.assertEqual((progress[0]["season"], progress[0]["episode"]), (1, 2))
+        self.assertEqual(progress[0]["position"], 120_000)
+        self.assertEqual(removed, set())
+
+    def test_noop_comparison_ignores_only_mtime(self) -> None:
+        left = {"_id": "tt0133093", "_mtime": "old", "state": {"timeOffset": 42}, "custom": True}
+        same = {**left, "_mtime": "new"}
+        changed = {**same, "custom": False}
+
+        self.assertTrue(_stremio_same_item(left, same))
+        self.assertFalse(_stremio_same_item(left, changed))
+
+    async def test_full_push_preserves_unrelated_remote_items(self) -> None:
+        connection = SimpleNamespace(
+            id=44,
+            token="auth-key",
+            push_collection=True,
+            push_watched=False,
+            push_playback=False,
+            stremio_pushed_library_ids=None,
+        )
+        local = {
+            "content_id": "tt0133093",
+            "content_type": "movie",
+            "name": "The Matrix",
+            "poster": "https://example.test/matrix.jpg",
+            "poster_shape": "poster",
+        }
+        remote_only = {
+            "_id": "tt9999999",
+            "name": "Remote only",
+            "type": "movie",
+            "removed": False,
+            "temp": False,
+            "_ctime": "2026-01-01T00:00:00Z",
+            "_mtime": "2026-01-01T00:00:00Z",
+            "state": {"customPlaybackState": True},
+            "unknownField": {"preserve": True},
+        }
+        datastore_put = AsyncMock()
+
+        with (
+            patch(
+                "routers.sync._build_nuvio_library_items",
+                AsyncMock(return_value=[local]),
+            ),
+            patch.object(
+                stremio,
+                "datastore_get",
+                AsyncMock(return_value=[remote_only]),
+            ),
+            patch.object(stremio, "datastore_put", datastore_put),
+        ):
+            changed = await _push_stremio_connection(
+                SimpleNamespace(),
+                connection,
+                7,
+                api_key="tmdb-key",
+            )
+
+        self.assertEqual(changed, 1)
+        pushed = datastore_put.await_args.args[1]
+        self.assertEqual([item["_id"] for item in pushed], ["tt0133093"])
+        self.assertEqual(remote_only["unknownField"], {"preserve": True})
+        self.assertEqual(connection.stremio_pushed_library_ids, ["tt0133093"])
+
+    async def test_remote_removal_requires_prior_scrob_push(self) -> None:
+        connection = SimpleNamespace(
+            id=45,
+            token="auth-key",
+            push_collection=True,
+            push_watched=False,
+            push_playback=False,
+            stremio_pushed_library_ids=["tt0133093"],
+        )
+        remote_items = [
+            {
+                "_id": "tt0133093",
+                "name": "The Matrix",
+                "type": "movie",
+                "removed": False,
+                "temp": False,
+                "_ctime": "2026-01-01T00:00:00Z",
+                "_mtime": "2026-01-01T00:00:00Z",
+                "state": {},
+            },
+            {
+                "_id": "tt9999999",
+                "name": "Remote only",
+                "type": "movie",
+                "removed": False,
+                "temp": False,
+                "_ctime": "2026-01-01T00:00:00Z",
+                "_mtime": "2026-01-01T00:00:00Z",
+                "state": {},
+            },
+        ]
+        datastore_put = AsyncMock()
+
+        with (
+            patch(
+                "routers.sync._build_nuvio_library_items",
+                AsyncMock(return_value=[]),
+            ),
+            patch.object(
+                stremio,
+                "datastore_get",
+                AsyncMock(return_value=remote_items),
+            ),
+            patch.object(stremio, "datastore_put", datastore_put),
+        ):
+            changed = await _push_stremio_connection(
+                SimpleNamespace(),
+                connection,
+                7,
+                api_key="tmdb-key",
+            )
+
+        self.assertEqual(changed, 1)
+        pushed = datastore_put.await_args.args[1]
+        self.assertEqual([item["_id"] for item in pushed], ["tt0133093"])
+        self.assertTrue(pushed[0]["removed"])
+        self.assertEqual(connection.stremio_pushed_library_ids, [])
+
+    async def test_unknown_watch_creates_temporary_item_without_fabricating_date(self) -> None:
+        connection = SimpleNamespace(
+            id=46,
+            token="auth-key",
+            push_collection=False,
+            push_watched=True,
+            push_playback=False,
+            stremio_pushed_library_ids=None,
+        )
+        record = {
+            "content_id": "tt0133093",
+            "content_type": "movie",
+            "title": "The Matrix",
+            "watched_at": None,
+        }
+        datastore_put = AsyncMock()
+        with (
+            patch(
+                "routers.sync._build_nuvio_watched_items",
+                AsyncMock(return_value=[record]),
+            ) as build_watched,
+            patch(
+                "routers.sync._stremio_media_records",
+                AsyncMock(return_value={10: {key: record[key] for key in ("content_id", "content_type", "title")}}),
+            ),
+            patch(
+                "routers.sync._latest_watched_at",
+                AsyncMock(return_value={10: None}),
+            ),
+            patch.object(stremio, "datastore_get", AsyncMock(return_value=[])),
+            patch.object(stremio, "datastore_put", datastore_put),
+        ):
+            changed = await _push_stremio_connection(
+                SimpleNamespace(),
+                connection,
+                7,
+                api_key="tmdb-key",
+                changed_media_ids={10},
+                watch_overrides={10: True},
+            )
+
+        self.assertEqual(changed, 1)
+        build_watched.assert_awaited_once_with(
+            ANY,
+            7,
+            media_ids={10},
+            api_key="tmdb-key",
+            include_unknown_dates=True,
+        )
+        pushed = datastore_put.await_args.args[1][0]
+        self.assertTrue(pushed["removed"])
+        self.assertTrue(pushed["temp"])
+        self.assertEqual(pushed["state"]["timesWatched"], 1)
+        self.assertIsNone(pushed["state"]["lastWatched"])
+
+    async def test_unwatch_clears_state_without_erasing_last_known_date(self) -> None:
+        connection = SimpleNamespace(
+            id=47,
+            token="auth-key",
+            push_collection=False,
+            push_watched=True,
+            push_playback=False,
+            stremio_pushed_library_ids=None,
+        )
+        record = {
+            "content_id": "tt0133093",
+            "content_type": "movie",
+            "title": "The Matrix",
+        }
+        remote = {
+            "_id": "tt0133093",
+            "name": "The Matrix",
+            "type": "movie",
+            "removed": True,
+            "temp": True,
+            "_ctime": "2026-01-01T00:00:00Z",
+            "_mtime": "2026-01-01T00:00:00Z",
+            "state": {
+                "timesWatched": 1,
+                "lastWatched": "2026-01-01T00:00:00Z",
+            },
+        }
+        datastore_put = AsyncMock()
+        with (
+            patch(
+                "routers.sync._build_nuvio_watched_items",
+                AsyncMock(return_value=[]),
+            ),
+            patch(
+                "routers.sync._stremio_media_records",
+                AsyncMock(return_value={10: record}),
+            ),
+            patch(
+                "routers.sync._latest_watched_at",
+                AsyncMock(return_value={}),
+            ),
+            patch.object(stremio, "datastore_get", AsyncMock(return_value=[remote])),
+            patch.object(stremio, "datastore_put", datastore_put),
+        ):
+            await _push_stremio_connection(
+                SimpleNamespace(),
+                connection,
+                7,
+                api_key="tmdb-key",
+                changed_media_ids={10},
+                watch_overrides={10: False},
+            )
+
+        pushed = datastore_put.await_args.args[1][0]
+        self.assertEqual(pushed["state"]["timesWatched"], 0)
+        self.assertEqual(
+            pushed["state"]["lastWatched"],
+            "2026-01-01T00:00:00Z",
+        )
+
+    async def test_progress_without_collection_creates_temporary_item(self) -> None:
+        connection = SimpleNamespace(
+            id=48,
+            token="auth-key",
+            push_collection=False,
+            push_watched=False,
+            push_playback=True,
+            stremio_pushed_library_ids=None,
+        )
+        progress = {
+            "content_id": "tt0133093",
+            "content_type": "movie",
+            "title": "The Matrix",
+            "position": 120_000,
+            "duration": 600_000,
+            "last_watched": None,
+        }
+        datastore_put = AsyncMock()
+        with (
+            patch(
+                "routers.sync._build_nuvio_progress_items",
+                AsyncMock(return_value=[progress]),
+            ),
+            patch.object(stremio, "datastore_get", AsyncMock(return_value=[])),
+            patch.object(stremio, "datastore_put", datastore_put),
+        ):
+            await _push_stremio_connection(
+                SimpleNamespace(),
+                connection,
+                7,
+                api_key="tmdb-key",
+            )
+
+        pushed = datastore_put.await_args.args[1][0]
+        self.assertTrue(pushed["removed"])
+        self.assertTrue(pushed["temp"])
+        self.assertEqual(pushed["state"]["timeOffset"], 120_000)
+        self.assertEqual(pushed["state"]["duration"], 600_000)
+
+
+class StremioCompatibilityTests(unittest.IsolatedAsyncioTestCase):
+    async def test_unknown_inbound_watch_is_persisted_without_a_date(self) -> None:
+        movie = Media(
+            id=10,
+            tmdb_id=603,
+            media_type=MediaType.movie,
+            title="The Matrix",
+        )
+        media_result = SimpleNamespace(
+            scalars=lambda: SimpleNamespace(all=lambda: [movie]),
+        )
+        existing_result = SimpleNamespace(all=lambda: [])
+        db = SimpleNamespace(
+            execute=AsyncMock(side_effect=[media_result, existing_result]),
+            add=MagicMock(),
+            commit=AsyncMock(),
+        )
+
+        added = await _apply_nuvio_watch_history(
+            db,
+            user_id=7,
+            rows=[
+                {
+                    "content_id": "tt0133093",
+                    "content_type": "movie",
+                    "watched_at": None,
+                }
+            ],
+            show_map={},
+            tmdb_ids={"tt0133093": 603},
+            include_unknown_dates=True,
+        )
+
+        self.assertEqual(added, {10})
+        self.assertIsNone(db.add.call_args.args[0].watched_at)
+
+    async def test_manual_unwatch_is_forwarded_to_stremio(self) -> None:
+        connection = SimpleNamespace(id=49, type="stremio")
+        settings = SimpleNamespace(
+            trakt_push_watched=False,
+            mdblist_push_watched=False,
+            simkl_push_watched=False,
+        )
+        connection_result = SimpleNamespace(
+            scalars=lambda: SimpleNamespace(all=lambda: [connection]),
+        )
+        settings_result = SimpleNamespace(scalar_one_or_none=lambda: settings)
+        files_result = SimpleNamespace(
+            scalars=lambda: SimpleNamespace(all=lambda: []),
+        )
+        db = SimpleNamespace(
+            execute=AsyncMock(
+                side_effect=[connection_result, settings_result, files_result],
+            ),
+            commit=AsyncMock(),
+        )
+        push = AsyncMock()
+        with (
+            patch(
+                "routers.sync._get_effective_tmdb_key",
+                AsyncMock(return_value="tmdb-key"),
+            ),
+            patch("routers.sync._push_stremio_connection", push),
+        ):
+            await _push_watch_state(
+                db,
+                user_id=7,
+                media_ids=[10],
+                watched=False,
+            )
+
+        push.assert_awaited_once_with(
+            db,
+            connection,
+            7,
+            api_key="tmdb-key",
+            changed_media_ids={10},
+            watch_overrides={10: False},
+        )
+        db.commit.assert_awaited_once()
+
+
+    def test_connection_response_redacts_auth_key(self) -> None:
+        response = MediaServerConnectionResponse.model_validate(
+            {
+                "id": 1,
+                "user_id": 7,
+                "type": "stremio",
+                "name": "Stremio",
+                "url": stremio.DEFAULT_URL,
+                "token": "secret-auth-key",
+                "created_at": datetime(2026, 7, 31),
+            }
+        )
+
+        self.assertEqual(response.token, "")

--- a/backend/tests/test_stremio.py
+++ b/backend/tests/test_stremio.py
@@ -248,6 +248,52 @@ class StremioSyncTests(unittest.IsolatedAsyncioTestCase):
         )
         self.assertEqual(removed, {"tt0944947"})
 
+    async def test_tmdb_catalog_series_still_resolves_episodes_via_cinemeta(self) -> None:
+        # Series added through a TMDB-based catalog addon carry a tmdb:<id>
+        # `_id`, but Stremio still tracks per-episode watch state using the
+        # IMDb-prefixed episode ids returned by Cinemeta.
+        videos = [
+            {"id": "tt34866681:1:1", "season": 1, "episode": 1, "name": "S1E1"},
+            {"id": "tt34866681:1:2", "season": 1, "episode": 2, "name": "S1E2"},
+        ]
+        watched = stremio.encode_watched_bitfield(
+            {"tt34866681:1:1"},
+            [video["id"] for video in videos],
+        )
+        item = {
+            "_id": "tmdb:278624",
+            "type": "series",
+            "name": "Lucky",
+            "removed": True,
+            "temp": True,
+            "state": {
+                "watched": watched,
+                "video_id": "tt34866681:1:2",
+                "timeOffset": 1,
+                "duration": 2_850_216,
+                "lastWatched": "2026-07-31T20:35:41.332Z",
+            },
+        }
+
+        with patch.object(
+            stremio,
+            "get_cinemeta_series",
+            AsyncMock(return_value={"videos": videos}),
+        ) as get_series:
+            library, watched_records, progress, removed = await _stremio_records([item])
+
+        get_series.assert_awaited_once_with("tt34866681")
+        self.assertEqual(library, [])
+        self.assertEqual(
+            [(record["content_id"], record["season"], record["episode"]) for record in watched_records],
+            [("tmdb:278624", 1, 1)],
+        )
+        self.assertEqual(
+            [(record["content_id"], record["season"], record["episode"]) for record in progress],
+            [("tmdb:278624", 1, 2)],
+        )
+        self.assertEqual(removed, {"tmdb:278624"})
+
     def test_noop_comparison_ignores_only_mtime(self) -> None:
         left = {"_id": "tt0133093", "_mtime": "old", "state": {"timeOffset": 42}, "custom": True}
         same = {**left, "_mtime": "new"}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -446,7 +446,7 @@ export interface UserSettings {
 export interface MediaServerConnection {
   id: number;
   user_id: number;
-  type: "jellyfin" | "emby" | "plex" | "nuvio";
+  type: "jellyfin" | "emby" | "plex" | "nuvio" | "stremio";
   name: string;
   url: string;
   token: string;
@@ -466,7 +466,7 @@ export interface MediaServerConnection {
 }
 
 export interface MediaServerConnectionCreate {
-  type: "jellyfin" | "emby" | "plex" | "nuvio";
+  type: "jellyfin" | "emby" | "plex" | "nuvio" | "stremio";
   name: string;
   url: string;
   token: string;
@@ -981,6 +981,10 @@ export const api = {
       patch<MediaServerConnection>(`/auth/connections/${id}`, body, token),
     deleteConnection: (id: number, token: string) =>
       del<{ status: string }>(`/auth/connections/${id}`, token),
+    startStremioLink: (token: string) =>
+      post<{ code: string; link: string; qrcode: string }>("/auth/stremio/link/start", undefined, token),
+    pollStremioLink: (body: { code: string; name: string }, token: string) =>
+      post<{ status: "pending" | "connected"; connection?: MediaServerConnection }>("/auth/stremio/link/poll", body, token),
     getScrobbleConnections: (token: string) =>
       get<ScrobbleConnection[]>("/auth/scrobble-connections", undefined, token),
     createScrobbleConnection: (body: ScrobbleConnectionCreate, token: string) =>
@@ -1255,6 +1259,8 @@ export const api = {
       post<{ status: string; job_id: number; message: string }>("/sync/plex", params, token),
     syncConnection: (connectionId: number, params?: { movie_limit?: number; show_limit?: number }, token?: string) =>
       post<{ status: string; job_id: number; message: string }>(`/sync/connection/${connectionId}`, params, token),
+    fullResyncConnection: (connectionId: number, token: string) =>
+      post<{ status: string; job_id: number; message: string }>(`/sync/connection/${connectionId}?full=true`, undefined, token),
     status: (token: string) =>
       get<SyncJob[]>("/sync/status", undefined, token),
     getConnectionLibraries: (connectionId: number, token: string) =>

--- a/frontend/src/pages/settings.astro
+++ b/frontend/src/pages/settings.astro
@@ -142,8 +142,8 @@ if (me.totp_enabled) {
             <!-- Connections list (server-side rendered, managed client-side) -->
             <div id="connections-list" class="space-y-3">
             {connections.map((conn) => {
-              const typeColor = conn.type === "jellyfin" ? "bg-purple-500" : conn.type === "emby" ? "bg-green-500" : conn.type === "plex" ? "bg-yellow-500" : "bg-cyan-500";
-              const typeLabel = conn.type === "jellyfin" ? "Jellyfin" : conn.type === "emby" ? "Emby" : conn.type === "plex" ? "Plex" : "Nuvio";
+              const typeColor = conn.type === "jellyfin" ? "bg-purple-500" : conn.type === "emby" ? "bg-green-500" : conn.type === "plex" ? "bg-yellow-500" : conn.type === "stremio" ? "bg-blue-500" : "bg-cyan-500";
+              const typeLabel = conn.type === "jellyfin" ? "Jellyfin" : conn.type === "emby" ? "Emby" : conn.type === "plex" ? "Plex" : conn.type === "stremio" ? "Stremio" : "Nuvio";
               return (
               <div class="bg-zinc-900 border border-zinc-800 rounded-2xl overflow-hidden" data-connection-id={conn.id}>
                 <div class="collapsible-header flex items-center justify-between px-6 py-4 hover:bg-zinc-900/40 cursor-pointer transition-colors select-none" data-target={`conn-body-${conn.id}`}>
@@ -190,11 +190,11 @@ if (me.totp_enabled) {
                   <div class="grid md:grid-cols-2 gap-8 px-6 py-6">
                     <!-- Left: Connection details -->
                     <div class="space-y-4">
-                      <div class="space-y-2">
+                      <div class={`space-y-2 ${conn.type === "stremio" ? "hidden" : ""}`}>
                         <label class="block text-sm font-medium text-zinc-400">{conn.type === "nuvio" ? "Cloud API URL" : "Server URL"}</label>
                         <input type="url" class="conn-url-input w-full bg-zinc-950 border border-zinc-800 rounded-lg px-4 py-3 text-zinc-100 focus:outline-none focus:ring-2 focus:ring-blue-500 transition-all disabled:opacity-70" value={conn.url} data-conn-id={conn.id} disabled={conn.type === "nuvio"} />
                       </div>
-                      <div class="space-y-2">
+                      <div class={`space-y-2 ${conn.type === "stremio" ? "hidden" : ""}`}>
                         <label class="block text-sm font-medium text-zinc-400">{conn.type === "plex" ? "X-Plex-Token" : conn.type === "nuvio" ? "Refresh Token" : "API Token"}</label>
                         <div class="relative">
                           <input type="password" class="conn-token-input w-full bg-zinc-950 border border-zinc-800 rounded-lg pl-4 pr-10 py-3 text-zinc-100 focus:outline-none focus:ring-2 focus:ring-blue-500 transition-all" value={conn.token} data-conn-id={conn.id} />
@@ -204,6 +204,13 @@ if (me.totp_enabled) {
                           </button>
                         </div>
                       </div>
+                      {conn.type === "stremio" && (
+                        <div class="rounded-xl border border-blue-500/20 bg-blue-500/5 p-4 space-y-1">
+                          <p class="text-sm font-medium text-zinc-200">Connected Stremio account</p>
+                          <p class="text-sm text-zinc-400">{conn.server_username || "Account connected"}</p>
+                          <p class="text-xs text-zinc-500">The account key is stored server-side and is never exposed here.</p>
+                        </div>
+                      )}
                       {conn.type === "nuvio" ? (
                         <div class="space-y-2">
                           <label class="block text-sm font-medium text-zinc-400">Nuvio Profile</label>
@@ -211,7 +218,7 @@ if (me.totp_enabled) {
                             <option value={conn.server_user_id || ""}>{conn.server_username || `Profile ${conn.server_user_id}`} (#{conn.server_user_id})</option>
                           </select>
                         </div>
-                      ) : conn.type !== "plex" && (
+                      ) : conn.type !== "plex" && conn.type !== "stremio" && (
                         <div class="space-y-2">
                           <label class="block text-sm font-medium text-zinc-400">User ID</label>
                           <input type="text" class="conn-user-id-input w-full bg-zinc-950 border border-zinc-800 rounded-lg px-4 py-3 text-zinc-100 focus:outline-none focus:ring-2 focus:ring-blue-500 transition-all" value={conn.server_user_id || ""} data-conn-id={conn.id} />
@@ -224,7 +231,7 @@ if (me.totp_enabled) {
                           <input type="text" class="conn-username-input w-full bg-zinc-950 border border-zinc-800 rounded-lg px-4 py-3 text-zinc-100 focus:outline-none focus:ring-2 focus:ring-blue-500 transition-all" value={conn.server_username || ""} data-conn-id={conn.id} />
                         </div>
                       )}
-                      {conn.type !== "nuvio" && (
+                      {conn.type !== "nuvio" && conn.type !== "stremio" && (
                         <>
                           <div class="space-y-2">
                             <label class="block text-sm font-medium text-zinc-400">Libraries to sync</label>
@@ -255,8 +262,8 @@ if (me.totp_enabled) {
                         {[
                           { key: "sync_collection", label: "Collection status" },
                           { key: "sync_watched", label: "Watched status" },
-                          ...(conn.type === "nuvio" ? [] : [{ key: "sync_ratings", label: "Ratings" }]),
-                          { key: "sync_playback", label: conn.type === "nuvio" ? "Playback progress" : "Playback events" },
+                          ...(conn.type === "nuvio" || conn.type === "stremio" ? [] : [{ key: "sync_ratings", label: "Ratings" }]),
+                          { key: "sync_playback", label: conn.type === "nuvio" || conn.type === "stremio" ? "Playback progress" : "Playback events" },
                           ...(conn.type === "plex" ? [{ key: "plex_sync_watchlist", label: "Watchlist" }] : []),
                         ].map(({ key, label }) => (
                           <label class="flex items-center gap-3 cursor-pointer group">
@@ -267,19 +274,25 @@ if (me.totp_enabled) {
                         <div class="flex items-center gap-3">
                           <button type="button" data-action="sync_connection" data-conn-id={conn.id} data-conn-type={conn.type} data-conn-name={conn.name}
                             disabled={!hasTmdbKey}
-                            title={!hasTmdbKey ? "TMDB Read Access Token is required for sync" : conn.type === "nuvio" ? "Sync Nuvio library, watch history, and playback progress" : `Pull from ${conn.name}`}
+                            title={!hasTmdbKey ? "TMDB Read Access Token is required for sync" : conn.type === "nuvio" || conn.type === "stremio" ? `Sync ${typeLabel} library, watched status, and playback progress` : `Pull from ${conn.name}`}
                             class={`js-action-btn text-sm px-3 py-1.5 rounded-lg transition-colors cursor-pointer disabled:opacity-50 ${hasTmdbKey ? "bg-zinc-800 hover:bg-zinc-700 text-zinc-300 border border-zinc-700" : "bg-zinc-800 text-zinc-400 border border-zinc-700 opacity-50"}`}
-                          >{conn.type === "nuvio" ? "Sync now" : "Pull"}</button>
+                          >{conn.type === "nuvio" || conn.type === "stremio" ? "Sync now" : "Pull"}</button>
+                          {conn.type === "stremio" && (
+                            <button type="button" data-action="full_resync_connection" data-conn-id={conn.id} data-conn-name={conn.name}
+                              disabled={!hasTmdbKey}
+                              class="js-action-btn text-sm px-3 py-1.5 rounded-lg transition-colors cursor-pointer disabled:opacity-50 bg-zinc-800 hover:bg-zinc-700 text-zinc-300 border border-zinc-700"
+                            >Full resync</button>
+                          )}
                           <span id={`${conn.type}-last-sync`} class="hidden text-xs text-zinc-500"></span>
                         </div>
                       </div>
                       <div class="bg-zinc-950 rounded-xl p-4 space-y-3">
                         <p class="text-xs font-semibold uppercase tracking-wide text-zinc-500">Scrob → {typeLabel}</p>
                         {[
-                          ...(conn.type === "nuvio" ? [{ key: "push_collection", label: "Collection status" }] : []),
+                          ...(conn.type === "nuvio" || conn.type === "stremio" ? [{ key: "push_collection", label: "Collection status" }] : []),
                           { key: "push_watched", label: "Watched status" },
-                          ...(conn.type === "nuvio" ? [{ key: "push_playback", label: "Playback progress" }] : []),
-                          ...(conn.type === "nuvio" ? [] : [{ key: "push_ratings", label: "Ratings" }]),
+                          ...(conn.type === "nuvio" || conn.type === "stremio" ? [{ key: "push_playback", label: "Playback progress" }] : []),
+                          ...(conn.type === "nuvio" || conn.type === "stremio" ? [] : [{ key: "push_ratings", label: "Ratings" }]),
                           ...(conn.type === "plex" ? [{ key: "plex_push_watchlist", label: "Watchlist" }] : []),
                         ].map(({ key, label }) => (
                           <label class="flex items-center gap-3 cursor-pointer group">
@@ -399,6 +412,7 @@ if (me.totp_enabled) {
                         <option value="emby">Emby</option>
                         <option value="plex">Plex</option>
                         <option value="nuvio">Nuvio</option>
+                        <option value="stremio">Stremio</option>
                       </select>
                     </div>
                     <div id="new-conn-url-row" class="space-y-2">
@@ -409,7 +423,7 @@ if (me.totp_enabled) {
                       <label for="new-nuvio-email" class="block text-sm font-medium text-zinc-400">Nuvio Email</label>
                       <input type="email" id="new-nuvio-email" autocomplete="username" class="w-full bg-zinc-950 border border-zinc-800 rounded-lg px-4 py-3 text-zinc-100 focus:outline-none focus:ring-2 focus:ring-blue-500 transition-all" />
                     </div>
-                    <div class="space-y-2">
+                    <div id="new-conn-token-row" class="space-y-2">
                       <label id="new-conn-token-label" for="new-conn-token" class="block text-sm font-medium text-zinc-400">Token</label>
                       <div class="relative">
                         <input type="password" id="new-conn-token" class="w-full bg-zinc-950 border border-zinc-800 rounded-lg pl-4 pr-10 py-3 text-zinc-100 focus:outline-none focus:ring-2 focus:ring-blue-500 transition-all" />
@@ -429,11 +443,21 @@ if (me.totp_enabled) {
                         <option value="">Sign in to load profiles</option>
                       </select>
                     </div>
+                    <div id="new-stremio-link-row" class="hidden rounded-xl border border-blue-500/20 bg-blue-500/5 p-4 space-y-3">
+                      <p class="text-sm text-zinc-300">Authorize Scrob from Stremio without sharing your password.</p>
+                      <button type="button" id="connect-stremio-btn" class="text-sm bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg transition-colors cursor-pointer">Connect Stremio</button>
+                      <div id="stremio-link-details" class="hidden space-y-3">
+                        <a id="stremio-link-url" href="#" target="_blank" rel="noopener noreferrer" class="block text-sm text-blue-400 hover:text-blue-300 underline">Open Stremio authorization</a>
+                        <p class="text-sm text-zinc-400">Code: <strong id="stremio-link-code" class="font-mono text-zinc-100"></strong></p>
+                        <img id="stremio-link-qr" alt="Stremio authorization QR code" class="w-40 h-40 rounded-lg bg-white p-2" />
+                        <p id="stremio-link-status" class="text-xs text-zinc-500">Waiting for authorization…</p>
+                      </div>
+                    </div>
                     <div id="new-conn-username-row" class="space-y-2 hidden">
                       <label for="new-conn-username" class="block text-sm font-medium text-zinc-400">Plex Username</label>
                       <input type="text" id="new-conn-username" placeholder="e.g. john_doe" class="w-full bg-zinc-950 border border-zinc-800 rounded-lg px-4 py-3 text-zinc-100 focus:outline-none focus:ring-2 focus:ring-blue-500 transition-all" />
                     </div>
-                    <div class="flex gap-2">
+                    <div id="new-connection-actions" class="flex gap-2">
                       <button type="button" id="create-connection-btn" class="text-sm bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg transition-colors cursor-pointer">Add</button>
                       <button type="button" id="test-new-connection-btn" class="text-sm bg-zinc-800 hover:bg-zinc-700 text-zinc-300 border border-zinc-700 px-4 py-2 rounded-lg transition-colors cursor-pointer">Test</button>
                       <button type="button" id="cancel-add-connection-btn" class="text-sm text-zinc-500 hover:text-zinc-300 px-4 py-2 cursor-pointer">Cancel</button>
@@ -2873,6 +2897,23 @@ if (me.totp_enabled) {
             const u = (card?.querySelector('.conn-url-input') as HTMLInputElement)?.value || '';
             const t = (card?.querySelector('.conn-token-input') as HTMLInputElement)?.value || '';
             const ui = (card?.querySelector('.conn-user-id-input') as HTMLInputElement)?.value || '';
+            if (connType === 'stremio') {
+              const statusResponse = await fetch('/api/proxy/auth/connection-status', {
+                headers: { 'Authorization': `Bearer ${token}` },
+              });
+              const statusData = await statusResponse.json();
+              const connectionStatus = (statusData.connections || []).find(
+                (entry: any) => String(entry.id) === String(connId)
+              );
+              if (statusResponse.ok && connectionStatus?.connected) {
+                showMessage('Stremio connection successful!');
+                if (connId) setConnStatus(`conn-status-${connId}`, 'connected');
+              } else {
+                if (connId) setConnStatus(`conn-status-${connId}`, 'disconnected');
+                throw new Error('Stremio connection test failed');
+              }
+              return;
+            }
             let testRes: Response;
             if (connType === 'nuvio') {
               testRes = await fetch('/api/proxy/auth/test-nuvio', {
@@ -3017,6 +3058,18 @@ if (me.totp_enabled) {
           } else if (action === 'scan_libraries') {
             const connId = newBtn.getAttribute('data-conn-id');
             url = `/api/proxy/sync/connection/${connId}/scan`;
+          } else if (action === 'full_resync_connection') {
+            const connId = newBtn.getAttribute('data-conn-id');
+            const connName = newBtn.getAttribute('data-conn-name') || 'Stremio';
+            const ok = await showConfirmModal(
+              `Full resync from ${connName}?`,
+              'This reads the complete Stremio library and safely reconciles provider-specific removals. Other collection sources are preserved.',
+              'Full resync',
+            );
+            if (!ok) return;
+            renderConnProgress(connId, { status: 'pending', job_type: 'pull', processed_items: 0, total_items: 0, updated_at: new Date().toISOString() });
+            url = `/api/proxy/sync/connection/${connId}?full=true`;
+            syncConnId = connId;
           } else if (action === 'sync_connection') {
             const connId = newBtn.getAttribute('data-conn-id');
             const connName = newBtn.getAttribute('data-conn-name') || 'this server';
@@ -3053,6 +3106,7 @@ if (me.totp_enabled) {
             const card = document.querySelector(`[data-connection-id="${connId}"]`);
             const pushPrefLabels: Record<string, string> = {
               push_watched: 'watched status',
+              push_collection: 'collection status',
               push_ratings: 'ratings',
               push_playback: 'playback progress',
               plex_push_watchlist: 'watchlist',
@@ -3912,13 +3966,26 @@ if (me.totp_enabled) {
     const addBtn = document.getElementById('add-connection-btn');
     const addForm = document.getElementById('add-connection-form');
     const cancelBtn = document.getElementById('cancel-add-connection-btn');
+    const connectStremioBtn = document.getElementById('connect-stremio-btn') as HTMLButtonElement | null;
+    let stremioPollTimer: number | null = null;
     if (addBtn && addForm) {
       addBtn.addEventListener('click', () => {
         addForm.classList.toggle('hidden');
       });
     }
     if (cancelBtn && addForm) {
-      cancelBtn.addEventListener('click', () => addForm.classList.add('hidden'));
+      cancelBtn.addEventListener('click', () => {
+        addForm.classList.add('hidden');
+        if (stremioPollTimer !== null) {
+          window.clearTimeout(stremioPollTimer);
+          stremioPollTimer = null;
+        }
+        document.getElementById('stremio-link-details')?.classList.add('hidden');
+        if (connectStremioBtn) {
+          connectStremioBtn.disabled = false;
+          connectStremioBtn.textContent = 'Connect Stremio';
+        }
+      });
     }
 
     // Provider-specific fields for a new connection
@@ -3927,6 +3994,9 @@ if (me.totp_enabled) {
     const usernameRow = document.getElementById('new-conn-username-row');
     const nuvioEmailRow = document.getElementById('new-nuvio-email-row');
     const nuvioProfileRow = document.getElementById('new-nuvio-profile-row');
+    const stremioLinkRow = document.getElementById('new-stremio-link-row');
+    const urlRow = document.getElementById('new-conn-url-row');
+    const tokenRow = document.getElementById('new-conn-token-row');
     const urlInput = document.getElementById('new-conn-url') as HTMLInputElement | null;
     const urlLabel = document.getElementById('new-conn-url-label');
     const tokenInput = document.getElementById('new-conn-token') as HTMLInputElement | null;
@@ -3939,16 +4009,26 @@ if (me.totp_enabled) {
       const type = typeSelect?.value ?? 'jellyfin';
       const isPlex = type === 'plex';
       const isNuvio = type === 'nuvio';
-      userIdRow?.classList.toggle('hidden', isPlex || isNuvio);
+      const isStremio = type === 'stremio';
+      const isCloud = isNuvio || isStremio;
+      userIdRow?.classList.toggle('hidden', isPlex || isCloud);
       usernameRow?.classList.toggle('hidden', !isPlex);
       nuvioEmailRow?.classList.toggle('hidden', !isNuvio);
       nuvioProfileRow?.classList.toggle('hidden', !isNuvio);
+      stremioLinkRow?.classList.toggle('hidden', !isStremio);
+      urlRow?.classList.toggle('hidden', isStremio);
+      tokenRow?.classList.toggle('hidden', isStremio);
+      document.getElementById('create-connection-btn')?.classList.toggle('hidden', isStremio);
+      document.getElementById('test-new-connection-btn')?.classList.toggle('hidden', isStremio);
       if (urlInput) {
         if (isNuvio) {
           urlInput.value = 'https://api.nuvio.tv';
           urlInput.disabled = true;
+        } else if (isStremio) {
+          urlInput.value = 'https://api.strem.io';
+          urlInput.disabled = true;
         } else {
-          if (previousType === 'nuvio' && urlInput.value === 'https://api.nuvio.tv') urlInput.value = '';
+          if (previousType === 'nuvio' || previousType === 'stremio') urlInput.value = '';
           urlInput.disabled = false;
         }
       }
@@ -3958,22 +4038,30 @@ if (me.totp_enabled) {
       const syncRatings = document.getElementById('new-sync-ratings') as HTMLInputElement | null;
       const pushRatings = document.getElementById('new-push-ratings') as HTMLInputElement | null;
       const pushPlayback = document.getElementById('new-push-playback') as HTMLInputElement | null;
-      pushPlayback?.closest('label')?.classList.toggle('hidden', !isNuvio);
-      if (pushPlayback) pushPlayback.disabled = !isNuvio;
+      pushPlayback?.closest('label')?.classList.toggle('hidden', !isCloud);
+      if (pushPlayback) pushPlayback.disabled = !isCloud;
       const pushCollection = document.getElementById('new-push-collection') as HTMLInputElement | null;
-      pushCollection?.closest('label')?.classList.toggle('hidden', !isNuvio);
-      if (pushCollection) pushCollection.disabled = !isNuvio;
+      pushCollection?.closest('label')?.classList.toggle('hidden', !isCloud);
+      if (pushCollection) pushCollection.disabled = !isCloud;
       for (const checkbox of [syncRatings, pushRatings]) {
-        checkbox?.closest('label')?.classList.toggle('hidden', isNuvio);
-        if (checkbox) checkbox.disabled = isNuvio;
+        checkbox?.closest('label')?.classList.toggle('hidden', isCloud);
+        if (checkbox) checkbox.disabled = isCloud;
       }
       const playbackLabel = document.getElementById('new-sync-playback-label');
-      if (playbackLabel) playbackLabel.textContent = isNuvio ? 'Playback progress' : 'Playback events';
+      if (playbackLabel) playbackLabel.textContent = isCloud ? 'Playback progress' : 'Playback events';
       const pullHeading = document.getElementById('new-pull-heading');
       const pushHeading = document.getElementById('new-push-heading');
-      if (pullHeading) pullHeading.textContent = isNuvio ? 'Nuvio → Scrob' : 'Server → Scrob';
-      if (pushHeading) pushHeading.textContent = isNuvio ? 'Scrob → Nuvio' : 'Scrob → Server';
-      if (type !== previousType) pendingNuvioRefreshToken = '';
+      const providerName = isNuvio ? 'Nuvio' : isStremio ? 'Stremio' : 'Server';
+      if (pullHeading) pullHeading.textContent = `${providerName} → Scrob`;
+      if (pushHeading) pushHeading.textContent = `Scrob → ${providerName}`;
+      if (type !== previousType) {
+        pendingNuvioRefreshToken = '';
+        if (stremioPollTimer !== null) {
+          window.clearTimeout(stremioPollTimer);
+          stremioPollTimer = null;
+          document.getElementById('stremio-link-details')?.classList.add('hidden');
+        }
+      }
       previousType = type;
     };
     typeSelect?.addEventListener('change', updateTypeFields);
@@ -4004,6 +4092,94 @@ if (me.totp_enabled) {
       if (!nuvioProfileSelect?.value) throw new Error('No Nuvio profile is available for this account.');
       return data;
     };
+
+    connectStremioBtn?.addEventListener('click', async () => {
+      const name = (document.getElementById('new-conn-name') as HTMLInputElement | null)?.value.trim() || '';
+      if (!name) {
+        showMessage('Choose a name for the Stremio connection.', 'error');
+        return;
+      }
+      if (stremioPollTimer !== null) {
+        window.clearTimeout(stremioPollTimer);
+        stremioPollTimer = null;
+      }
+      connectStremioBtn.disabled = true;
+      const originalLabel = connectStremioBtn.textContent;
+      connectStremioBtn.textContent = 'Creating link…';
+      try {
+        const response = await fetch('/api/proxy/auth/stremio/link/start', {
+          method: 'POST',
+          headers: { 'Authorization': `Bearer ${token}` },
+        });
+        const link = await response.json();
+        if (!response.ok) throw new Error(link.detail || 'Could not create the Stremio link.');
+        const details = document.getElementById('stremio-link-details');
+        const linkUrl = document.getElementById('stremio-link-url') as HTMLAnchorElement | null;
+        const code = document.getElementById('stremio-link-code');
+        const qr = document.getElementById('stremio-link-qr') as HTMLImageElement | null;
+        const status = document.getElementById('stremio-link-status');
+        details?.classList.remove('hidden');
+        if (linkUrl) linkUrl.href = link.link;
+        if (code) code.textContent = link.code;
+        if (qr) qr.src = link.qrcode;
+        if (status) status.textContent = 'Waiting for authorization…';
+        window.open(link.link, '_blank', 'noopener,noreferrer');
+        const linkExpiresAt = Date.now() + 10 * 60 * 1000;
+
+        const poll = async () => {
+          try {
+            if (Date.now() >= linkExpiresAt) {
+              throw new Error('Stremio authorization expired. Create a new link and try again.');
+            }
+            const pollResponse = await fetch('/api/proxy/auth/stremio/link/poll', {
+              method: 'POST',
+              headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' },
+              body: JSON.stringify({
+                code: link.code,
+                name,
+                sync_collection: (document.getElementById('new-sync-collection') as HTMLInputElement)?.checked ?? true,
+                sync_watched: (document.getElementById('new-sync-watched') as HTMLInputElement)?.checked ?? true,
+                sync_playback: (document.getElementById('new-sync-playback') as HTMLInputElement)?.checked ?? true,
+                push_collection: (document.getElementById('new-push-collection') as HTMLInputElement)?.checked ?? false,
+                push_watched: (document.getElementById('new-push-watched') as HTMLInputElement)?.checked ?? false,
+                push_playback: (document.getElementById('new-push-playback') as HTMLInputElement)?.checked ?? false,
+                auto_sync_interval: (() => {
+                  const value = (document.getElementById('new-auto-sync') as HTMLSelectElement)?.value;
+                  return value ? parseFloat(value) : null;
+                })(),
+                auto_push_interval: (() => {
+                  const value = (document.getElementById('new-auto-push') as HTMLSelectElement)?.value;
+                  return value ? parseFloat(value) : null;
+                })(),
+              }),
+            });
+            const result = await pollResponse.json();
+            if (!pollResponse.ok) throw new Error(result.detail || 'Stremio authorization failed.');
+            if (result.status === 'connected') {
+              stremioPollTimer = null;
+              if (status) status.textContent = 'Connected. Reloading…';
+              showMessage('Stremio connected.');
+              window.location.reload();
+              return;
+            }
+            stremioPollTimer = window.setTimeout(poll, 2000);
+          } catch (error: any) {
+            stremioPollTimer = null;
+            if (status) status.textContent = error.message;
+            showMessage(error.message, 'error');
+            connectStremioBtn.disabled = false;
+            connectStremioBtn.textContent = originalLabel;
+          }
+        };
+        stremioPollTimer = window.setTimeout(poll, 1500);
+        connectStremioBtn.textContent = 'Waiting…';
+      } catch (error: any) {
+        stremioPollTimer = null;
+        showMessage(error.message, 'error');
+        connectStremioBtn.disabled = false;
+        connectStremioBtn.textContent = originalLabel;
+      }
+    });
 
     // Test new connection button
     const testNewBtn = document.getElementById('test-new-connection-btn');
@@ -4675,7 +4851,7 @@ if (me.totp_enabled) {
         return `${Math.floor(diff / 86400)}d ago`;
       }
 
-      for (const source of ['jellyfin', 'emby', 'plex', 'nuvio'] as const) {
+      for (const source of ['jellyfin', 'emby', 'plex', 'nuvio', 'stremio'] as const) {
         const el = document.getElementById(`${source}-last-sync`);
         if (!el) continue;
         const job = jobs.find(j => j.source === source && (j.status === 'completed' || j.status === 'failed'));


### PR DESCRIPTION
## Summary
- add Stremio as a first-class sync provider alongside Jellyfin, Emby, Plex, and Nuvio
- connect accounts through Stremio's official Link flow without collecting passwords
- pull and push library membership, watched state, and playback progress through Stremio datastore `libraryItem` records
- support incremental pulls, explicit full resyncs, automatic pull/push schedules, and safe ownership-aware remote removals
- map IMDb series and episode state through Cinemeta while preserving unrelated remote Stremio items
- expose the complete provider configuration and Link/QR flow in Settings

## Compatibility and safety
- rebased onto the current `upstream/main`, including the merged Nuvio, manual episode-to-show, and unknown watch-date changes
- preserves explicit unknown watch dates instead of fabricating timestamps
- treats Stremio `removed` and `temp` as library-membership flags while still importing their usable watched/progress state
- throttles Cinemeta metadata lookups using the existing sync concurrency limit
- redacts the Stremio auth key from connection responses
- keeps the Alembic chain linear with `d7e8f9a0b1c2` as the single head

## Validation
- `python -m unittest discover -s tests -v` — 126 passed
- `python -m unittest tests.test_stremio -v` — 18 passed
- `npm run build` — passed
- `python -m alembic heads` — single head: `d7e8f9a0b1c2`
- `python -m alembic upgrade c7d8e9f0a1b2:d7e8f9a0b1c2 --sql` — compiled successfully
- browser smoke: Settings renders the Stremio-specific sync controls; Link start displays the returned URL, code, QR image, and pending state

## Stremio model limitation
Stremio stores a series-wide `lastWatched` timestamp plus an episode bitfield. Scrob can preserve watched episode state, but Stremio does not expose distinct watch timestamps for every episode in that representation.

Closes #60