### PR TITLE
fix(compat): resolve tvdbId for Sonarr list import

### DIFF
--- a/backend/routers/compat.py
+++ b/backend/routers/compat.py
@@ -15,6 +15,8 @@ log = logging.getLogger(__name__)
 
 router = APIRouter(tags=["compat"])
 
+TMDB_CONCURRENCY = 5  # Max concurrent TMDB requests
+
 
 async def _user_by_api_key(
     x_api_key: str | None = Header(None, alias="X-Api-Key"),
@@ -117,10 +119,12 @@ async def sonarr_list(
         from routers.media import get_user_tmdb_key
 
         tmdb_key = await get_user_tmdb_key(db, user.id)
+        semaphore = asyncio.Semaphore(TMDB_CONCURRENCY)
 
         async def _lookup(idx: int, tmdb_id: int) -> tuple[int, int | None]:
             try:
-                ext = await tmdb_core.get_external_ids(tmdb_id, "tv", api_key=tmdb_key)
+                async with semaphore:
+                    ext = await tmdb_core.get_external_ids(tmdb_id, "tv", api_key=tmdb_key)
                 return idx, ext.get("tvdb_id")
             except Exception as e:
                 log.warning(f"sonarr-compat: TMDB external_ids lookup failed for tmdb:{tmdb_id}: {e}")

--- a/backend/routers/compat.py
+++ b/backend/routers/compat.py
@@ -1,3 +1,6 @@
+import asyncio
+import logging
+
 from fastapi import APIRouter, Depends, HTTPException, Query, Header
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
@@ -7,6 +10,8 @@ from models.users import User
 from models.lists import List as UserList, ListItem
 from models.media import Media, MediaType
 from models.show import Show
+
+log = logging.getLogger(__name__)
 
 router = APIRouter(tags=["compat"])
 
@@ -84,14 +89,49 @@ async def sonarr_list(
     await _get_list(list_id, user, db)
 
     rows = (await db.execute(
-        select(Media, Show.tvdb_id)
+        select(Media, Show.tvdb_id, Show.tmdb_data)
         .join(ListItem, ListItem.media_id == Media.id)
         .outerjoin(Show, Show.tmdb_id == Media.tmdb_id)
         .where(ListItem.list_id == list_id, Media.media_type == MediaType.series)
     )).all()
 
+    # Sonarr requires tvdbId to add a series from an import list. List items
+    # added from TMDB search often lack a linked Show row with tvdb_id, so
+    # fall back to the cached TMDB payload and finally to a live TMDB lookup —
+    # mirroring the resolution order used by the manual "Request on Sonarr"
+    # flow in routers/media.py.
+    unresolved: list[tuple[int, int]] = []
+    resolved: dict[int, int] = {}
+    for idx, (media, tvdb_id, tmdb_data) in enumerate(rows):
+        if not media.tmdb_id or tvdb_id:
+            continue
+        cached = (tmdb_data or {}).get("external_ids") or {}
+        cached_tvdb = cached.get("tvdb_id") if isinstance(cached, dict) else None
+        if cached_tvdb:
+            resolved[idx] = cached_tvdb
+        else:
+            unresolved.append((idx, media.tmdb_id))
+
+    if unresolved:
+        from core import tmdb as tmdb_core
+        from routers.media import get_user_tmdb_key
+
+        tmdb_key = await get_user_tmdb_key(db, user.id)
+
+        async def _lookup(idx: int, tmdb_id: int) -> tuple[int, int | None]:
+            try:
+                ext = await tmdb_core.get_external_ids(tmdb_id, "tv", api_key=tmdb_key)
+                return idx, ext.get("tvdb_id")
+            except Exception as e:
+                log.warning(f"sonarr-compat: TMDB external_ids lookup failed for tmdb:{tmdb_id}: {e}")
+                return idx, None
+
+        for idx, tvdb in await asyncio.gather(*[_lookup(i, t) for i, t in unresolved]):
+            if tvdb:
+                resolved[idx] = tvdb
+
     result = []
-    for media, tvdb_id in rows:
+    for idx, (media, tvdb_id, _tmdb_data) in enumerate(rows):
         if not media.tmdb_id:
             continue
         # Radarr/Sonarr deserialize this into a non-nullable int — a null year
@@ -114,7 +154,8 @@ async def sonarr_list(
             "monitored": True,
             "seasonFolder": True,
         }
-        if tvdb_id:
-            entry["tvdbId"] = tvdb_id
+        effective_tvdb = tvdb_id or resolved.get(idx)
+        if effective_tvdb:
+            entry["tvdbId"] = effective_tvdb
         result.append(entry)
     return result

--- a/backend/tests/test_compat.py
+++ b/backend/tests/test_compat.py
@@ -1,7 +1,7 @@
 import os
 import unittest
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 os.environ.setdefault("SECRET_KEY", "test-secret")
 os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://test:test@localhost/test")
@@ -30,6 +30,13 @@ class _FakeSession:
         return self.list_row
 
 
+def _series_media(tmdb_id: int = 42, title: str = "A Show") -> SimpleNamespace:
+    return SimpleNamespace(
+        tmdb_id=tmdb_id, title=title, original_title=None,
+        overview=None, release_date=None, runtime=None, status=None,
+    )
+
+
 class MissingYearTests(unittest.IsolatedAsyncioTestCase):
     """Regression test for issue #99: Radarr/Sonarr deserialize `year` into a
     non-nullable int, so a null year on any one item aborts the whole import."""
@@ -50,15 +57,60 @@ class MissingYearTests(unittest.IsolatedAsyncioTestCase):
     async def test_sonarr_list_defaults_missing_year_to_zero(self) -> None:
         user = SimpleNamespace(id=1)
         lst = SimpleNamespace(user_id=1)
-        media = SimpleNamespace(
-            tmdb_id=42, title="No Release Date", original_title=None,
-            overview=None, release_date=None, runtime=None, status=None,
-        )
-        db = _FakeSession(lst, [(media, None)])
+        db = _FakeSession(lst, [(_series_media(), None, None)])
 
-        result = await compat.sonarr_list(list_id=1, user=user, db=db)
+        with patch("routers.media.get_user_tmdb_key", new=AsyncMock(return_value=None)), \
+             patch("core.tmdb.get_external_ids", new=AsyncMock(return_value={})):
+            result = await compat.sonarr_list(list_id=1, user=user, db=db)
 
         self.assertEqual(result[0]["year"], 0)
+
+
+class SonarrTvdbResolutionTests(unittest.IsolatedAsyncioTestCase):
+    """Sonarr import lists require a valid tvdbId. Resolve it from the Show
+    column, the cached TMDB payload, or a live TMDB external_ids lookup."""
+
+    async def test_uses_show_tvdb_id_column_without_tmdb_call(self) -> None:
+        user = SimpleNamespace(id=1)
+        lst = SimpleNamespace(user_id=1)
+        db = _FakeSession(lst, [(_series_media(tmdb_id=93870), 393926, None)])
+
+        with patch("core.tmdb.get_external_ids", new=AsyncMock()) as m:
+            result = await compat.sonarr_list(list_id=1, user=user, db=db)
+
+        self.assertEqual(result[0]["tvdbId"], 393926)
+        m.assert_not_awaited()
+
+    async def test_falls_back_to_cached_tmdb_external_ids(self) -> None:
+        user = SimpleNamespace(id=1)
+        lst = SimpleNamespace(user_id=1)
+        tmdb_data = {"external_ids": {"tvdb_id": 328487}}
+        db = _FakeSession(lst, [(_series_media(tmdb_id=62479), None, tmdb_data)])
+
+        with patch("core.tmdb.get_external_ids", new=AsyncMock()) as m:
+            result = await compat.sonarr_list(list_id=1, user=user, db=db)
+
+        self.assertEqual(result[0]["tvdbId"], 328487)
+        m.assert_not_awaited()
+
+    async def test_falls_back_to_tmdb_lookup_and_omits_when_unresolved(self) -> None:
+        user = SimpleNamespace(id=1)
+        lst = SimpleNamespace(user_id=1)
+        db = _FakeSession(lst, [
+            (_series_media(tmdb_id=93870, title="Resolvable"), None, None),
+            (_series_media(tmdb_id=999999, title="Unlisted"), None, None),
+        ])
+
+        async def fake_external_ids(tmdb_id, type, api_key=None):
+            return {"tvdb_id": 393926} if tmdb_id == 93870 else {}
+
+        with patch("routers.media.get_user_tmdb_key", new=AsyncMock(return_value="k")), \
+             patch("core.tmdb.get_external_ids", side_effect=fake_external_ids) as m:
+            result = await compat.sonarr_list(list_id=1, user=user, db=db)
+
+        self.assertEqual(result[0]["tvdbId"], 393926)
+        self.assertNotIn("tvdbId", result[1])
+        self.assertEqual(m.await_count, 2)
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_compat.py
+++ b/backend/tests/test_compat.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 import unittest
 from types import SimpleNamespace
@@ -111,6 +112,36 @@ class SonarrTvdbResolutionTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result[0]["tvdbId"], 393926)
         self.assertNotIn("tvdbId", result[1])
         self.assertEqual(m.await_count, 2)
+
+    async def test_tmdb_lookup_fan_out_is_capped_by_concurrency_limit(self) -> None:
+        user = SimpleNamespace(id=1)
+        lst = SimpleNamespace(user_id=1)
+        item_count = compat.TMDB_CONCURRENCY * 3
+        db = _FakeSession(lst, [
+            (_series_media(tmdb_id=1000 + i, title=f"Show {i}"), None, None)
+            for i in range(item_count)
+        ])
+
+        in_flight = 0
+        max_in_flight = 0
+        lock = asyncio.Lock()
+
+        async def fake_external_ids(tmdb_id, type, api_key=None):
+            nonlocal in_flight, max_in_flight
+            async with lock:
+                in_flight += 1
+                max_in_flight = max(max_in_flight, in_flight)
+            await asyncio.sleep(0.01)
+            async with lock:
+                in_flight -= 1
+            return {"tvdb_id": tmdb_id}
+
+        with patch("routers.media.get_user_tmdb_key", new=AsyncMock(return_value="k")), \
+             patch("core.tmdb.get_external_ids", side_effect=fake_external_ids):
+            result = await compat.sonarr_list(list_id=1, user=user, db=db)
+
+        self.assertEqual(len(result), item_count)
+        self.assertEqual(max_in_flight, compat.TMDB_CONCURRENCY)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Sonarr requires a valid `tvdbId` on import list entries. The current compat endpoint only sets `tvdbId` when `Show.tvdb_id` is populated via the DB join. List items added from TMDB search typically lack a linked `Show` row with `tvdb_id`, so Sonarr silently drops them — the import reports `Items found: N, Series added: 0` even when new series are present.

Fixes the Sonarr half of #57. Radarr already works after the v1.46.0 fixes.

## Fix

Resolve `tvdbId` in `sonarr_list()` using the same three-tier order as the manual "Request on Sonarr" flow in `routers/media.py`:

1. `Show.tvdb_id` column (unchanged — no extra work when already set)
2. `Show.tmdb_data.external_ids.tvdb_id` (already cached — no extra call)
3. `tmdb.get_external_ids()` fallback using the list owner's TMDB key

Fallback lookups are batched via `asyncio.gather` so large lists stay fast. Entries that still can't be resolved (e.g. upcoming shows not yet on TVDB) are emitted without `tvdbId` — same behaviour as before, Sonarr simply skips them.

## Scope

- One production file: `backend/routers/compat.py` (+45 / −4 — one query widened to also select `Show.tmdb_data`, ~30 lines of new resolution logic)
- Test file: `backend/tests/test_compat.py` (+59 / −7) — 3 new cases covering each resolution tier plus the unresolved path; existing year-regression test updated to neutralise the new fallback
- No schema changes, migrations, dependencies, or frontend changes

## Test plan

- [x] `python -m unittest discover tests` — full backend suite (152 tests) passes locally
- [x] Local Docker omnibus image built from this branch on a real deployment
- [x] `curl` against `/api/proxy/sonarr-compat/{id}/api/v3/series` — all 10 series in a real list now return valid `tvdbId` (previously `null` for every entry)
- [x] Sonarr import list sync end-to-end: previously `Items found: 10, Series added: 0`; now `Items found: 10, Series added: 5` (the other 5 already existed in Sonarr)

Refs #57

## Notes

Code was drafted with AI assistance (Cursor). All changes were reviewed, tested locally against a real deployment, and verified end-to-end against a running Sonarr instance before opening this PR.