### PR TITLE
fix(plex): stop the watchlist push from re-adding items removed on Plex

### DIFF
--- a/backend/core/watchlist_reconcile.py
+++ b/backend/core/watchlist_reconcile.py
@@ -1,0 +1,153 @@
+"""Three-way reconciliation for the Plex watchlist mirror.
+
+The watchlist is synced by pull and push jobs on independent schedules, so
+an item missing on one side is ambiguous: never synced, or deliberately
+removed there. Guessing wrong is how Plex's auto-remove-after-watching used
+to get undone by the next push.
+
+The tiebreaker is a persisted baseline - the key set both sides agreed on
+after the last reconcile (None until a first one completes). Comparing
+local L, remote R and baseline B classifies every key, and the same plan
+comes out no matter which job runs first:
+
+    L R B   both directions      pull only              push only
+    -----   ------------------   --------------------   ------------------
+    1 1 *   in sync              in sync                in sync
+    1 0 0   push_add             remove_local (mirror)  push_add
+    0 1 0   add_local            add_local              (ignored)
+    1 0 1   remove_local         remove_local           push_add (master)
+    0 1 1   push_remove          add_local (mirror)     push_remove
+    0 0 1   drops from baseline  drops from baseline    drops from baseline
+
+Pull-only stays a plain mirror of the remote and push-only keeps Scrob as
+the master, same as before. With both directions on, each side's removals
+now propagate exactly once ((1,0,1) is the resurrection fix), and a local
+add whose fire-and-forget live push failed gets retried instead of deleted
+by the next pull ((1,0,0)).
+
+With no baseline yet nothing is ever deleted - the plan is purely additive
+in whichever directions are enabled, like a first sync always was.
+
+Remote-driven deletions go through the same circuit breaker idea as the
+collection pruner in routers/sync.py: a fetch that succeeds but comes back
+empty or majority-shrunk against an established baseline looks exactly like
+a broken fetch, so the run is skipped rather than trusted.
+"""
+
+from dataclasses import dataclass, field
+from typing import Iterable, Optional
+
+# Same thresholds as the collection pruner (kept local - core doesn't import
+# from routers). Below the floor there is no suppression at all: small
+# watchlists drain to empty legitimately all the time.
+SUPPRESS_MIN_BASELINE = 10
+SUPPRESS_MAX_FRACTION = 0.5
+
+_EMPTY: frozenset[str] = frozenset()
+
+
+def media_key(kind: str, tmdb_id: int) -> str:
+    """Key like "movie:603" - typed, since a movie and a show can share a
+    TMDB id. Same format the watchlist poller in main.py uses."""
+    return f"{kind}:{tmdb_id}"
+
+
+@dataclass(frozen=True)
+class ReconcilePlan:
+    add_local    : frozenset[str] = _EMPTY
+    remove_local : frozenset[str] = _EMPTY
+    push_add     : frozenset[str] = _EMPTY
+    push_remove  : frozenset[str] = _EMPTY
+    suppressed   : bool = False
+    suppressed_reason : Optional[str] = field(default=None, compare=False)
+
+    @property
+    def has_changes(self) -> bool:
+        return bool(self.add_local or self.remove_local or self.push_add or self.push_remove)
+
+
+def plan_watchlist_reconcile(
+    local: Iterable[str],
+    remote: Iterable[str],
+    baseline: Optional[Iterable[str]],
+    *,
+    pull_enabled: bool,
+    push_enabled: bool,
+) -> ReconcilePlan:
+    """Classify every key per the table in the module docstring.
+
+    baseline=None means "never reconciled" and is not the same as an empty
+    baseline - only the former disables deletion inference."""
+    l, r = set(local), set(remote)
+
+    if baseline is None:
+        return ReconcilePlan(
+            add_local=frozenset(r - l) if pull_enabled else _EMPTY,
+            push_add=frozenset(l - r) if push_enabled else _EMPTY,
+        )
+
+    b = set(baseline)
+
+    add_local: set[str] = set()
+    remove_local: set[str] = set()
+    push_add: set[str] = set()
+    push_remove: set[str] = set()
+
+    for key in l - r:
+        if key in b:  # (1,0,1) synced before, gone remotely
+            if pull_enabled:
+                remove_local.add(key)
+            elif push_enabled:  # Scrob is master: put it back
+                push_add.add(key)
+        else:  # (1,0,0) added locally since last reconcile
+            if push_enabled:
+                push_add.add(key)
+            elif pull_enabled:  # plain mirror: remote wins
+                remove_local.add(key)
+
+    for key in r - l:
+        if key in b:  # (0,1,1) synced before, gone locally
+            if push_enabled:
+                push_remove.add(key)
+            elif pull_enabled:  # plain mirror: remote wins
+                add_local.add(key)
+        else:  # (0,1,0) added remotely since last reconcile
+            if pull_enabled:
+                add_local.add(key)
+
+    if remove_local and len(b) >= SUPPRESS_MIN_BASELINE:
+        reason = None
+        if not r:
+            reason = f"remote watchlist came back empty with {len(b)} baseline item(s)"
+        elif len(remove_local & b) > SUPPRESS_MAX_FRACTION * len(b):
+            reason = (
+                f"remote watchlist would remove {len(remove_local & b)} of "
+                f"{len(b)} baseline item(s)"
+            )
+        if reason:
+            # Don't act on any of it - a suspect fetch shouldn't drive a mass
+            # re-add either. Baseline stays put so a healthy fetch recovers.
+            return ReconcilePlan(suppressed=True, suppressed_reason=reason)
+
+    return ReconcilePlan(
+        add_local=frozenset(add_local),
+        remove_local=frozenset(remove_local),
+        push_add=frozenset(push_add),
+        push_remove=frozenset(push_remove),
+    )
+
+
+def compute_new_baseline(
+    final_local: Iterable[str],
+    *,
+    failed_push_add: Iterable[str] = (),
+    failed_push_remove: Iterable[str] = (),
+) -> list[str]:
+    """Next baseline from what actually happened, not what was planned.
+
+    final_local must be the real post-apply local state - a local add that
+    failed must not land in the baseline, or the key would later read as a
+    local deletion and get removed from Plex. Failed remote adds are left
+    out so they retry as (1,0,0); failed remote removes are kept in so they
+    retry as (0,1,1)."""
+    return sorted((set(final_local) | set(failed_push_remove)) - set(failed_push_add))

--- a/backend/main.py
+++ b/backend/main.py
@@ -132,15 +132,7 @@ async def _auto_sync_scheduler():
                     schedules: list[tuple[str, float, object]] = []
                     if conn.auto_sync_interval is not None:
                         schedules.append(("pull", conn.auto_sync_interval, pull_runner))
-                    if (
-                        conn.auto_push_interval is not None
-                        and (
-                            conn.push_collection
-                            or conn.push_watched
-                            or conn.push_playback
-                            or conn.push_ratings
-                        )
-                    ):
+                    if conn.auto_push_interval is not None and conn.push_enabled:
                         schedules.append(("push", conn.auto_push_interval, _run_full_push))
 
                     due: list[tuple[datetime, str, object]] = []

--- a/backend/migrations/versions/5806acaa7d6e_add_plex_watchlist_synced_keys.py
+++ b/backend/migrations/versions/5806acaa7d6e_add_plex_watchlist_synced_keys.py
@@ -1,0 +1,25 @@
+"""Add plex_watchlist_synced_keys baseline to media_server_connections
+
+Revision ID: 5806acaa7d6e
+Revises: e4a1c2b3d5f6
+Create Date: 2026-08-10
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision = "5806acaa7d6e"
+down_revision = "e4a1c2b3d5f6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "media_server_connections",
+        sa.Column("plex_watchlist_synced_keys", JSONB(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("media_server_connections", "plex_watchlist_synced_keys")

--- a/backend/models/connections.py
+++ b/backend/models/connections.py
@@ -51,8 +51,28 @@ class MediaServerConnection(Base):
     # Plex watchlist ↔ Scrob list sync (Plex connections only)
     plex_sync_watchlist : Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="false")
     plex_push_watchlist : Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="false")
+    # Typed keys ("movie:603") on the Plex watchlist as of the last successful
+    # reconcile; NULL = never reconciled, so deletions are never inferred.
+    # Unrelated to watchlist_synced_ids above (the Radarr/Sonarr request cache).
+    plex_watchlist_synced_keys : Mapped[Optional[list]] = mapped_column(JSONB, nullable=True)
 
     # Plex per-play watch history backfill cursor (Plex connections only)
     plex_history_cursor_at : Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
 
     created_at       : Mapped[datetime] = mapped_column(DateTime, server_default=func.now(), nullable=False)
+
+    @property
+    def push_enabled(self) -> bool:
+        """Whether this connection has any Scrob → server push direction enabled.
+
+        Single source of truth for the auto-push scheduler and the manual push
+        endpoint, so a newly added push flag can't be forgotten in one of them
+        again (plex_push_watchlist was, leaving watchlist-only connections
+        without auto-push)."""
+        return bool(
+            self.push_collection
+            or self.push_watched
+            or self.push_playback
+            or self.push_ratings
+            or self.plex_push_watchlist
+        )

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -595,6 +595,13 @@ async def update_connection(
             update_data["push_playback"] = False
             update_data["push_collection"] = False
 
+    # Re-enabling a watchlist sync direction starts from a clean bootstrap: a
+    # baseline recorded under the old settings must not drive deletions.
+    for flag in ("plex_sync_watchlist", "plex_push_watchlist"):
+        if update_data.get(flag) and not getattr(conn, flag):
+            update_data["plex_watchlist_synced_keys"] = None
+            break
+
     for field, value in update_data.items():
         setattr(conn, field, value)
 

--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -31,6 +31,7 @@ from core.enrichment import enrich_media, is_unmapped_tvdb_episode
 from core.image_cache import pre_cache_all_collected_bg
 from core.translations import get_user_metadata_language
 from core.rewatch import record_rewatch_progress, get_active_rewatches_for_shows
+from core.watchlist_reconcile import compute_new_baseline, media_key, plan_watchlist_reconcile
 from models.rewatch import ShowRewatch, RewatchProgress
 
 from dependencies import get_current_user, get_current_user_or_api_key
@@ -69,6 +70,11 @@ router = APIRouter()
 # Global semaphore — at most one sync running at a time across all users
 _sync_semaphore = asyncio.Semaphore(1)
 _stremio_push_locks: dict[int, asyncio.Lock] = {}
+# One reconcile at a time per Plex connection - the pull job, the scheduled
+# push and manual pushes all run independently and share no other lock.
+_plex_watchlist_locks: dict[int, asyncio.Lock] = {}
+
+_PLEX_WATCHLIST_SLUG = "__plex_watchlist__"
 
 BATCH_SIZE = 500
 TMDB_CONCURRENCY = 5  # Max concurrent TMDB requests
@@ -2816,6 +2822,287 @@ async def run_plex_sync(user_id: int, job_id: int, movie_limit: int, show_limit:
         await _run_plex_sync(user_id, job_id, movie_limit, show_limit, connection_id)
 
 
+def _plex_watchlist_lock(connection_id: int) -> asyncio.Lock:
+    return _plex_watchlist_locks.setdefault(connection_id, asyncio.Lock())
+
+
+def _plex_watchlist_remote_map(remote_items: list[dict]) -> dict[str, dict]:
+    """Typed key -> raw watchlist item for every remote entry with a TMDB
+    guid. Entries without one can't match anything local, so they stay out
+    of the reconcile entirely."""
+    remote_by_key: dict[str, dict] = {}
+    for item in remote_items:
+        kind = item.get("type")
+        if kind not in ("movie", "show"):
+            continue
+        tmdb_id: int | None = None
+        for guid in item.get("Guid") or []:
+            gid = guid.get("id", "")
+            if gid.startswith("tmdb://"):
+                try:
+                    tmdb_id = int(gid[7:])
+                except ValueError:
+                    pass
+        if tmdb_id is None:
+            continue
+        remote_by_key.setdefault(media_key(kind, tmdb_id), item)
+    return remote_by_key
+
+
+async def _load_local_watchlist_state(db: AsyncSession, user_id: int):
+    """The managed list row (or None) plus typed key -> (media_id, title)
+    for its TMDB-mapped movies and shows."""
+    from models.lists import List as ListModel, ListItem
+
+    wl_result = await db.execute(
+        select(ListModel).where(
+            ListModel.user_id == user_id,
+            ListModel.trakt_slug == _PLEX_WATCHLIST_SLUG,
+        )
+    )
+    watchlist = wl_result.scalar_one_or_none()
+    local_by_key: dict[str, tuple[int, str]] = {}
+    if watchlist:
+        rows = await db.execute(
+            select(Media.id, Media.media_type, Media.tmdb_id, Media.title)
+            .join(ListItem, ListItem.media_id == Media.id)
+            .where(ListItem.list_id == watchlist.id)
+        )
+        for media_id, media_type, tmdb_id, title in rows:
+            if tmdb_id is None:
+                continue
+            if media_type == MediaType.movie:
+                kind = "movie"
+            elif media_type == MediaType.series:
+                kind = "show"
+            else:
+                continue
+            local_by_key[media_key(kind, tmdb_id)] = (media_id, title)
+    return watchlist, local_by_key
+
+
+async def _apply_local_watchlist_changes(
+    db: AsyncSession,
+    user_id: int,
+    watchlist,
+    local_by_key: dict[str, tuple[int, str]],
+    plan,
+    remote_by_key: dict[str, dict],
+    tmdb_api_key: str | None,
+) -> set[str]:
+    """Apply the plan's local side. Returns the keys actually present
+    afterwards: an import that failed stays out, so the baseline never
+    records state that doesn't exist."""
+    from models.lists import List as ListModel, ListItem
+
+    applied = set(local_by_key)
+
+    if plan.add_local and not tmdb_api_key:
+        print("  Warning: skipping Plex watchlist imports - no TMDB API key configured")
+    elif plan.add_local:
+        if not watchlist:
+            watchlist = ListModel(user_id=user_id, name="Plex - Watchlist", trakt_slug=_PLEX_WATCHLIST_SLUG)
+            db.add(watchlist)
+            await db.flush()
+        for key in sorted(plan.add_local):
+            item = remote_by_key.get(key, {})
+            kind, _, raw_id = key.partition(":")
+            tmdb_id_item = int(raw_id)
+            try:
+                if kind == "movie":
+                    media_result = await db.execute(
+                        select(Media).where(Media.tmdb_id == tmdb_id_item, Media.media_type == MediaType.movie)
+                    )
+                    media = media_result.scalar_one_or_none()
+                    if not media:
+                        d = await tmdb.get_movie(tmdb_id_item, api_key=tmdb_api_key)
+                        media = Media(
+                            tmdb_id=tmdb_id_item,
+                            media_type=MediaType.movie,
+                            title=d.get("title") or item.get("title", ""),
+                            poster_path=tmdb.poster_url(d.get("poster_path")),
+                            backdrop_path=tmdb.poster_url(d.get("backdrop_path"), size="w1280"),
+                            release_date=d.get("release_date"),
+                            tmdb_rating=d.get("vote_average"),
+                            overview=d.get("overview"),
+                            adult=d.get("adult", False),
+                        )
+                        db.add(media)
+                        await db.flush()
+                else:
+                    media_result = await db.execute(
+                        select(Media).where(Media.tmdb_id == tmdb_id_item, Media.media_type == MediaType.series)
+                    )
+                    media = media_result.scalar_one_or_none()
+                    if not media:
+                        d = await tmdb.get_show(tmdb_id_item, api_key=tmdb_api_key)
+                        media = Media(
+                            tmdb_id=tmdb_id_item,
+                            media_type=MediaType.series,
+                            title=d.get("name") or item.get("title", ""),
+                            poster_path=tmdb.poster_url(d.get("poster_path")),
+                            backdrop_path=tmdb.poster_url(d.get("backdrop_path"), size="w1280"),
+                            release_date=d.get("first_air_date"),
+                            tmdb_rating=d.get("vote_average"),
+                            overview=d.get("overview"),
+                            adult=d.get("adult", False),
+                        )
+                        db.add(media)
+                        await db.flush()
+
+                # Idempotent against a concurrent add from the lists UI, which
+                # doesn't hold this connection's reconcile lock.
+                await db.execute(
+                    insert(ListItem)
+                    .values(list_id=watchlist.id, media_id=media.id)
+                    .on_conflict_do_nothing(constraint="uq_list_item")
+                )
+                applied.add(key)
+            except Exception as exc:
+                print(f"  Warning: failed to import Plex watchlist item {key}: {exc}")
+
+    if plan.remove_local and watchlist:
+        remove_ids = [local_by_key[key][0] for key in plan.remove_local if key in local_by_key]
+        if remove_ids:
+            await db.execute(
+                ListItem.__table__.delete().where(
+                    ListItem.list_id == watchlist.id,
+                    ListItem.media_id.in_(remove_ids),
+                )
+            )
+        applied -= set(plan.remove_local)
+
+    return applied
+
+
+async def _apply_remote_watchlist_changes(
+    conn,
+    plan,
+    local_by_key: dict[str, tuple[int, str]],
+    remote_by_key: dict[str, dict],
+) -> tuple[set[str], set[str]]:
+    """Push the plan's remote side to Plex. Failed keys are reported back so
+    the baseline keeps them pending and the next reconcile retries them."""
+    failed_add: set[str] = set()
+    failed_remove: set[str] = set()
+
+    for key in sorted(plan.push_add):
+        kind, _, raw_id = key.partition(":")
+        _, title = local_by_key.get(key, (None, None))
+        plex_type = "movie" if kind == "movie" else "show"
+        try:
+            rating_key = await plex.resolve_tmdb_ratingkey(conn.token, int(raw_id), plex_type, title)
+            if not rating_key:
+                logger.warning(
+                    "Could not resolve Plex ratingKey for %s (connection %s); will retry on the next reconcile",
+                    key, conn.id,
+                )
+                failed_add.add(key)
+                continue
+            if not await plex.add_to_watchlist(conn.token, rating_key):
+                failed_add.add(key)
+        except Exception as exc:
+            logger.warning("Plex watchlist add failed for %s (connection %s): %s", key, conn.id, exc)
+            failed_add.add(key)
+
+    for key in sorted(plan.push_remove):
+        # push_remove keys are on the remote by definition, so the fetched
+        # item usually carries its own ratingKey; resolving is the fallback.
+        item = remote_by_key.get(key) or {}
+        rating_key = item.get("ratingKey")
+        try:
+            if not rating_key:
+                kind, _, raw_id = key.partition(":")
+                plex_type = "movie" if kind == "movie" else "show"
+                rating_key = await plex.resolve_tmdb_ratingkey(conn.token, int(raw_id), plex_type, item.get("title"))
+            if not rating_key or not await plex.remove_from_watchlist(conn.token, rating_key):
+                failed_remove.add(key)
+        except Exception as exc:
+            logger.warning("Plex watchlist remove failed for %s (connection %s): %s", key, conn.id, exc)
+            failed_remove.add(key)
+
+    return failed_add, failed_remove
+
+
+async def _reconcile_plex_watchlist(db: AsyncSession, user_id: int, conn, tmdb_api_key: str | None) -> None:
+    """Reconcile the Plex account watchlist with the managed Scrob list in
+    both directions, against this connection's last-synced baseline (see
+    core/watchlist_reconcile.py for the semantics).
+
+    The pull job and the full push job both call this, and it honors both
+    direction flags itself, so it doesn't matter which job runs first.
+    Never raises: failures log a warning and leave the baseline alone so
+    the next run retries."""
+    pull_enabled = bool(conn.plex_sync_watchlist)
+    push_enabled = bool(conn.plex_push_watchlist)
+    if not (pull_enabled or push_enabled):
+        return
+
+    async with _plex_watchlist_lock(conn.id):
+        try:
+            # A concurrent job may have reconciled while we waited on the
+            # lock, and conn was loaded well before it. Re-read the baseline.
+            baseline_result = await db.execute(
+                select(MediaServerConnection.plex_watchlist_synced_keys).where(
+                    MediaServerConnection.id == conn.id
+                )
+            )
+            baseline = baseline_result.scalar_one_or_none()
+
+            print(f"  Fetching Plex watchlist...")
+            remote_items = await plex.get_watchlist(conn.token)
+            print(f"  {len(remote_items)} items in Plex watchlist")
+            remote_by_key = _plex_watchlist_remote_map(remote_items)
+
+            watchlist, local_by_key = await _load_local_watchlist_state(db, user_id)
+            if watchlist is None and baseline is not None:
+                # The managed list was deleted in the UI. Without this reset,
+                # every baseline key would read as a local deletion and wipe
+                # the user's real Plex watchlist. Start over instead.
+                baseline = None
+
+            plan = plan_watchlist_reconcile(
+                local_by_key.keys(),
+                remote_by_key.keys(),
+                baseline,
+                pull_enabled=pull_enabled,
+                push_enabled=push_enabled,
+            )
+            if plan.suppressed:
+                logger.warning(
+                    "Plex watchlist reconcile suppressed for connection %s: %s. Not acting on a fetch "
+                    "that may be truncated. If the removals are real, remove the items from the list "
+                    "in Scrob, or toggle watchlist sync off and on to rebuild from a fresh baseline.",
+                    conn.id, plan.suppressed_reason,
+                )
+                return
+
+            applied_local = await _apply_local_watchlist_changes(
+                db, user_id, watchlist, local_by_key, plan, remote_by_key, tmdb_api_key
+            )
+            failed_add, failed_remove = await _apply_remote_watchlist_changes(
+                conn, plan, local_by_key, remote_by_key
+            )
+
+            new_baseline = compute_new_baseline(
+                applied_local, failed_push_add=failed_add, failed_push_remove=failed_remove
+            )
+            await db.execute(
+                update(MediaServerConnection)
+                .where(MediaServerConnection.id == conn.id)
+                .values(plex_watchlist_synced_keys=new_baseline)
+            )
+            await db.commit()
+            print(
+                f"  Plex watchlist reconcile complete: "
+                f"+{len(plan.add_local)}/-{len(plan.remove_local)} local, "
+                f"+{len(plan.push_add) - len(failed_add)}/-{len(plan.push_remove) - len(failed_remove)} on Plex"
+            )
+        except Exception as exc:
+            print(f"  Warning: Plex watchlist reconcile failed: {exc}")
+            await db.rollback()
+
+
 async def _run_plex_sync(user_id: int, job_id: int, movie_limit: int, show_limit: int, connection_id: int | None = None):
     print(f"Starting Plex sync for user {user_id}, job {job_id}")
     async_session = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
@@ -3105,128 +3392,9 @@ async def _run_plex_sync(user_id: int, job_id: int, movie_limit: int, show_limit
                         )
                         all_warnings.extend(w)
 
-            # ── Plex watchlist → Scrob list ──────────────────────────────────
+            # ── Plex watchlist ↔ Scrob list ──────────────────────────────────
             if conn.plex_sync_watchlist:
-                from models.lists import List as ListModel, ListItem
-                PLEX_WATCHLIST_SLUG = "__plex_watchlist__"
-                print(f"  Fetching Plex watchlist...")
-                try:
-                    wl_items = await plex.get_watchlist(p_token)
-                    print(f"  {len(wl_items)} items in Plex watchlist")
-
-                    wl_result = await db.execute(
-                        select(ListModel).where(
-                            ListModel.user_id == user_id,
-                            ListModel.trakt_slug == PLEX_WATCHLIST_SLUG,
-                        )
-                    )
-                    watchlist = wl_result.scalar_one_or_none()
-                    if not watchlist:
-                        watchlist = ListModel(user_id=user_id, name="Plex - Watchlist", trakt_slug=PLEX_WATCHLIST_SLUG)
-                        db.add(watchlist)
-                        await db.flush()
-
-                    existing_result = await db.execute(
-                        select(ListItem.media_id).where(ListItem.list_id == watchlist.id)
-                    )
-                    wl_existing_ids: set[int] = {row[0] for row in existing_result}
-
-                    # Build set of TMDB IDs currently on Plex watchlist
-                    plex_tmdb_ids: set[int] = set()
-                    for item in wl_items:
-                        for guid in item.get("Guid", []):
-                            gid = guid.get("id", "")
-                            if gid.startswith("tmdb://"):
-                                try:
-                                    plex_tmdb_ids.add(int(gid[7:]))
-                                except ValueError:
-                                    pass
-
-                    # Remove items no longer on Plex watchlist
-                    if wl_existing_ids:
-                        stale_result = await db.execute(
-                            select(Media).where(
-                                Media.id.in_(wl_existing_ids),
-                                Media.tmdb_id.notin_(plex_tmdb_ids) if plex_tmdb_ids else Media.tmdb_id.isnot(None),
-                            )
-                        )
-                        for stale in stale_result.scalars():
-                            await db.execute(
-                                ListItem.__table__.delete().where(
-                                    ListItem.list_id == watchlist.id,
-                                    ListItem.media_id == stale.id,
-                                )
-                            )
-                            wl_existing_ids.discard(stale.id)
-
-                    # Add new items
-                    for item in wl_items:
-                        item_type = item.get("type")  # "movie" or "show"
-                        tmdb_id_item: int | None = None
-                        for guid in item.get("Guid", []):
-                            gid = guid.get("id", "")
-                            if gid.startswith("tmdb://"):
-                                try:
-                                    tmdb_id_item = int(gid[7:])
-                                except ValueError:
-                                    pass
-                        if not tmdb_id_item:
-                            continue
-                        try:
-                            if item_type == "movie":
-                                media_result = await db.execute(
-                                    select(Media).where(Media.tmdb_id == tmdb_id_item, Media.media_type == MediaType.movie)
-                                )
-                                media = media_result.scalar_one_or_none()
-                                if not media:
-                                    d = await tmdb.get_movie(tmdb_id_item, api_key=tmdb_api_key)
-                                    media = Media(
-                                        tmdb_id=tmdb_id_item,
-                                        media_type=MediaType.movie,
-                                        title=d.get("title") or item.get("title", ""),
-                                        poster_path=tmdb.poster_url(d.get("poster_path")),
-                                        backdrop_path=tmdb.poster_url(d.get("backdrop_path"), size="w1280"),
-                                        release_date=d.get("release_date"),
-                                        tmdb_rating=d.get("vote_average"),
-                                        overview=d.get("overview"),
-                                        adult=d.get("adult", False),
-                                    )
-                                    db.add(media)
-                                    await db.flush()
-                            elif item_type == "show":
-                                media_result = await db.execute(
-                                    select(Media).where(Media.tmdb_id == tmdb_id_item, Media.media_type == MediaType.series)
-                                )
-                                media = media_result.scalar_one_or_none()
-                                if not media:
-                                    d = await tmdb.get_show(tmdb_id_item, api_key=tmdb_api_key)
-                                    media = Media(
-                                        tmdb_id=tmdb_id_item,
-                                        media_type=MediaType.series,
-                                        title=d.get("name") or item.get("title", ""),
-                                        poster_path=tmdb.poster_url(d.get("poster_path")),
-                                        backdrop_path=tmdb.poster_url(d.get("backdrop_path"), size="w1280"),
-                                        release_date=d.get("first_air_date"),
-                                        tmdb_rating=d.get("vote_average"),
-                                        overview=d.get("overview"),
-                                        adult=d.get("adult", False),
-                                    )
-                                    db.add(media)
-                                    await db.flush()
-                            else:
-                                continue
-
-                            if media and media.id not in wl_existing_ids:
-                                db.add(ListItem(list_id=watchlist.id, media_id=media.id))
-                                wl_existing_ids.add(media.id)
-                        except Exception as exc:
-                            print(f"  Warning: failed to sync Plex watchlist item tmdb={tmdb_id_item}: {exc}")
-
-                    await db.commit()
-                    print(f"  Plex watchlist sync complete.")
-                except Exception as exc:
-                    print(f"  Warning: Plex watchlist sync failed: {exc}")
-                    await db.rollback()
+                await _reconcile_plex_watchlist(db, user_id, conn, tmdb_api_key)
 
             backfilled = await _backfill_plex_languages(user_id, conn.id, p_url, p_token, job_id)
             if backfilled:
@@ -3254,6 +3422,9 @@ async def _run_plex_sync(user_id: int, job_id: int, movie_limit: int, show_limit
             print(f"Plex sync job {job_id} completed. Stats: {stats}")
             # A pull only populates scrob's own data — it never automatically pushes to
             # other connections; users push explicitly per-service (the "Push" buttons).
+            # The watchlist reconcile above is the one exception: it honors this
+            # connection's own plex_push_watchlist flag in both jobs, so pull/push
+            # scheduling order can't resurrect items removed on the other side.
             all_warnings = await _stamp_matched_show_warnings(db, user_id, all_warnings)
             await db.execute(update(SyncJob).where(SyncJob.id == job_id).values(status=SyncStatus.completed, stats=stats, warnings=all_warnings or None, updated_at=func.now()))
             await db.commit()
@@ -5147,66 +5318,13 @@ async def _run_full_push(user_id: int, connection_id: int, job_id: int) -> None:
             conn_source = CollectionSource(conn.type)
 
             if conn.type == "plex" and conn.plex_push_watchlist:
-                from models.lists import List as ListModel, ListItem
-                PLEX_WATCHLIST_SLUG = "__plex_watchlist__"
-                try:
-                    watchlist_result = await db.execute(
-                        select(ListModel).where(
-                            ListModel.user_id == user_id,
-                            ListModel.trakt_slug == PLEX_WATCHLIST_SLUG,
-                        )
-                    )
-                    watchlist = watchlist_result.scalar_one_or_none()
-                    local_watchlist_items: list[Media] = []
-                    if watchlist:
-                        local_items_result = await db.execute(
-                            select(Media)
-                            .join(ListItem, ListItem.media_id == Media.id)
-                            .where(
-                                ListItem.list_id == watchlist.id,
-                                Media.tmdb_id.isnot(None),
-                                Media.media_type.in_([MediaType.movie, MediaType.series]),
-                            )
-                        )
-                        local_watchlist_items = list(local_items_result.scalars().all())
-
-                    watchlist_pushed = 0
-                    if local_watchlist_items:
-                        # Additive only: a full push only knows the current local
-                        # watchlist list, not what changed since last time, so it
-                        # must never remove items from the user's real Plex
-                        # watchlist — only the explicit add/remove action on the
-                        # local list (_push_list_item_to_plex_watchlist) does that.
-                        remote_items = await plex.get_watchlist(conn.token)
-                        remote_tmdb_ids: set[int] = set()
-                        for item in remote_items:
-                            for guid in item.get("Guid", []) or []:
-                                gid = guid.get("id", "")
-                                if gid.startswith("tmdb://"):
-                                    try:
-                                        remote_tmdb_ids.add(int(gid[7:]))
-                                    except ValueError:
-                                        pass
-                        for media in local_watchlist_items:
-                            if media.tmdb_id in remote_tmdb_ids:
-                                continue
-                            plex_type = "movie" if media.media_type == MediaType.movie else "show"
-                            rating_key = await plex.resolve_tmdb_ratingkey(conn.token, media.tmdb_id, plex_type, media.title)
-                            if not rating_key:
-                                logger.warning(
-                                    "Full push: could not resolve Plex ratingKey for tmdb_id=%s (%s), connection %s",
-                                    media.tmdb_id, plex_type, connection_id,
-                                )
-                                continue
-                            if await plex.add_to_watchlist(conn.token, rating_key):
-                                watchlist_pushed += 1
-                    logger.info(
-                        "Full push for connection %s: pushed %s item(s) to Plex watchlist",
-                        connection_id,
-                        watchlist_pushed,
-                    )
-                except Exception as exc:
-                    logger.warning("Full push: Plex watchlist push failed for connection %s: %s", connection_id, exc)
+                # The reconcile can import remote-only items when the pull
+                # direction is also enabled, so it needs a TMDB key here too.
+                wl_settings_result = await db.execute(
+                    select(UserSettings).where(UserSettings.user_id == user_id)
+                )
+                wl_tmdb_key = await _get_effective_tmdb_key(db, wl_settings_result.scalar_one_or_none())
+                await _reconcile_plex_watchlist(db, user_id, conn, wl_tmdb_key)
 
             watched_ids: set[int] = set()
             ratings_map: RatingChanges = {}
@@ -5479,13 +5597,7 @@ async def push_upstream(
     current_user: User = Depends(get_current_user),
 ):
     conn = await _get_connection_or_404(db, connection_id, current_user.id)
-    if not (
-        conn.push_collection
-        or conn.push_watched
-        or conn.push_ratings
-        or conn.push_playback
-        or conn.plex_push_watchlist
-    ):
+    if not conn.push_enabled:
         raise HTTPException(
             status_code=400,
             detail="Enable 'Scrob → Server' push flags for this connection first",

--- a/backend/tests/test_sync.py
+++ b/backend/tests/test_sync.py
@@ -485,5 +485,199 @@ class ExpandMultiEpisodeItemsTests(unittest.TestCase):
         self.assertEqual(expanded, [item])
 
 
+from sqlalchemy.sql import Select as _SASelect
+from sqlalchemy.dialects import postgresql as _pg
+
+
+class _ReconcileFakeDB:
+    """Serves only what _reconcile_plex_watchlist itself executes: the
+    baseline re-read (SELECT) and the baseline write (UPDATE). Everything
+    heavier sits behind the patched load/apply helpers."""
+
+    def __init__(self, baseline):
+        self._baseline = baseline
+        self.baseline_writes = []
+        self.commit = AsyncMock()
+        self.rollback = AsyncMock()
+
+    async def execute(self, stmt):
+        if isinstance(stmt, _SASelect):
+            return _Result(self._baseline)
+        params = stmt.compile(dialect=_pg.dialect()).params
+        self.baseline_writes.append(params.get("plex_watchlist_synced_keys"))
+        return SimpleNamespace()
+
+
+def _wl_conn(pull=True, push=True):
+    return MediaServerConnection(
+        id=1, user_id=1, type="plex", token="tok",
+        plex_sync_watchlist=pull, plex_push_watchlist=push,
+    )
+
+
+def _remote_item(kind, tmdb_id, rating_key="rk", title="Title"):
+    return {"type": kind, "Guid": [{"id": f"tmdb://{tmdb_id}"}], "ratingKey": rating_key, "title": title}
+
+
+class PlexWatchlistReconcileTests(unittest.IsolatedAsyncioTestCase):
+    """The routine wiring around core.watchlist_reconcile: what plan reaches
+    the apply helpers, and what baseline gets persisted."""
+
+    async def _run(self, db, conn, remote_items, local_state, applied_local, remote_failures=(set(), set())):
+        apply_local = AsyncMock(return_value=applied_local)
+        apply_remote = AsyncMock(return_value=remote_failures)
+        with patch.object(sync.plex, "get_watchlist", AsyncMock(return_value=remote_items)), \
+             patch.object(sync, "_load_local_watchlist_state", AsyncMock(return_value=local_state)), \
+             patch.object(sync, "_apply_local_watchlist_changes", apply_local), \
+             patch.object(sync, "_apply_remote_watchlist_changes", apply_remote):
+            await sync._reconcile_plex_watchlist(db, 1, conn, "tmdb-key")
+        local_plan = apply_local.call_args.args[4] if apply_local.call_args else None
+        remote_plan = apply_remote.call_args.args[1] if apply_remote.call_args else None
+        return local_plan, remote_plan, apply_local, apply_remote
+
+    async def test_remote_removal_is_applied_locally_not_resurrected(self):
+        """Regression: Plex auto-removed a watched item; the old additive push
+        re-added it. Now the baseline turns it into a local removal."""
+        db = _ReconcileFakeDB(["movie:1"])
+        local_plan, remote_plan, _, _ = await self._run(
+            db, _wl_conn(), [], (SimpleNamespace(id=5), {"movie:1": (11, "Inception")}), applied_local=set(),
+        )
+        self.assertEqual(local_plan.remove_local, {"movie:1"})
+        self.assertEqual(remote_plan.push_add, frozenset())
+        self.assertEqual(db.baseline_writes, [[]])
+        db.commit.assert_awaited()
+
+    async def test_deleted_managed_list_resets_baseline_instead_of_wiping_plex(self):
+        """Regression: with the list deleted in the UI, a stale baseline must
+        not turn the entire real Plex watchlist into push_remove calls."""
+        db = _ReconcileFakeDB(["movie:1", "show:2"])
+        remote = [_remote_item("movie", 1), _remote_item("show", 2)]
+        local_plan, remote_plan, _, _ = await self._run(
+            db, _wl_conn(), remote, (None, {}), applied_local={"movie:1", "show:2"},
+        )
+        self.assertEqual(remote_plan.push_remove, frozenset())
+        self.assertEqual(local_plan.add_local, {"movie:1", "show:2"})  # bootstrap re-import
+        self.assertEqual(db.baseline_writes, [["movie:1", "show:2"]])
+
+    async def test_bootstrap_first_contact_is_purely_additive(self):
+        db = _ReconcileFakeDB(None)
+        local_plan, remote_plan, _, _ = await self._run(
+            db, _wl_conn(), [_remote_item("show", 2)],
+            (SimpleNamespace(id=5), {"movie:1": (11, "Inception")}),
+            applied_local={"movie:1", "show:2"},
+        )
+        self.assertEqual(remote_plan.push_add, {"movie:1"})
+        self.assertEqual(local_plan.add_local, {"show:2"})
+        self.assertEqual(local_plan.remove_local, frozenset())
+        self.assertEqual(db.baseline_writes, [["movie:1", "show:2"]])
+
+    async def test_failed_remote_add_stays_out_of_the_baseline(self):
+        db = _ReconcileFakeDB(["movie:1"])
+        _, remote_plan, _, _ = await self._run(
+            db, _wl_conn(), [_remote_item("movie", 1)],
+            (SimpleNamespace(id=5), {"movie:1": (11, "A"), "movie:9": (12, "B")}),
+            applied_local={"movie:1", "movie:9"},
+            remote_failures=({"movie:9"}, set()),
+        )
+        self.assertEqual(remote_plan.push_add, {"movie:9"})
+        self.assertEqual(db.baseline_writes, [["movie:1"]])  # movie:9 retries next run
+
+    async def test_suppressed_run_changes_nothing(self):
+        baseline = [f"movie:{i}" for i in range(12)]
+        db = _ReconcileFakeDB(baseline)
+        local = {key: (i, "T") for i, key in enumerate(baseline)}
+        _, _, apply_local, apply_remote = await self._run(
+            db, _wl_conn(), [], (SimpleNamespace(id=5), local), applied_local=set(),
+        )
+        apply_local.assert_not_called()
+        apply_remote.assert_not_called()
+        self.assertEqual(db.baseline_writes, [])
+        db.commit.assert_not_awaited()
+
+    async def test_fetch_failure_is_swallowed_and_rolled_back(self):
+        db = _ReconcileFakeDB(["movie:1"])
+        with patch.object(sync.plex, "get_watchlist", AsyncMock(side_effect=RuntimeError("plex down"))):
+            await sync._reconcile_plex_watchlist(db, 1, _wl_conn(), "tmdb-key")
+        db.rollback.assert_awaited()
+        self.assertEqual(db.baseline_writes, [])
+
+    async def test_disabled_flags_do_nothing(self):
+        db = _ReconcileFakeDB(["movie:1"])
+        fetch = AsyncMock()
+        with patch.object(sync.plex, "get_watchlist", fetch):
+            await sync._reconcile_plex_watchlist(db, 1, _wl_conn(pull=False, push=False), "tmdb-key")
+        fetch.assert_not_called()
+
+
+class PushEnabledPropertyTests(unittest.TestCase):
+    """The scheduler's auto-push gate and the manual push endpoint share this
+    property, so a watchlist-only connection can't be forgotten by one of
+    them again."""
+
+    def test_watchlist_only_connection_is_push_enabled(self):
+        conn = MediaServerConnection(
+            push_collection=False, push_watched=False, push_ratings=False, push_playback=False,
+            plex_push_watchlist=True,
+        )
+        self.assertTrue(conn.push_enabled)
+
+    def test_no_push_flags_at_all(self):
+        conn = MediaServerConnection(
+            push_collection=False, push_watched=False, push_ratings=False, push_playback=False,
+            plex_push_watchlist=False,
+        )
+        self.assertFalse(conn.push_enabled)
+
+    def test_classic_push_flags_still_count(self):
+        conn = MediaServerConnection(
+            push_collection=False, push_watched=True, push_ratings=False, push_playback=False,
+            plex_push_watchlist=False,
+        )
+        self.assertTrue(conn.push_enabled)
+
+
+class ConnectionUpdateBaselineResetTests(unittest.IsolatedAsyncioTestCase):
+    """Flipping a watchlist direction off→on must restart from a clean
+    bootstrap - a baseline recorded under the old settings must not drive
+    deletions."""
+
+    async def _patch_connection(self, conn, **body_fields):
+        import schemas
+        from routers import auth as auth_router
+
+        db = _FakeSession(conn)
+        body = schemas.MediaServerConnectionUpdate(**body_fields)
+        return await auth_router.update_connection(
+            connection_id=1, body=body, db=db, current_user=SimpleNamespace(id=1),
+        )
+
+    def _conn(self, sync_on=False, push_on=False):
+        return MediaServerConnection(
+            id=1, user_id=1, type="plex", name="Plex", url="http://p", token="t",
+            plex_sync_watchlist=sync_on, plex_push_watchlist=push_on,
+            plex_watchlist_synced_keys=["movie:1"],
+        )
+
+    async def test_enabling_pull_resets_the_baseline(self):
+        conn = self._conn()
+        await self._patch_connection(conn, plex_sync_watchlist=True)
+        self.assertIsNone(conn.plex_watchlist_synced_keys)
+
+    async def test_enabling_push_resets_the_baseline(self):
+        conn = self._conn()
+        await self._patch_connection(conn, plex_push_watchlist=True)
+        self.assertIsNone(conn.plex_watchlist_synced_keys)
+
+    async def test_updating_while_already_enabled_keeps_the_baseline(self):
+        conn = self._conn(sync_on=True)
+        await self._patch_connection(conn, plex_sync_watchlist=True)
+        self.assertEqual(conn.plex_watchlist_synced_keys, ["movie:1"])
+
+    async def test_disabling_keeps_the_baseline(self):
+        conn = self._conn(sync_on=True)
+        await self._patch_connection(conn, plex_sync_watchlist=False)
+        self.assertEqual(conn.plex_watchlist_synced_keys, ["movie:1"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/backend/tests/test_watchlist_reconcile.py
+++ b/backend/tests/test_watchlist_reconcile.py
@@ -1,0 +1,225 @@
+import unittest
+
+from core.watchlist_reconcile import (
+    SUPPRESS_MIN_BASELINE,
+    compute_new_baseline,
+    media_key,
+    plan_watchlist_reconcile,
+)
+
+
+def _plan(local, remote, baseline, pull=True, push=True):
+    return plan_watchlist_reconcile(local, remote, baseline, pull_enabled=pull, push_enabled=push)
+
+
+class MediaKeyTests(unittest.TestCase):
+    def test_typed_keys_distinguish_movie_and_show_with_same_tmdb_id(self):
+        self.assertNotEqual(media_key("movie", 603), media_key("show", 603))
+        self.assertEqual(media_key("movie", 603), "movie:603")
+
+
+class TruthTableBothDirectionsTests(unittest.TestCase):
+    """Every (local, remote, baseline) membership state with both flags on."""
+
+    def test_in_sync_key_produces_no_action(self):
+        plan = _plan({"movie:1"}, {"movie:1"}, ["movie:1"])
+        self.assertFalse(plan.has_changes)
+        self.assertFalse(plan.suppressed)
+
+    def test_locally_added_key_is_pushed(self):
+        plan = _plan({"movie:1"}, set(), [])
+        self.assertEqual(plan.push_add, {"movie:1"})
+        self.assertEqual(plan.remove_local, frozenset())
+
+    def test_remotely_added_key_is_imported(self):
+        plan = _plan(set(), {"movie:1"}, [])
+        self.assertEqual(plan.add_local, {"movie:1"})
+
+    def test_remotely_deleted_key_is_removed_locally_not_resurrected(self):
+        # The headline fix: Plex auto-removed a watched item; the old additive
+        # push re-added it. The baseline proves it was synced before, so the
+        # only correct action is the local removal.
+        plan = _plan({"movie:1"}, set(), ["movie:1"])
+        self.assertEqual(plan.remove_local, {"movie:1"})
+        self.assertEqual(plan.push_add, frozenset())
+
+    def test_locally_deleted_key_is_removed_remotely(self):
+        plan = _plan(set(), {"movie:1"}, ["movie:1"])
+        self.assertEqual(plan.push_remove, {"movie:1"})
+        self.assertEqual(plan.add_local, frozenset())
+
+    def test_key_deleted_on_both_sides_just_leaves_the_baseline(self):
+        plan = _plan(set(), set(), ["movie:1"])
+        self.assertFalse(plan.has_changes)
+
+    def test_key_added_on_both_sides_is_simply_in_sync(self):
+        plan = _plan({"movie:1"}, {"movie:1"}, [])
+        self.assertFalse(plan.has_changes)
+
+
+class PullOnlyModeTests(unittest.TestCase):
+    """Pull-only stays a plain mirror of the remote, as it always was."""
+
+    def test_local_extra_is_removed_even_without_baseline_entry(self):
+        plan = _plan({"movie:1"}, set(), [], push=False)
+        self.assertEqual(plan.remove_local, {"movie:1"})
+        self.assertEqual(plan.push_add, frozenset())
+
+    def test_locally_deleted_key_is_readded_immediately(self):
+        # No push direction to propagate the local deletion, so the mirror
+        # re-adds in the same run rather than flapping over two runs.
+        plan = _plan(set(), {"movie:1"}, ["movie:1"], push=False)
+        self.assertEqual(plan.add_local, {"movie:1"})
+        self.assertEqual(plan.push_remove, frozenset())
+
+    def test_never_pushes(self):
+        plan = _plan({"movie:1", "movie:2"}, {"movie:3"}, ["movie:2"], push=False)
+        self.assertEqual(plan.push_add, frozenset())
+        self.assertEqual(plan.push_remove, frozenset())
+
+
+class PushOnlyModeTests(unittest.TestCase):
+    """Push-only keeps Scrob as the master, as it always was."""
+
+    def test_remote_deletion_of_synced_key_is_readded(self):
+        plan = _plan({"movie:1"}, set(), ["movie:1"], pull=False)
+        self.assertEqual(plan.push_add, {"movie:1"})
+        self.assertEqual(plan.remove_local, frozenset())
+
+    def test_remote_only_key_is_ignored(self):
+        plan = _plan(set(), {"movie:1"}, [], pull=False)
+        self.assertFalse(plan.has_changes)
+
+    def test_locally_deleted_key_is_removed_remotely(self):
+        plan = _plan(set(), {"movie:1"}, ["movie:1"], pull=False)
+        self.assertEqual(plan.push_remove, {"movie:1"})
+
+    def test_never_touches_local_state(self):
+        plan = _plan({"movie:1"}, {"movie:2", "movie:3"}, ["movie:3"], pull=False)
+        self.assertEqual(plan.add_local, frozenset())
+        self.assertEqual(plan.remove_local, frozenset())
+
+
+class BootstrapTests(unittest.TestCase):
+    def test_none_baseline_never_infers_deletions(self):
+        plan = _plan({"movie:1"}, {"show:2"}, None)
+        self.assertEqual(plan.push_add, {"movie:1"})
+        self.assertEqual(plan.add_local, {"show:2"})
+        self.assertEqual(plan.remove_local, frozenset())
+        self.assertEqual(plan.push_remove, frozenset())
+
+    def test_none_baseline_is_not_the_same_as_empty_baseline(self):
+        # An empty baseline means a reconcile happened and everything was
+        # cleared, so deletions may be inferred. None means no reconcile has
+        # ever happened, so they may not.
+        with_none = _plan({"movie:1"}, set(), None, push=False)
+        with_empty = _plan({"movie:1"}, set(), [], push=False)
+        self.assertEqual(with_none.remove_local, frozenset())
+        self.assertEqual(with_empty.remove_local, {"movie:1"})
+
+    def test_none_baseline_respects_direction_flags(self):
+        pull_only = _plan({"movie:1"}, {"show:2"}, None, push=False)
+        self.assertEqual(pull_only.push_add, frozenset())
+        push_only = _plan({"movie:1"}, {"show:2"}, None, pull=False)
+        self.assertEqual(push_only.add_local, frozenset())
+
+
+class CircuitBreakerTests(unittest.TestCase):
+    def _baseline(self, n):
+        return [media_key("movie", i) for i in range(n)]
+
+    def test_small_watchlist_draining_to_empty_reconciles_unconditionally(self):
+        # The canonical trigger: the last watched item auto-removed from a
+        # small watchlist. Below the floor there is no suppression, or the
+        # headline fix would never fire.
+        baseline = self._baseline(SUPPRESS_MIN_BASELINE - 1)
+        plan = _plan(set(baseline), set(), baseline)
+        self.assertFalse(plan.suppressed)
+        self.assertEqual(plan.remove_local, frozenset(baseline))
+
+    def test_empty_remote_with_established_baseline_suppresses_everything(self):
+        baseline = self._baseline(SUPPRESS_MIN_BASELINE)
+        plan = _plan(set(baseline) | {"show:99"}, set(), baseline)
+        self.assertTrue(plan.suppressed)
+        self.assertIsNotNone(plan.suppressed_reason)
+        self.assertFalse(plan.has_changes)  # a suspect fetch drives nothing
+
+    def test_majority_shrink_suppresses(self):
+        baseline = self._baseline(12)
+        remote = set(baseline[:5])  # 7 of 12 would be removed
+        plan = _plan(set(baseline), remote, baseline)
+        self.assertTrue(plan.suppressed)
+
+    def test_minority_shrink_reconciles(self):
+        baseline = self._baseline(12)
+        remote = set(baseline[:7])  # 5 of 12 removed, under half
+        plan = _plan(set(baseline), remote, baseline)
+        self.assertFalse(plan.suppressed)
+        self.assertEqual(plan.remove_local, frozenset(baseline[7:]))
+
+    def test_push_only_mode_never_suppresses(self):
+        # No local deletions can happen, so there is nothing to protect;
+        # re-adding everything is that mode's documented master semantics.
+        baseline = self._baseline(20)
+        plan = _plan(set(baseline), set(), baseline, pull=False)
+        self.assertFalse(plan.suppressed)
+        self.assertEqual(plan.push_add, frozenset(baseline))
+
+
+class NewBaselineTests(unittest.TestCase):
+    def test_reflects_final_local_state(self):
+        self.assertEqual(compute_new_baseline({"movie:2", "movie:1"}), ["movie:1", "movie:2"])
+
+    def test_failed_remote_add_is_excluded_so_it_retries(self):
+        new = compute_new_baseline({"movie:1", "movie:2"}, failed_push_add={"movie:2"})
+        self.assertEqual(new, ["movie:1"])
+
+    def test_failed_remote_remove_is_retained_so_it_retries(self):
+        new = compute_new_baseline({"movie:1"}, failed_push_remove={"movie:3"})
+        self.assertEqual(new, ["movie:1", "movie:3"])
+
+
+class ConvergenceTests(unittest.TestCase):
+    """Two consecutive runs settle; nothing oscillates."""
+
+    def _apply(self, plan, local, remote):
+        local = (set(local) | set(plan.add_local)) - set(plan.remove_local)
+        remote = (set(remote) | set(plan.push_add)) - set(plan.push_remove)
+        return local, remote
+
+    def test_resurrection_scenario_settles_in_one_run(self):
+        local, remote, baseline = {"movie:1"}, set(), ["movie:1"]
+        plan = _plan(local, remote, baseline)
+        local, remote = self._apply(plan, local, remote)
+        baseline = compute_new_baseline(local)
+        self.assertEqual((local, remote, baseline), (set(), set(), []))
+        second = _plan(local, remote, baseline)
+        self.assertFalse(second.has_changes)
+
+    def test_failed_live_push_retries_then_settles(self):
+        # A UI add whose fire-and-forget push failed: locally present,
+        # remotely absent, not in the baseline.
+        local, remote, baseline = {"movie:1"}, set(), []
+        plan = _plan(local, remote, baseline)
+        self.assertEqual(plan.push_add, {"movie:1"})
+        local, remote = self._apply(plan, local, remote)
+        baseline = compute_new_baseline(local)
+        second = _plan(local, remote, baseline)
+        self.assertFalse(second.has_changes)
+
+    def test_failed_remote_remove_retries_then_settles(self):
+        local, remote, baseline = set(), {"movie:1"}, ["movie:1"]
+        plan = _plan(local, remote, baseline)
+        self.assertEqual(plan.push_remove, {"movie:1"})
+        # The remove fails: remote unchanged, key retained in the baseline.
+        baseline = compute_new_baseline(set(), failed_push_remove={"movie:1"})
+        second = _plan(local, remote, baseline)
+        self.assertEqual(second.push_remove, {"movie:1"})  # retried
+        local, remote = self._apply(second, local, remote)
+        baseline = compute_new_baseline(local)
+        third = _plan(local, remote, baseline)
+        self.assertFalse(third.has_changes)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Plex auto-removes watched items from the watchlist, but the full push is additive only and can't tell "removed on Plex" from "not pushed yet". Pull and push run on separate schedules, so a push often lands before the next pull and re-adds the item, permanently. Manual removals on Plex come back the same way, and the reverse is also broken: a local add whose live push failed gets deleted by the next pull instead of retried.

## Fix

Same approach as the Stremio collection push (`stremio_pushed_library_ids`): each connection stores the watchlist keys from its last successful reconcile, and both jobs now run one shared three-way reconcile (local / remote / baseline) instead of the separate mirror and additive blocks. A key that was synced before and is gone from Plex gets removed locally instead of re-added, local removals propagate to Plex, failed calls stay out of the baseline and retry next run. A null baseline (first run after upgrading) never infers deletions, so existing installs just bootstrap. Pull-only and push-only connections behave as before.

Since this adds a deletion path that didn't exist: the collection pruner's circuit breaker is reused (an empty or majority-shrunk fetch against a 10+ item baseline skips the run), deleting the managed list resets the baseline instead of wiping the Plex watchlist, and reconciles take a per-connection lock.

Also fixed along the way: the auto-push scheduler never checked `plex_push_watchlist` (the manual push endpoint did), so watchlist-only connections were never pushed on a schedule.

## Verification

- `python -m unittest discover -s tests` - 365 passed, 43 new
- `alembic heads` - single head, migration is one nullable JSONB column