### PR TITLE
Feature: show remaining episodes and estimated runtime in Next Up (#170)

### DIFF
--- a/backend/routers/history.py
+++ b/backend/routers/history.py
@@ -4,9 +4,9 @@ from datetime import date, datetime, timezone
 from typing import Any
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy import and_, or_, select, desc, func, delete
+from sqlalchemy import and_, or_, select, desc, func, delete, case
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import selectinload
+from sqlalchemy.orm import selectinload, aliased
 from db import get_db
 from models.media import Media
 from models.show import Show
@@ -21,7 +21,7 @@ from models.episode_order import EpisodeOrderMapping
 from models.rewatch import ShowRewatch, RewatchProgress
 from routers.media import enrich_with_state, get_user_tmdb_key, check_tmdb_key
 from core.translations import get_user_metadata_language, get_media_translations, apply_media_translations
-from core.rewatch import get_active_rewatch, record_rewatch_progress, get_already_watched_for_bulk_mark
+from core.rewatch import get_active_rewatch, record_rewatch_progress, get_already_watched_for_bulk_mark, capped_season_episode_counts
 from core.enrichment import create_media_safely
 
 from dependencies import get_current_user, get_current_user_or_api_key
@@ -613,6 +613,127 @@ class _NextUpEpisodeNotOnTmdb(Exception):
     doesn't actually have it — not a real error, never raised past get_next_up."""
 
 
+def _remaining_episode_stats(
+    season_ep_counts: dict[int, int],
+    watched_per_season: dict[int, int],
+    avg_runtime: float | None,
+) -> dict | None:
+    """episodes_left / remaining_runtime for one show's Next Up card (#170).
+
+    season_ep_counts is capped_season_episode_counts output (released episodes
+    per season); watched counts are capped per season so provider numbering
+    mismatches (more local watched rows than TMDB says a season has) can't push
+    the remainder negative. Specials (season 0) are excluded, matching
+    total_aired_episodes. The caller only asks about shows that have an aired
+    unwatched episode, so the count is clamped to at least 1 even when stale
+    TMDB season data hasn't caught up with the episode that just aired.
+    """
+    total_aired = sum(v for sn, v in season_ep_counts.items() if sn != 0)
+    if not total_aired:
+        return None
+    watched_aired = sum(
+        min(watched_per_season.get(sn, 0), cnt)
+        for sn, cnt in season_ep_counts.items()
+        if sn != 0
+    )
+    episodes_left = max(total_aired - watched_aired, 1)
+    remaining_runtime = int(round(episodes_left * float(avg_runtime))) if avg_runtime else None
+    return {"episodes_left": episodes_left, "remaining_runtime": remaining_runtime}
+
+
+async def _next_up_remaining_stats(
+    db: AsyncSession,
+    user_id: int,
+    next_up_media: list[Media],
+    active_rewatch_by_show: dict[int, ShowRewatch],
+) -> dict[int, dict]:
+    """Batched per-show remaining-episode estimates for the Next Up items (#170).
+
+    Watched counts follow the show detail page's definition (any WatchEvent for
+    the episode, or RewatchProgress on the active rewatch) so the numbers agree
+    with the watch percentages shown there. Runtime is estimated from the
+    average effective runtime of the show's local episode rows, falling back to
+    TMDB's episode_run_time; None when neither is known.
+    """
+    shows_by_id = {m.show_id: m.show for m in next_up_media if m.show_id and m.show}
+    if not shows_by_id:
+        return {}
+
+    watched_per: dict[tuple[int, int], int] = {}
+    non_rewatch_ids = [sid for sid in shows_by_id if sid not in active_rewatch_by_show]
+    if non_rewatch_ids:
+        watch_a = aliased(WatchEvent)
+        rows = await db.execute(
+            select(
+                Media.show_id,
+                Media.season_number,
+                func.count(func.distinct(
+                    case((watch_a.id.isnot(None), Media.episode_number), else_=None)
+                )),
+            )
+            .outerjoin(watch_a, and_(watch_a.media_id == Media.id, watch_a.user_id == user_id))
+            .where(
+                Media.show_id.in_(non_rewatch_ids),
+                Media.media_type == MediaType.episode,
+                Media.season_number.isnot(None),
+                Media.episode_number.isnot(None),
+            )
+            .group_by(Media.show_id, Media.season_number)
+        )
+        for sid, sn, cnt in rows.all():
+            watched_per[(sid, sn)] = cnt
+
+    rewatch_show_ids = [sid for sid in shows_by_id if sid in active_rewatch_by_show]
+    if rewatch_show_ids:
+        rewatch_ids = [active_rewatch_by_show[sid].id for sid in rewatch_show_ids]
+        rows = await db.execute(
+            select(Media.show_id, Media.season_number, func.count(func.distinct(Media.episode_number)))
+            .select_from(RewatchProgress)
+            .join(Media, Media.id == RewatchProgress.media_id)
+            .where(
+                RewatchProgress.rewatch_id.in_(rewatch_ids),
+                Media.show_id.in_(rewatch_show_ids),
+                Media.season_number.isnot(None),
+                Media.episode_number.isnot(None),
+            )
+            .group_by(Media.show_id, Media.season_number)
+        )
+        for sid, sn, cnt in rows.all():
+            watched_per[(sid, sn)] = cnt
+
+    # Average effective runtime per show — same coalesce as profile.py's watch
+    # time stats: episodes often only carry runtime in tmdb_data['runtime'].
+    from sqlalchemy import Integer as SAInteger
+    from sqlalchemy.types import Text as SAText
+
+    json_runtime = func.cast(
+        func.nullif(func.cast(Media.tmdb_data["runtime"], SAText), "null"),
+        SAInteger,
+    )
+    avg_rows = await db.execute(
+        select(Media.show_id, func.avg(func.coalesce(Media.runtime, json_runtime)))
+        .where(
+            Media.show_id.in_(list(shows_by_id)),
+            Media.media_type == MediaType.episode,
+        )
+        .group_by(Media.show_id)
+    )
+    avg_by_show = {sid: float(avg) for sid, avg in avg_rows.all() if avg is not None}
+
+    stats: dict[int, dict] = {}
+    for sid, show in shows_by_id.items():
+        season_counts = capped_season_episode_counts(show)
+        avg_runtime = avg_by_show.get(sid)
+        if not avg_runtime:
+            run_times = (show.tmdb_data or {}).get("episode_run_time") or []
+            avg_runtime = run_times[0] if run_times else None
+        per_season = {sn: cnt for (s, sn), cnt in watched_per.items() if s == sid}
+        show_stats = _remaining_episode_stats(season_counts, per_season, avg_runtime)
+        if show_stats:
+            stats[sid] = show_stats
+    return stats
+
+
 @router.get("/next-up")
 async def get_next_up(
     db: AsyncSession = Depends(get_db),
@@ -836,9 +957,17 @@ async def get_next_up(
     if limit is not None:
         next_up = next_up[:limit]
 
+    remaining_stats = await _next_up_remaining_stats(
+        db, current_user.id, next_up, active_rewatch_by_show
+    )
+
     items = [_format_media_item(m) for m in next_up]
     for item in items:
         item["next_up_hidden"] = item.get("show_id") in hidden_set
+        show_stats = remaining_stats.get(item.get("show_id"))
+        if show_stats:
+            item["episodes_left"] = show_stats["episodes_left"]
+            item["remaining_runtime"] = show_stats["remaining_runtime"]
     if items:
         await enrich_with_state(db, current_user.id, items)
         lang = await get_user_metadata_language(db, current_user.id)

--- a/backend/routers/history.py
+++ b/backend/routers/history.py
@@ -659,7 +659,9 @@ async def _next_up_remaining_stats(
     if not shows_by_id:
         return {}
 
-    watched_per: dict[tuple[int, int], int] = {}
+    # Grouped by show_id up front so the per-show lookup below is a single dict
+    # access instead of a full-dict filter repeated once per show.
+    watched_per_by_show: dict[int, dict[int, int]] = {}
     non_rewatch_ids = [sid for sid in shows_by_id if sid not in active_rewatch_by_show]
     if non_rewatch_ids:
         watch_a = aliased(WatchEvent)
@@ -681,7 +683,7 @@ async def _next_up_remaining_stats(
             .group_by(Media.show_id, Media.season_number)
         )
         for sid, sn, cnt in rows.all():
-            watched_per[(sid, sn)] = cnt
+            watched_per_by_show.setdefault(sid, {})[sn] = cnt
 
     rewatch_show_ids = [sid for sid in shows_by_id if sid in active_rewatch_by_show]
     if rewatch_show_ids:
@@ -699,7 +701,7 @@ async def _next_up_remaining_stats(
             .group_by(Media.show_id, Media.season_number)
         )
         for sid, sn, cnt in rows.all():
-            watched_per[(sid, sn)] = cnt
+            watched_per_by_show.setdefault(sid, {})[sn] = cnt
 
     # Average effective runtime per show — same coalesce as profile.py's watch
     # time stats: episodes often only carry runtime in tmdb_data['runtime'].
@@ -727,7 +729,7 @@ async def _next_up_remaining_stats(
         if not avg_runtime:
             run_times = (show.tmdb_data or {}).get("episode_run_time") or []
             avg_runtime = run_times[0] if run_times else None
-        per_season = {sn: cnt for (s, sn), cnt in watched_per.items() if s == sid}
+        per_season = watched_per_by_show.get(sid, {})
         show_stats = _remaining_episode_stats(season_counts, per_season, avg_runtime)
         if show_stats:
             stats[sid] = show_stats

--- a/backend/tests/test_next_up.py
+++ b/backend/tests/test_next_up.py
@@ -5,7 +5,7 @@ from datetime import date, datetime, timezone
 os.environ.setdefault("SECRET_KEY", "test-secret")
 os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://test:test@localhost/test")
 
-from routers.history import _compute_next_episode, _group_last_watched, _has_aired, _has_confirmed_air_date
+from routers.history import _compute_next_episode, _group_last_watched, _has_aired, _has_confirmed_air_date, _remaining_episode_stats
 
 
 class ComputeNextEpisodeTests(unittest.TestCase):
@@ -131,3 +131,45 @@ class HasConfirmedAirDateTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class RemainingEpisodeStatsTests(unittest.TestCase):
+    """Feature #170: episodes-left / remaining-runtime estimate on Next Up."""
+
+    def test_basic_remaining_count_and_runtime(self):
+        stats = _remaining_episode_stats(
+            {1: 12, 2: 10}, {1: 12, 2: 4}, avg_runtime=30.0
+        )
+        self.assertEqual(stats["episodes_left"], 6)
+        self.assertEqual(stats["remaining_runtime"], 180)
+
+    def test_specials_are_excluded(self):
+        stats = _remaining_episode_stats(
+            {0: 5, 1: 10}, {0: 5, 1: 3}, avg_runtime=None
+        )
+        self.assertEqual(stats["episodes_left"], 7)
+        self.assertIsNone(stats["remaining_runtime"])
+
+    def test_watched_capped_per_season(self):
+        # Provider numbering mismatch: more local watched rows than TMDB says
+        # the season has must not push the remainder of other seasons down.
+        stats = _remaining_episode_stats(
+            {1: 8, 2: 8}, {1: 12, 2: 0}, avg_runtime=45.0
+        )
+        self.assertEqual(stats["episodes_left"], 8)
+
+    def test_clamped_to_one_when_metadata_is_stale(self):
+        # The caller only asks about shows with an aired unwatched episode, so
+        # stale TMDB counts saying "all watched" still yield 1, never 0.
+        stats = _remaining_episode_stats({1: 10}, {1: 10}, avg_runtime=40.0)
+        self.assertEqual(stats["episodes_left"], 1)
+        self.assertEqual(stats["remaining_runtime"], 40)
+
+    def test_no_aired_episodes_returns_none(self):
+        self.assertIsNone(_remaining_episode_stats({}, {}, avg_runtime=30.0))
+        self.assertIsNone(_remaining_episode_stats({0: 3}, {}, avg_runtime=30.0))
+
+    def test_fractional_average_runtime_rounds(self):
+        stats = _remaining_episode_stats({1: 4}, {1: 1}, avg_runtime=42.5)
+        self.assertEqual(stats["episodes_left"], 3)
+        self.assertEqual(stats["remaining_runtime"], 128)

--- a/frontend/src/components/SortButton.astro
+++ b/frontend/src/components/SortButton.astro
@@ -11,15 +11,19 @@ interface Props {
   paramKey?: string; // query param to set on selection; default "sort"
   label?: string; // popup title; default "Sort By"
   iconPaths?: string[]; // trigger icon SVG path "d" strings; default arrows-up-down (sort)
+  navigate?: boolean; // default true: selecting an option navigates to ?paramKey=value.
+  // false: no navigation - the trigger label updates in place and a "sortchange"
+  // CustomEvent (detail: { value }) bubbles up for the host page to handle
+  // (e.g. a client-side-only sort that doesn't warrant a page reload).
 }
 
 const SORT_ICON = ["M3 7.5 7.5 3m0 0L12 7.5M7.5 3v13.5m13.5 0L16.5 21m0 0L12 16.5m4.5 4.5V7.5"];
 
-const { id, options, current, paramKey = "sort", label = "Sort By", iconPaths = SORT_ICON } = Astro.props;
+const { id, options, current, paramKey = "sort", label = "Sort By", iconPaths = SORT_ICON, navigate = true } = Astro.props;
 const currentLabel = options.find((o) => o.value === current)?.label ?? label;
 ---
 
-<div class="relative inline-block" id={id} data-sort-panel-root data-param-key={paramKey}>
+<div class="relative inline-block" id={id} data-sort-panel-root data-param-key={paramKey} data-navigate={String(navigate)}>
   <button
     type="button"
     data-role="trigger"
@@ -28,7 +32,7 @@ const currentLabel = options.find((o) => o.value === current)?.label ?? label;
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
       {iconPaths.map((d) => <path stroke-linecap="round" stroke-linejoin="round" d={d} />)}
     </svg>
-    {currentLabel}
+    <span data-role="trigger-label">{currentLabel}</span>
   </button>
 
   <div data-role="overlay" class="fixed inset-0 z-50 hidden flex items-end sm:items-center justify-center">
@@ -75,11 +79,13 @@ const currentLabel = options.find((o) => o.value === current)?.label ?? label;
     root.dataset.initialized = "true";
 
     const trigger = root.querySelector<HTMLElement>('[data-role="trigger"]');
+    const triggerLabel = root.querySelector<HTMLElement>('[data-role="trigger-label"]');
     const overlay = root.querySelector<HTMLElement>('[data-role="overlay"]');
     const panel = root.querySelector<HTMLElement>('[data-role="panel"]');
     const backdrop = root.querySelector<HTMLElement>('[data-role="backdrop"]');
     const closeBtn = root.querySelector<HTMLElement>('[data-role="close"]');
     const paramKey = root.dataset.paramKey || "sort";
+    const navigate = root.dataset.navigate !== "false";
 
     function open() {
       overlay?.classList.remove("hidden");
@@ -100,6 +106,13 @@ const currentLabel = options.find((o) => o.value === current)?.label ?? label;
 
     root.querySelectorAll<HTMLInputElement>('[data-role="option"]').forEach((input) => {
       input.addEventListener("change", () => {
+        if (!navigate) {
+          const optionLabel = input.closest("label")?.querySelector("span")?.textContent;
+          if (triggerLabel && optionLabel) triggerLabel.textContent = optionLabel;
+          close();
+          root.dispatchEvent(new CustomEvent("sortchange", { detail: { value: input.value }, bubbles: true }));
+          return;
+        }
         const url = new URL(window.location.href);
         url.searchParams.set(paramKey, input.value);
         url.searchParams.delete("page");

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -570,6 +570,10 @@ export interface MediaItem {
   // raw numbers, not TMDB's, regardless of whether show_tmdb_id is set.
   tvdb_sourced?: boolean;
   next_up_hidden?: boolean;
+  // Next Up remaining-content estimate (#170) — released unwatched episodes
+  // for the show and their estimated total runtime in minutes.
+  episodes_left?: number | null;
+  remaining_runtime?: number | null;
   known_for_department?: string | null;
   in_library?: boolean;
   playable?: boolean;

--- a/frontend/src/lib/media-format.ts
+++ b/frontend/src/lib/media-format.ts
@@ -1,3 +1,16 @@
+export function formatEpisodesLeft(
+  episodesLeft?: number | null,
+  remainingRuntime?: number | null,
+): string | null {
+  if (episodesLeft == null || episodesLeft <= 0) return null;
+  const label = `${episodesLeft} episode${episodesLeft === 1 ? "" : "s"} left`;
+  if (!remainingRuntime || remainingRuntime <= 0) return label;
+  const h = Math.floor(remainingRuntime / 60);
+  const m = remainingRuntime % 60;
+  const runtime = h > 0 ? (m > 0 ? `~${h}h ${m}m` : `~${h}h`) : `~${m}m`;
+  return `${label} · ${runtime}`;
+}
+
 export function formatSeasonTitle(seasonNumber: number, name?: string | null): string {
   const fallback = `Season ${seasonNumber}`;
   const trimDecorators = (value: string) => value.replace(/^[-–—:·\s]+|[-–—:·\s]+$/g, "").trim();

--- a/frontend/src/pages/index.astro
+++ b/frontend/src/pages/index.astro
@@ -5,6 +5,7 @@ import MediaCard from "../components/MediaCard.astro";
 import EpisodeCard from "../components/EpisodeCard.astro";
 import ContinueWatchingCard from "../components/ContinueWatchingCard.astro";
 import { api, type ContinueWatchingItem, type MediaItem, tmdbImageUrl } from "../lib/api";
+import { formatEpisodesLeft } from "../lib/media-format";
 
 const { token } = Astro.locals;
 Astro.response.headers.set("Cache-Control", "no-store");
@@ -154,6 +155,11 @@ const discoverBackdropUrl = discoverPick?.backdrop_path
               </h3>
               {hero.show_title && (
                 <p class="text-sm sm:text-base text-zinc-300 font-medium truncate">{hero.title}</p>
+              )}
+              {formatEpisodesLeft(hero.episodes_left, hero.remaining_runtime) && (
+                <p class="text-xs sm:text-sm text-zinc-400 font-medium mt-1.5 drop-shadow">
+                  {formatEpisodesLeft(hero.episodes_left, hero.remaining_runtime)}
+                </p>
               )}
             </a>
           </div>

--- a/frontend/src/pages/next-up.astro
+++ b/frontend/src/pages/next-up.astro
@@ -66,6 +66,21 @@ Astro.response.headers.set("Cache-Control", "no-store");
 
   let showingHidden = false;
 
+  // Local copy of lib/media-format's formatEpisodesLeft — this define:vars
+  // script can't import from lib/ (same reason tmdbImageUrl is re-implemented
+  // above).
+  function episodesLeftLabel(item) {
+    const n = item.episodes_left;
+    if (n == null || n <= 0) return null;
+    let label = `${n} episode${n === 1 ? '' : 's'} left`;
+    const mins = item.remaining_runtime;
+    if (mins && mins > 0) {
+      const h = Math.floor(mins / 60), m = mins % 60;
+      label += ` · ~${h > 0 ? (m > 0 ? `${h}h ${m}m` : `${h}h`) : `${m}m`}`;
+    }
+    return label;
+  }
+
   function buildCard(item) {
     const isHidden = item.next_up_hidden === true;
     const href = !item.tvdb_sourced && item.show_tmdb_id && item.season_number != null && item.episode_number != null
@@ -112,6 +127,7 @@ Astro.response.headers.set("Cache-Control", "no-store");
             ${item.show_title ? `<h3 class="text-xs font-medium text-zinc-400 truncate mb-0.5">${esc(item.show_title)}</h3>` : ''}
             <h3 class="text-sm font-bold text-zinc-100 group-hover:text-blue-400 truncate transition-colors leading-tight mb-1">${esc(item.title)}</h3>
             ${sxe ? `<p class="text-[11px] font-bold text-blue-400 tracking-wide">${esc(sxe)}</p>` : ''}
+            ${episodesLeftLabel(item) ? `<p class="text-[11px] text-zinc-500 font-medium mt-0.5">${esc(episodesLeftLabel(item))}</p>` : ''}
           </a>
         </div>
       </div>

--- a/frontend/src/pages/next-up.astro
+++ b/frontend/src/pages/next-up.astro
@@ -1,5 +1,6 @@
 ---
 import Base from "../layouts/Base.astro";
+import SortButton from "../components/SortButton.astro";
 export const prerender = false;
 
 const { token } = Astro.locals;
@@ -7,23 +8,25 @@ Astro.response.headers.set("Cache-Control", "no-store");
 ---
 
 <Base title="Next Up">
-  <div class="mb-8 flex items-center justify-between gap-4">
+  <div class="flex flex-col md:flex-row md:items-center justify-between gap-4 mb-8">
     <div>
       <h1 class="page-title mb-2">Next Up</h1>
       <p class="text-zinc-500">Continue where you left off</p>
     </div>
-    <div class="flex items-center gap-3 shrink-0">
-    <select
-      id="sort-select"
-      title="Sort"
-      class="px-3 py-2 text-sm font-bold text-zinc-400 bg-zinc-900 border border-zinc-800 rounded-xl hover:border-zinc-600 hover:text-zinc-200 transition-all cursor-pointer"
-    >
-      <option value="recent">Recently watched</option>
-      <option value="episodes_asc">Episodes left ↑</option>
-      <option value="episodes_desc">Episodes left ↓</option>
-      <option value="time_asc">Time left ↑</option>
-      <option value="time_desc">Time left ↓</option>
-    </select>
+    <div class="flex items-center gap-3">
+    <SortButton
+      id="next-up-sort"
+      current="recent"
+      label="Sort By"
+      navigate={false}
+      options={[
+        { value: "recent", label: "Recently watched" },
+        { value: "episodes_asc", label: "Episodes left ↑" },
+        { value: "episodes_desc", label: "Episodes left ↓" },
+        { value: "time_asc", label: "Time left ↑" },
+        { value: "time_desc", label: "Time left ↓" },
+      ]}
+    />
     <button
       id="toggle-hidden-btn"
       class="flex items-center gap-2 px-4 py-2 text-sm font-bold text-zinc-400 bg-zinc-900 border border-zinc-800 rounded-xl hover:border-zinc-600 hover:text-zinc-200 transition-all cursor-pointer shrink-0"
@@ -291,15 +294,23 @@ Astro.response.headers.set("Cache-Control", "no-store");
     updateEmptyState();
   });
 
-  const sortSelect = document.getElementById('sort-select');
-  sortSelect.value = sortMode;
-  if (sortSelect.value !== sortMode) {
+  const sortButton = document.getElementById('next-up-sort');
+  const validSortModes = ['recent', 'episodes_asc', 'episodes_desc', 'time_asc', 'time_desc'];
+  if (!validSortModes.includes(sortMode)) {
     // Unknown value lingering in localStorage — fall back to the default.
     sortMode = 'recent';
-    sortSelect.value = 'recent';
   }
-  sortSelect.addEventListener('change', () => {
-    sortMode = sortSelect.value;
+  if (sortMode !== 'recent') {
+    // The button is server-rendered as "recent" (localStorage isn't available
+    // at that point) — sync the checked option and visible label to match.
+    const input = sortButton.querySelector(`[data-role="option"][value="${sortMode}"]`);
+    const optionLabel = input?.closest('label')?.querySelector('span')?.textContent;
+    const triggerLabel = sortButton.querySelector('[data-role="trigger-label"]');
+    if (input) input.checked = true;
+    if (triggerLabel && optionLabel) triggerLabel.textContent = optionLabel;
+  }
+  sortButton.addEventListener('sortchange', (e) => {
+    sortMode = e.detail.value;
     localStorage.setItem('nextUpSort', sortMode);
     if (allItems.length) renderGrid();
   });

--- a/frontend/src/pages/next-up.astro
+++ b/frontend/src/pages/next-up.astro
@@ -12,6 +12,18 @@ Astro.response.headers.set("Cache-Control", "no-store");
       <h1 class="page-title mb-2">Next Up</h1>
       <p class="text-zinc-500">Continue where you left off</p>
     </div>
+    <div class="flex items-center gap-3 shrink-0">
+    <select
+      id="sort-select"
+      title="Sort"
+      class="px-3 py-2 text-sm font-bold text-zinc-400 bg-zinc-900 border border-zinc-800 rounded-xl hover:border-zinc-600 hover:text-zinc-200 transition-all cursor-pointer"
+    >
+      <option value="recent">Recently watched</option>
+      <option value="episodes_asc">Episodes left ↑</option>
+      <option value="episodes_desc">Episodes left ↓</option>
+      <option value="time_asc">Time left ↑</option>
+      <option value="time_desc">Time left ↓</option>
+    </select>
     <button
       id="toggle-hidden-btn"
       class="flex items-center gap-2 px-4 py-2 text-sm font-bold text-zinc-400 bg-zinc-900 border border-zinc-800 rounded-xl hover:border-zinc-600 hover:text-zinc-200 transition-all cursor-pointer shrink-0"
@@ -22,6 +34,7 @@ Astro.response.headers.set("Cache-Control", "no-store");
       </svg>
       <span id="toggle-label">Show hidden</span>
     </button>
+    </div>
   </div>
 
   <div id="loading-grid" class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-6">
@@ -65,6 +78,24 @@ Astro.response.headers.set("Cache-Control", "no-store");
   const SPIN   = `<svg class="animate-spin" xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><circle cx="12" cy="12" r="10" stroke-opacity="0.25"/><path d="M12 2a10 10 0 0 1 10 10"/></svg>`;
 
   let showingHidden = false;
+  let allItems = [];
+  let sortMode = localStorage.getItem('nextUpSort') || 'recent';
+
+  // 'recent' keeps the server's order (most recently watched first). The
+  // other modes sort on the #170 stats; items without stats always sink to
+  // the bottom, whatever the direction.
+  function sortedItems() {
+    if (sortMode === 'recent') return allItems;
+    const key = sortMode.startsWith('episodes') ? 'episodes_left' : 'remaining_runtime';
+    const dir = sortMode.endsWith('_desc') ? -1 : 1;
+    return [...allItems].sort((a, b) => {
+      const av = a[key], bv = b[key];
+      if (av == null && bv == null) return 0;
+      if (av == null) return 1;
+      if (bv == null) return -1;
+      return (av - bv) * dir;
+    });
+  }
 
   // Local copy of lib/media-format's formatEpisodesLeft — this define:vars
   // script can't import from lib/ (same reason tmdbImageUrl is re-implemented
@@ -106,8 +137,9 @@ Astro.response.headers.set("Cache-Control", "no-store");
       >${isHidden ? EYE : EYE_SLASH}</button>
     ` : '';
 
-    // Hidden cards: rendered as opacity-50 + hidden (show/hide toggled by JS)
-    const wrapperClass = isHidden ? 'opacity-50 hidden' : '';
+    // Hidden cards: rendered as opacity-50 + hidden (show/hide toggled by JS).
+    // A re-render while "Show hidden" is active must keep them visible.
+    const wrapperClass = isHidden ? (showingHidden ? 'opacity-50' : 'opacity-50 hidden') : '';
 
     return `
       <div class="${wrapperClass}" data-next-up-hidden="${isHidden ? 'true' : 'false'}">
@@ -134,6 +166,14 @@ Astro.response.headers.set("Cache-Control", "no-store");
     `;
   }
 
+  function renderGrid() {
+    const grid = document.getElementById('next-up-grid');
+    grid.innerHTML = sortedItems().map(buildCard).join('');
+    grid.classList.remove('hidden');
+    updateEmptyState();
+    bindHideButtons();
+  }
+
   function updateEmptyState() {
     const grid = document.getElementById('next-up-grid');
     const empty = document.getElementById('empty-state');
@@ -156,19 +196,16 @@ Astro.response.headers.set("Cache-Control", "no-store");
       });
       if (!res.ok) throw new Error('Failed');
       const data = await res.json();
-      const items = data.next_up ?? [];
+      allItems = data.next_up ?? [];
 
       loading.classList.add('hidden');
 
-      if (items.length === 0) {
+      if (allItems.length === 0) {
         empty.classList.remove('hidden');
         return;
       }
 
-      grid.innerHTML = items.map(buildCard).join('');
-      grid.classList.remove('hidden');
-      updateEmptyState();
-      bindHideButtons();
+      renderGrid();
     } catch {
       loading.classList.add('hidden');
       empty.classList.remove('hidden');
@@ -197,7 +234,10 @@ Astro.response.headers.set("Cache-Control", "no-store");
               method: 'DELETE',
               headers: { 'Authorization': `Bearer ${token}` },
             });
-            // Restore
+            // Restore — also sync allItems so a later re-sort re-render
+            // doesn't resurrect the stale hidden state.
+            const restored = allItems.find(i => i.show_id === showId);
+            if (restored) restored.next_up_hidden = false;
             wrapper.dataset.nextUpHidden = 'false';
             wrapper.classList.remove('opacity-50', 'hidden');
             btn.classList.remove('bg-amber-900/60', 'border-amber-600', 'text-amber-300', 'hover:bg-amber-700', 'hover:border-amber-500', 'hover:text-white');
@@ -210,7 +250,9 @@ Astro.response.headers.set("Cache-Control", "no-store");
               headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' },
               body: JSON.stringify({ show_id: showId }),
             });
-            // Hide
+            // Hide — same allItems sync as the restore branch above.
+            const hidden = allItems.find(i => i.show_id === showId);
+            if (hidden) hidden.next_up_hidden = true;
             wrapper.dataset.nextUpHidden = 'true';
             wrapper.classList.add('opacity-50');
             if (!showingHidden) {
@@ -247,6 +289,19 @@ Astro.response.headers.set("Cache-Control", "no-store");
     });
 
     updateEmptyState();
+  });
+
+  const sortSelect = document.getElementById('sort-select');
+  sortSelect.value = sortMode;
+  if (sortSelect.value !== sortMode) {
+    // Unknown value lingering in localStorage — fall back to the default.
+    sortMode = 'recent';
+    sortSelect.value = 'recent';
+  }
+  sortSelect.addEventListener('change', () => {
+    sortMode = sortSelect.value;
+    localStorage.setItem('nextUpSort', sortMode);
+    if (allItems.length) renderGrid();
   });
 
   loadNextUp();


### PR DESCRIPTION
Implements #170.

/history/next-up now returns episodes_left and remaining_runtime per item. Released-episode counts come from the show's stored TMDB season data (specials excluded, counts capped per season so provider numbering mismatches cannot go negative), watched counts use the same definition as the show detail page (rewatch-aware), and runtime is estimated from the show's average episode runtime with a fallback to TMDB's episode_run_time. The Now Playing hero and the /next-up cards render it as e.g. "12 episodes left · ~9h 30m".

The second commit adds a sort dropdown on /next-up: recently watched (default), episodes left or time left, asc/desc, remembered in localStorage.