### PR TITLE
Fix: MDBList push fails entirely with 400 Too many shows in one request (#176)

### DIFF
--- a/backend/core/mdblist.py
+++ b/backend/core/mdblist.py
@@ -9,7 +9,8 @@ import httpx
 
 MDBLIST_BASE = "https://api.mdblist.com"
 PAGE_SIZE = 1000
-PUSH_BATCH_SIZE = 500
+# MDBList rejects more than 200 shows per sync request.
+PUSH_BATCH_SIZE = 200
 
 
 class MDBListAPIError(RuntimeError):


### PR DESCRIPTION
Fixes #176.

PUSH_BATCH_SIZE was 500 while MDBList rejects sync requests with more than 200 shows, so any push with 201-500 shows in one batch got a 400 and the whole job failed. The batching machinery already exists - only the size was wrong.