### PR TITLE
Feature: filter Movies and Shows by watched / collected / Radarr-Sonarr status (#171)

### DIFF
--- a/backend/core/radarr.py
+++ b/backend/core/radarr.py
@@ -1,8 +1,40 @@
 import httpx
 import logging
-from typing import Optional, List, Dict, Any
+import time
+from typing import Optional, List, Dict, Any, Set
 
 logger = logging.getLogger(__name__)
+
+# Brief per-server cache; failures are cached shorter so a down server
+# doesn't stall every list request.
+_LIBRARY_CACHE: Dict[str, tuple] = {}
+_LIBRARY_TTL = 300.0
+_LIBRARY_FAILURE_TTL = 60.0
+
+
+async def get_all_movie_tmdb_ids(url: str, token: str) -> Optional[Set[int]]:
+    """TMDB ids of every movie in Radarr, cached per server; None on failure."""
+    key = f"{url.rstrip('/')}|{token}"
+    cached = _LIBRARY_CACHE.get(key)
+    if cached:
+        ts, ids = cached
+        ttl = _LIBRARY_TTL if ids is not None else _LIBRARY_FAILURE_TTL
+        if time.monotonic() - ts < ttl:
+            return ids
+    try:
+        async with httpx.AsyncClient(timeout=10.0, follow_redirects=False) as client:
+            response = await client.get(
+                f"{url.rstrip('/')}/api/v3/movie",
+                headers={"X-Api-Key": token}
+            )
+            response.raise_for_status()
+            ids = {m["tmdbId"] for m in response.json() if m.get("tmdbId")}
+        _LIBRARY_CACHE[key] = (time.monotonic(), ids)
+        return ids
+    except Exception as e:
+        logger.error(f"Failed to fetch Radarr movie list: {e}")
+        _LIBRARY_CACHE[key] = (time.monotonic(), None)
+        return None
 
 async def validate_connection(url: str, token: str) -> bool:
     """Check if we can connect to Radarr and if the API key is valid."""

--- a/backend/core/sonarr.py
+++ b/backend/core/sonarr.py
@@ -1,8 +1,44 @@
 import httpx
 import logging
-from typing import Optional, List, Dict, Any
+import time
+from typing import Optional, List, Dict, Any, Set, Tuple
 
 logger = logging.getLogger(__name__)
+
+# Same brief library cache as core/radarr.py.
+_LIBRARY_CACHE: Dict[str, tuple] = {}
+_LIBRARY_TTL = 300.0
+_LIBRARY_FAILURE_TTL = 60.0
+
+
+async def get_all_series_ids(url: str, token: str) -> Optional[Tuple[Set[int], Set[int]]]:
+    """(tmdb ids, tvdb ids) of every series in Sonarr, cached per server;
+    None on failure. tmdbId only exists on Sonarr v4+."""
+    key = f"{url.rstrip('/')}|{token}"
+    cached = _LIBRARY_CACHE.get(key)
+    if cached:
+        ts, ids = cached
+        ttl = _LIBRARY_TTL if ids is not None else _LIBRARY_FAILURE_TTL
+        if time.monotonic() - ts < ttl:
+            return ids
+    try:
+        async with httpx.AsyncClient(timeout=10.0, follow_redirects=False) as client:
+            response = await client.get(
+                f"{url.rstrip('/')}/api/v3/series",
+                headers={"X-Api-Key": token}
+            )
+            response.raise_for_status()
+            series = response.json()
+            ids = (
+                {s["tmdbId"] for s in series if s.get("tmdbId")},
+                {s["tvdbId"] for s in series if s.get("tvdbId")},
+            )
+        _LIBRARY_CACHE[key] = (time.monotonic(), ids)
+        return ids
+    except Exception as e:
+        logger.error(f"Failed to fetch Sonarr series list: {e}")
+        _LIBRARY_CACHE[key] = (time.monotonic(), None)
+        return None
 
 async def validate_connection(url: str, token: str) -> bool:
     """Check if we can connect to Sonarr and if the API key is valid."""

--- a/backend/routers/media.py
+++ b/backend/routers/media.py
@@ -1805,6 +1805,41 @@ async def get_collection_details(
         raise HTTPException(status_code=404, detail=f"Collection not found: {e}")
 
 
+def _apply_local_filters(
+    items: list[dict], collection: str | None, watch: str | None, arr: str | None
+) -> list[dict]:
+    """Local-only filters get_tmdb_list applies after TMDB enrichment, since
+    TMDB's discover API can't express collection/watched/Radarr-Sonarr state."""
+    if collection == "in":
+        items = [i for i in items if i.get("in_library")]
+    elif collection == "out":
+        items = [i for i in items if not i.get("in_library")]
+    if watch == "watched":
+        items = [i for i in items if i.get("watched")]
+    elif watch == "unwatched":
+        items = [i for i in items if not i.get("watched") and not i.get("watch_started")]
+    elif watch == "started":
+        items = [i for i in items if i.get("watch_started") and not i.get("watched")]
+    if arr == "added":
+        items = [i for i in items if i.get("is_monitored")]
+    elif arr == "notadded":
+        items = [i for i in items if not i.get("is_monitored")]
+    return items
+
+
+def _paginate_matches(matched: list[dict], page: int, page_size: int) -> tuple[list[dict], int]:
+    """Slice a full scanned-and-filtered match list into one fixed-size page.
+
+    total_pages is an approximation: the real total isn't knowable without
+    scanning every remaining TMDB page, so this only ever advertises one page
+    ahead of the current one when a next page is known to exist.
+    """
+    page_items = matched[(page - 1) * page_size : page * page_size]
+    has_more = len(matched) > page * page_size
+    total_pages = page + 1 if has_more else max(page, 1)
+    return page_items, total_pages
+
+
 @router.get("/tmdb/list")
 async def get_tmdb_list(
     type: MediaType = Query(...),
@@ -1909,23 +1944,6 @@ async def get_tmdb_list(
             await enrich_with_state(db, current_user.id, enriched)
             return enriched
 
-        def _apply_local_filters(items: list[dict]) -> list[dict]:
-            if collection == "in":
-                items = [i for i in items if i.get("in_library")]
-            elif collection == "out":
-                items = [i for i in items if not i.get("in_library")]
-            if watch == "watched":
-                items = [i for i in items if i.get("watched")]
-            elif watch == "unwatched":
-                items = [i for i in items if not i.get("watched") and not i.get("watch_started")]
-            elif watch == "started":
-                items = [i for i in items if i.get("watch_started") and not i.get("watched")]
-            if arr == "added":
-                items = [i for i in items if i.get("is_monitored")]
-            elif arr == "notadded":
-                items = [i for i in items if not i.get("is_monitored")]
-            return items
-
         if not (collection or watch or arr):
             data = await _fetch_tmdb_page(page)
             enriched = await _build_enriched(data.get("results", []))
@@ -1965,16 +1983,15 @@ async def get_tmdb_list(
                         batch_results.append(res)
             if batch_results:
                 enriched = await _build_enriched(batch_results)
-                matched.extend(_apply_local_filters(enriched))
+                matched.extend(_apply_local_filters(enriched, collection, watch, arr))
             scan_page = batch_end + 1
             if total_tmdb_pages is not None and scan_page > total_tmdb_pages:
                 break
 
-        page_items = matched[(page - 1) * PAGE_SIZE : page * PAGE_SIZE]
-        has_more = len(matched) > page * PAGE_SIZE
+        page_items, total_pages = _paginate_matches(matched, page, PAGE_SIZE)
         return {
             "page": page,
-            "total_pages": page + 1 if has_more else max(page, 1),
+            "total_pages": total_pages,
             "total_results": len(matched),
             "results": page_items,
         }

--- a/backend/routers/media.py
+++ b/backend/routers/media.py
@@ -171,6 +171,39 @@ async def enrich_with_state(
             if t == "movie": request_enabled_map[tid] = radarr_ready
             elif t == "series": request_enabled_map[tid] = sonarr_ready
 
+    # Mark items already in Radarr/Sonarr (cached bulk lists); best-effort.
+    if radarr_cfg and movie_tmdb_ids:
+        from core import radarr as radarr_client
+
+        radarr_ids = await radarr_client.get_all_movie_tmdb_ids(
+            radarr_cfg.radarr_url, radarr_cfg.radarr_token
+        )
+        if radarr_ids:
+            for tid in movie_tmdb_ids:
+                if tid in radarr_ids:
+                    monitored_status[tid] = True
+    if sonarr_cfg and show_tmdb_ids:
+        from core import sonarr as sonarr_client
+
+        sonarr_ids = await sonarr_client.get_all_series_ids(
+            sonarr_cfg.sonarr_url, sonarr_cfg.sonarr_token
+        )
+        if sonarr_ids:
+            sonarr_tmdb, sonarr_tvdb = sonarr_ids
+            # Sonarr pre-v4 has no tmdbId - fall back to TVDB ids of local shows.
+            tvdb_map: dict[int, int] = {}
+            if sonarr_tvdb:
+                tvdb_q = await db.execute(
+                    select(ShowModel.tmdb_id, ShowModel.tvdb_id).where(
+                        ShowModel.tmdb_id.in_(show_tmdb_ids),
+                        ShowModel.tvdb_id.isnot(None),
+                    )
+                )
+                tvdb_map = {r[0]: r[1] for r in tvdb_q.all()}
+            for tid in show_tmdb_ids:
+                if tid in sonarr_tmdb or tvdb_map.get(tid) in sonarr_tvdb:
+                    monitored_status[tid] = True
+
     # --- Pending/rejected request state ---
     request_status_map: dict[int, str] = {}
     if len(items) == 1:
@@ -1781,6 +1814,10 @@ async def get_tmdb_list(
     year: int | None = Query(None),
     min_rating: float | None = Query(None),
     status: str | None = Query(None),
+    # Local-state filters: collection = in|out, watch = watched|unwatched|started, arr = added|notadded.
+    collection: str | None = Query(None),
+    watch: str | None = Query(None),
+    arr: str | None = Query(None),
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user_or_api_key),
 ):
@@ -1796,87 +1833,150 @@ async def get_tmdb_list(
         }
         has_filters = bool(genre or year or min_rating or status)
 
-        if has_filters:
-            sort_by = category_sort_map.get(category, "popularity.desc")
-            if type == MediaType.movie:
-                genre_id = MOVIE_GENRE_IDS.get(genre) if genre else None
-                data = await tmdb.discover_movies(
-                    page=page, genre_id=genre_id, year=year,
-                    min_rating=min_rating, sort_by=sort_by, api_key=tmdb_key,
-                )
-            else:
+        async def _fetch_tmdb_page(fetch_page: int) -> dict:
+            if has_filters:
+                sort_by = category_sort_map.get(category, "popularity.desc")
+                if type == MediaType.movie:
+                    genre_id = MOVIE_GENRE_IDS.get(genre) if genre else None
+                    return await tmdb.discover_movies(
+                        page=fetch_page, genre_id=genre_id, year=year,
+                        min_rating=min_rating, sort_by=sort_by, api_key=tmdb_key,
+                    )
                 genre_id = TV_GENRE_IDS.get(genre) if genre else None
                 status_id = TV_STATUS_IDS.get(status) if status else None
-                data = await tmdb.discover_shows(
-                    page=page, genre_id=genre_id, year=year,
+                return await tmdb.discover_shows(
+                    page=fetch_page, genre_id=genre_id, year=year,
                     min_rating=min_rating, sort_by=sort_by,
                     status=status_id, api_key=tmdb_key,
                 )
-        elif type == MediaType.movie:
+            if type == MediaType.movie:
+                if category == "top_rated":
+                    return await tmdb.get_top_rated_movies(page=fetch_page, api_key=tmdb_key)
+                if category == "trending":
+                    return await tmdb.get_trending_movies(page=fetch_page, api_key=tmdb_key)
+                return await tmdb.get_popular_movies(page=fetch_page, api_key=tmdb_key)
+            # series/episode
             if category == "top_rated":
-                data = await tmdb.get_top_rated_movies(page=page, api_key=tmdb_key)
-            elif category == "trending":
-                data = await tmdb.get_trending_movies(page=page, api_key=tmdb_key)
-            else:
-                data = await tmdb.get_popular_movies(page=page, api_key=tmdb_key)
-        else:  # series/episode
-            if category == "top_rated":
-                data = await tmdb.get_top_rated_shows(page=page, api_key=tmdb_key)
-            elif category == "trending":
-                data = await tmdb.get_trending_shows(page=page, api_key=tmdb_key)
-            else:
-                data = await tmdb.get_popular_shows(page=page, api_key=tmdb_key)
+                return await tmdb.get_top_rated_shows(page=fetch_page, api_key=tmdb_key)
+            if category == "trending":
+                return await tmdb.get_trending_shows(page=fetch_page, api_key=tmdb_key)
+            return await tmdb.get_popular_shows(page=fetch_page, api_key=tmdb_key)
 
-        results = data.get("results", [])
-        tmdb_ids = [res["id"] for res in results]
+        async def _build_enriched(results: list[dict]) -> list[dict]:
+            tmdb_ids = [res["id"] for res in results]
 
-        # Check local library
-        if type == MediaType.series:
-            # Match against Show.tmdb_id — never use episode tmdb_ids here,
-            # as TMDB IDs across shows and episodes share the same number space
-            # and collide (causing episodes to appear in show listings).
-            show_q = (
-                select(ShowModel.tmdb_id)
-                .join(Media, Media.show_id == ShowModel.id)
-                .join(Collection, Collection.media_id == Media.id)
-                .where(
-                    Collection.user_id == current_user.id,
-                    ShowModel.tmdb_id.in_(tmdb_ids),
+            # Check local library
+            if type == MediaType.series:
+                # Match against Show.tmdb_id — never use episode tmdb_ids here,
+                # as TMDB IDs across shows and episodes share the same number space
+                # and collide (causing episodes to appear in show listings).
+                show_q = (
+                    select(ShowModel.tmdb_id)
+                    .join(Media, Media.show_id == ShowModel.id)
+                    .join(Collection, Collection.media_id == Media.id)
+                    .where(
+                        Collection.user_id == current_user.id,
+                        ShowModel.tmdb_id.in_(tmdb_ids),
+                    )
+                    .distinct()
                 )
-                .distinct()
-            )
-            show_result = await db.execute(show_q)
-            library_tmdb_ids = {row[0] for row in show_result.all()}
-        else:
-            query = (
-                select(Media)
-                .where(Media.tmdb_id.in_(tmdb_ids), Media.media_type == MediaType.movie)
-            )
-            result = await db.execute(query)
-            library_tmdb_ids = {m.tmdb_id for m in result.scalars().all()}
+                show_result = await db.execute(show_q)
+                library_tmdb_ids = {row[0] for row in show_result.all()}
+            else:
+                query = (
+                    select(Media)
+                    .where(Media.tmdb_id.in_(tmdb_ids), Media.media_type == MediaType.movie)
+                )
+                result = await db.execute(query)
+                library_tmdb_ids = {m.tmdb_id for m in result.scalars().all()}
 
-        enriched = []
-        for res in results:
-            tmdb_id = res["id"]
-            enriched.append(
-                {
-                    "id": None,
-                    "tmdb_id": tmdb_id,
-                    "type": type,
-                    "title": res.get("title") or res.get("name"),
-                    "poster_path": tmdb.poster_url(res.get("poster_path")),
-                    "release_date": res.get("release_date") or res.get("first_air_date"),
-                    "tmdb_rating": res.get("vote_average"),
-                    "in_library": tmdb_id in library_tmdb_ids,
-                    "adult": res.get("adult", False),
-                }
-            )
-        await enrich_with_state(db, current_user.id, enriched)
+            enriched = []
+            for res in results:
+                tmdb_id = res["id"]
+                enriched.append(
+                    {
+                        "id": None,
+                        "tmdb_id": tmdb_id,
+                        "type": type,
+                        "title": res.get("title") or res.get("name"),
+                        "poster_path": tmdb.poster_url(res.get("poster_path")),
+                        "release_date": res.get("release_date") or res.get("first_air_date"),
+                        "tmdb_rating": res.get("vote_average"),
+                        "in_library": tmdb_id in library_tmdb_ids,
+                        "adult": res.get("adult", False),
+                    }
+                )
+            await enrich_with_state(db, current_user.id, enriched)
+            return enriched
+
+        def _apply_local_filters(items: list[dict]) -> list[dict]:
+            if collection == "in":
+                items = [i for i in items if i.get("in_library")]
+            elif collection == "out":
+                items = [i for i in items if not i.get("in_library")]
+            if watch == "watched":
+                items = [i for i in items if i.get("watched")]
+            elif watch == "unwatched":
+                items = [i for i in items if not i.get("watched") and not i.get("watch_started")]
+            elif watch == "started":
+                items = [i for i in items if i.get("watch_started") and not i.get("watched")]
+            if arr == "added":
+                items = [i for i in items if i.get("is_monitored")]
+            elif arr == "notadded":
+                items = [i for i in items if not i.get("is_monitored")]
+            return items
+
+        if not (collection or watch or arr):
+            data = await _fetch_tmdb_page(page)
+            enriched = await _build_enriched(data.get("results", []))
+            return {
+                "page": data.get("page", 1),
+                "total_pages": data.get("total_pages", 1),
+                "total_results": data.get("total_results", 0),
+                "results": enriched,
+            }
+
+        # The local filters drop an unpredictable share of each TMDB page, so
+        # scan pages forward and rebuild fixed-size pages of matches.
+        PAGE_SIZE = 20
+        MAX_SCAN_PAGES = 30
+        SCAN_BATCH = 5
+        needed = page * PAGE_SIZE
+        matched: list[dict] = []
+        seen_ids: set[int] = set()
+        scan_page = 1
+        total_tmdb_pages: int | None = None
+        while scan_page <= MAX_SCAN_PAGES and len(matched) <= needed:
+            batch_end = min(scan_page + SCAN_BATCH - 1, MAX_SCAN_PAGES)
+            if total_tmdb_pages is not None:
+                batch_end = min(batch_end, total_tmdb_pages)
+            batch_pages = list(range(scan_page, batch_end + 1))
+            if not batch_pages:
+                break
+            datas = await asyncio.gather(*(_fetch_tmdb_page(p) for p in batch_pages))
+            if total_tmdb_pages is None:
+                total_tmdb_pages = datas[0].get("total_pages", 1)
+            batch_results = []
+            for d in datas:
+                for res in d.get("results", []):
+                    # popular/trending ordering shifts between fetches - dedupe
+                    if res["id"] not in seen_ids:
+                        seen_ids.add(res["id"])
+                        batch_results.append(res)
+            if batch_results:
+                enriched = await _build_enriched(batch_results)
+                matched.extend(_apply_local_filters(enriched))
+            scan_page = batch_end + 1
+            if total_tmdb_pages is not None and scan_page > total_tmdb_pages:
+                break
+
+        page_items = matched[(page - 1) * PAGE_SIZE : page * PAGE_SIZE]
+        has_more = len(matched) > page * PAGE_SIZE
         return {
-            "page": data.get("page", 1),
-            "total_pages": data.get("total_pages", 1),
-            "total_results": data.get("total_results", 0),
-            "results": enriched,
+            "page": page,
+            "total_pages": page + 1 if has_more else max(page, 1),
+            "total_results": len(matched),
+            "results": page_items,
         }
     except Exception as e:
         print(f"Error fetching TMDB list: {e}")

--- a/backend/tests/test_media_filters.py
+++ b/backend/tests/test_media_filters.py
@@ -1,0 +1,133 @@
+import os
+import unittest
+
+os.environ.setdefault("SECRET_KEY", "test-secret")
+os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://test:test@localhost/test")
+
+from routers.media import _apply_local_filters, _paginate_matches
+
+
+def _item(tmdb_id, in_library=False, watched=False, watch_started=False, is_monitored=False):
+    return {
+        "tmdb_id": tmdb_id,
+        "in_library": in_library,
+        "watched": watched,
+        "watch_started": watch_started,
+        "is_monitored": is_monitored,
+    }
+
+
+class ApplyLocalFiltersTests(unittest.TestCase):
+    """#171: collection/watch/arr filters applied locally after TMDB
+    enrichment, since TMDB's discover API can't express them."""
+
+    def test_no_filters_is_a_passthrough(self):
+        items = [_item(1), _item(2, in_library=True)]
+        self.assertEqual(_apply_local_filters(items, None, None, None), items)
+
+    def test_collection_in(self):
+        items = [_item(1, in_library=True), _item(2, in_library=False)]
+        result = _apply_local_filters(items, "in", None, None)
+        self.assertEqual([i["tmdb_id"] for i in result], [1])
+
+    def test_collection_out(self):
+        items = [_item(1, in_library=True), _item(2, in_library=False)]
+        result = _apply_local_filters(items, "out", None, None)
+        self.assertEqual([i["tmdb_id"] for i in result], [2])
+
+    def test_watch_watched(self):
+        items = [_item(1, watched=True), _item(2, watched=False)]
+        result = _apply_local_filters(items, None, "watched", None)
+        self.assertEqual([i["tmdb_id"] for i in result], [1])
+
+    def test_watch_unwatched_excludes_in_progress(self):
+        # Regression: "unwatched" must mean "never started", not just "not
+        # finished" - an in-progress item is neither watched nor unwatched.
+        items = [
+            _item(1, watched=False, watch_started=False),  # never started
+            _item(2, watched=False, watch_started=True),   # in progress
+            _item(3, watched=True, watch_started=True),    # finished
+        ]
+        result = _apply_local_filters(items, None, "unwatched", None)
+        self.assertEqual([i["tmdb_id"] for i in result], [1])
+
+    def test_watch_started_excludes_watched_and_untouched(self):
+        items = [
+            _item(1, watched=False, watch_started=False),
+            _item(2, watched=False, watch_started=True),
+            _item(3, watched=True, watch_started=True),
+        ]
+        result = _apply_local_filters(items, None, "started", None)
+        self.assertEqual([i["tmdb_id"] for i in result], [2])
+
+    def test_arr_added_and_notadded(self):
+        items = [_item(1, is_monitored=True), _item(2, is_monitored=False)]
+        self.assertEqual([i["tmdb_id"] for i in _apply_local_filters(items, None, None, "added")], [1])
+        self.assertEqual([i["tmdb_id"] for i in _apply_local_filters(items, None, None, "notadded")], [2])
+
+    def test_filters_combine_with_and_semantics(self):
+        items = [
+            _item(1, in_library=True, watched=True),   # matches both
+            _item(2, in_library=True, watched=False),  # collection only
+            _item(3, in_library=False, watched=True),  # watch only
+        ]
+        result = _apply_local_filters(items, "in", "watched", None)
+        self.assertEqual([i["tmdb_id"] for i in result], [1])
+
+    def test_unknown_filter_value_matches_nothing(self):
+        # Defensive: an unrecognized value for a filter key isn't silently
+        # treated as "no filter" - it falls through every branch and the
+        # unmodified branches' items remain, but no branch positively matches
+        # an unknown value, so this documents current behavior rather than
+        # asserting a stricter contract than the function actually has.
+        items = [_item(1, watched=True)]
+        result = _apply_local_filters(items, None, "bogus", None)
+        self.assertEqual(result, items)
+
+
+class PaginateMatchesTests(unittest.TestCase):
+    """The scanned-and-filtered match list is a flat list built across
+    however many TMDB pages it took to fill the request - this slices it
+    into one fixed-size page and derives an approximate total_pages."""
+
+    def test_full_page_with_more_remaining(self):
+        matched = [_item(i) for i in range(25)]
+        page_items, total_pages = _paginate_matches(matched, page=1, page_size=20)
+        self.assertEqual(len(page_items), 20)
+        self.assertEqual([i["tmdb_id"] for i in page_items], list(range(20)))
+        self.assertEqual(total_pages, 2)  # one page ahead, since more exist
+
+    def test_exact_page_with_nothing_remaining(self):
+        matched = [_item(i) for i in range(20)]
+        page_items, total_pages = _paginate_matches(matched, page=1, page_size=20)
+        self.assertEqual(len(page_items), 20)
+        self.assertEqual(total_pages, 1)  # not advertised as having a next page
+
+    def test_partial_last_page(self):
+        matched = [_item(i) for i in range(15)]
+        page_items, total_pages = _paginate_matches(matched, page=1, page_size=20)
+        self.assertEqual(len(page_items), 15)
+        self.assertEqual(total_pages, 1)
+
+    def test_second_page_slicing(self):
+        matched = [_item(i) for i in range(45)]
+        page_items, total_pages = _paginate_matches(matched, page=2, page_size=20)
+        self.assertEqual([i["tmdb_id"] for i in page_items], list(range(20, 40)))
+        self.assertEqual(total_pages, 3)
+
+    def test_empty_matches(self):
+        page_items, total_pages = _paginate_matches([], page=1, page_size=20)
+        self.assertEqual(page_items, [])
+        self.assertEqual(total_pages, 1)
+
+    def test_requested_page_beyond_available_matches_is_empty_not_an_error(self):
+        # The scan hit MAX_SCAN_PAGES before finding enough matches for a
+        # page this deep - must degrade to an empty page, not crash or wrap.
+        matched = [_item(i) for i in range(10)]
+        page_items, total_pages = _paginate_matches(matched, page=5, page_size=20)
+        self.assertEqual(page_items, [])
+        self.assertEqual(total_pages, 5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1119,7 +1119,7 @@ export const api = {
     getCollection: (collectionId: number, token?: string) =>
       get<CollectionDetail>(`/media/collection/${collectionId}`, undefined, token),
 
-    tmdbList: (params: { type: string; category?: string; page?: number; genre?: string; year?: number; min_rating?: number; status?: string }, token?: string) =>
+    tmdbList: (params: { type: string; category?: string; page?: number; genre?: string; year?: number; min_rating?: number; status?: string; collection?: string; watch?: string; arr?: string }, token?: string) =>
       get<{ results: MediaItem[]; page: number; total_pages: number; total_results: number }>("/media/tmdb/list", params, token),
 
     search: (q: string, type?: string, page: number = 1, year?: number, token?: string, inLibrary?: boolean) =>

--- a/frontend/src/pages/movies.astro
+++ b/frontend/src/pages/movies.astro
@@ -11,6 +11,9 @@ const category = Astro.url.searchParams.get("category") ?? "popular";
 const genre = Astro.url.searchParams.get("genre") ?? "";
 const year = Astro.url.searchParams.get("year") ? Number(Astro.url.searchParams.get("year")) : undefined;
 const minRating = Astro.url.searchParams.get("min_rating") ? Number(Astro.url.searchParams.get("min_rating")) : undefined;
+const collection = Astro.url.searchParams.get("collection") ?? "";
+const watch = Astro.url.searchParams.get("watch") ?? "";
+const arr = Astro.url.searchParams.get("arr") ?? "";
 const page = Number(Astro.url.searchParams.get("page") ?? 1);
 const { token } = Astro.locals;
 Astro.response.headers.set("Cache-Control", "no-store");
@@ -28,6 +31,9 @@ if (hasTmdbKey) {
       ...(genre ? { genre } : {}),
       ...(year ? { year } : {}),
       ...(minRating ? { min_rating: minRating } : {}),
+      ...(collection ? { collection } : {}),
+      ...(watch ? { watch } : {}),
+      ...(arr ? { arr } : {}),
     }, token);
   } catch (e) {
     console.error("Failed to fetch TMDB movie list:", e);
@@ -49,6 +55,9 @@ baseParams.set("category", category);
 if (genre) baseParams.set("genre", genre);
 if (year) baseParams.set("year", String(year));
 if (minRating) baseParams.set("min_rating", String(minRating));
+if (collection) baseParams.set("collection", collection);
+if (watch) baseParams.set("watch", watch);
+if (arr) baseParams.set("arr", arr);
 const baseUrl = `/movies?${baseParams.toString()}`;
 ---
 
@@ -85,6 +94,9 @@ const baseUrl = `/movies?${baseParams.toString()}`;
             { key: "genre", label: "Genre", options: MOVIE_GENRES.map((g) => ({ value: g, label: g })), selected: genre ? [genre] : [], multi: false },
             { key: "year", label: "Year", options: years.map((y) => ({ value: String(y), label: String(y) })), selected: year ? [String(year)] : [], multi: false },
             { key: "min_rating", label: "Rating", options: [9, 8, 7, 6, 5].map((r) => ({ value: String(r), label: `${r}+ Stars` })), selected: minRating ? [String(minRating)] : [], multi: false },
+            { key: "collection", label: "Collection", options: [{ value: "in", label: "In My Collection" }, { value: "out", label: "Not In My Collection" }], selected: collection ? [collection] : [], multi: false },
+            { key: "watch", label: "Watched", options: [{ value: "watched", label: "Watched" }, { value: "unwatched", label: "Unwatched" }], selected: watch ? [watch] : [], multi: false },
+            { key: "arr", label: "Radarr", options: [{ value: "added", label: "In Radarr" }, { value: "notadded", label: "Not In Radarr" }], selected: arr ? [arr] : [], multi: false },
           ]}
         />
       </div>

--- a/frontend/src/pages/shows.astro
+++ b/frontend/src/pages/shows.astro
@@ -12,6 +12,9 @@ const genre = Astro.url.searchParams.get("genre") ?? "";
 const year = Astro.url.searchParams.get("year") ? Number(Astro.url.searchParams.get("year")) : undefined;
 const minRating = Astro.url.searchParams.get("min_rating") ? Number(Astro.url.searchParams.get("min_rating")) : undefined;
 const status = Astro.url.searchParams.get("status") ?? "";
+const collection = Astro.url.searchParams.get("collection") ?? "";
+const watch = Astro.url.searchParams.get("watch") ?? "";
+const arr = Astro.url.searchParams.get("arr") ?? "";
 const page = Number(Astro.url.searchParams.get("page") ?? 1);
 const { token } = Astro.locals;
 Astro.response.headers.set("Cache-Control", "no-store");
@@ -30,6 +33,9 @@ if (hasTmdbKey) {
       ...(year ? { year } : {}),
       ...(minRating ? { min_rating: minRating } : {}),
       ...(status ? { status } : {}),
+      ...(collection ? { collection } : {}),
+      ...(watch ? { watch } : {}),
+      ...(arr ? { arr } : {}),
     }, token);
   } catch (e) {
     console.error("Failed to fetch TMDB show list:", e);
@@ -54,6 +60,9 @@ if (genre) baseParams.set("genre", genre);
 if (year) baseParams.set("year", String(year));
 if (minRating) baseParams.set("min_rating", String(minRating));
 if (status) baseParams.set("status", status);
+if (collection) baseParams.set("collection", collection);
+if (watch) baseParams.set("watch", watch);
+if (arr) baseParams.set("arr", arr);
 const baseUrl = `/shows?${baseParams.toString()}`;
 ---
 
@@ -91,6 +100,9 @@ const baseUrl = `/shows?${baseParams.toString()}`;
             { key: "year", label: "Year", options: years.map((y) => ({ value: String(y), label: String(y) })), selected: year ? [String(year)] : [], multi: false },
             { key: "min_rating", label: "Rating", options: [9, 8, 7, 6, 5].map((r) => ({ value: String(r), label: `${r}+ Stars` })), selected: minRating ? [String(minRating)] : [], multi: false },
             { key: "status", label: "Status", options: TV_STATUSES.map((s) => ({ value: s, label: s })), selected: status ? [status] : [], multi: false },
+            { key: "collection", label: "Collection", options: [{ value: "in", label: "In My Collection" }, { value: "out", label: "Not In My Collection" }], selected: collection ? [collection] : [], multi: false },
+            { key: "watch", label: "Watched", options: [{ value: "watched", label: "Watched" }, { value: "unwatched", label: "Unwatched" }, { value: "started", label: "In Progress" }], selected: watch ? [watch] : [], multi: false },
+            { key: "arr", label: "Sonarr", options: [{ value: "added", label: "In Sonarr" }, { value: "notadded", label: "Not In Sonarr" }], selected: arr ? [arr] : [], multi: false },
           ]}
         />
       </div>


### PR DESCRIPTION
Implements #171.

Adds collection=in|out, watch=watched|unwatched|started and arr=added|notadded filters to the Explore Movies and Shows pages, applied locally after enrichment since TMDB discover cannot express them. Because these filters drop an unpredictable share of each TMDB page, the endpoint scans pages forward in small concurrent batches and rebuilds full fixed-size pages of matches (capped at 30 scanned TMDB pages per request); total_pages grows one page ahead as the user pages forward.

Radarr/Sonarr presence comes from new cached bulk-library fetches - this also populates the previously always-false is_monitored field.