### PR TITLE
Fix: duplicate watches after MDBList pull - treat the watched snapshot as state, not plays (#148)

### DIFF
--- a/backend/routers/mdblist.py
+++ b/backend/routers/mdblist.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from collections import defaultdict
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from typing import Any
 
 from dateutil import parser as dt_parser
@@ -35,16 +35,6 @@ from routers.trakt import (
 logger = logging.getLogger(__name__)
 router = APIRouter()
 WATCHLIST_SLUG = "__watchlist__"
-
-# MDBList's own watched_at for the same play can differ slightly between pulls
-# (and doesn't always agree with a timestamp for the same watch reported by
-# another source, e.g. after a push round-trips through a media server). A
-# watch reported within this window of one we already have for the title is
-# treated as the same watch rather than a rewatch. Mirrors
-# routers.sync.PLEX_WEBHOOK_RECONCILE_WINDOW, which reconciles the exact same
-# kind of same-play-different-timestamp drift. See #148.
-WATCH_DEDUP_WINDOW = timedelta(minutes=10)
-
 
 def _utc_naive(value: Any) -> datetime:
     if isinstance(value, datetime):
@@ -424,10 +414,9 @@ async def _import_watched(
                         stats["skipped"] += 1
                         continue
                     watched_at = _utc_naive(entry.get("watched_at") or entry.get("last_watched_at"))
-                    if any(
-                        existing_at is not None and abs(watched_at - existing_at) <= WATCH_DEDUP_WINDOW
-                        for existing_at in existing.get(media.id, [])
-                    ):
+                    # MDBList re-stamps pushed plays, so any dedup window eventually
+                    # re-imports the whole watched list (#148) - only record a first play.
+                    if existing.get(media.id):
                         stats["skipped"] += 1
                         continue
                     event = WatchEvent(

--- a/backend/tests/test_mdblist.py
+++ b/backend/tests/test_mdblist.py
@@ -484,13 +484,13 @@ class _WatchedFakeSessionWithHistory(_WatchedFakeSession):
         return SimpleNamespace(all=lambda: [], scalar_one_or_none=lambda: None)
 
 
-class ImportWatchedDedupWindowTests(unittest.IsolatedAsyncioTestCase):
-    async def test_watch_within_window_of_existing_is_skipped(self) -> None:
+class ImportWatchedFirstPlayOnlyTests(unittest.IsolatedAsyncioTestCase):
+    async def test_watch_close_to_existing_is_skipped(self) -> None:
         """Regression test for #148: MDBList (and a source it round-tripped
         through, e.g. a push to a media server) doesn't always agree on the
         exact watched_at for what's really the same play. A new watch
-        reported within WATCH_DEDUP_WINDOW of one we already have for the
-        title must not create a second WatchEvent."""
+        close to one we already have for the title must not create a second
+        WatchEvent."""
         from routers.mdblist import _import_watched
 
         async def fake_resolve_media(db, kind, entry, api_key, external_cache):
@@ -514,11 +514,12 @@ class ImportWatchedDedupWindowTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(stats["skipped"], 1)
         self.assertEqual(changed, set())
 
-    async def test_watch_outside_window_of_existing_is_recorded(self) -> None:
-        """A watch reported more than WATCH_DEDUP_WINDOW away from the last
-        known one for the title is a genuine rewatch and must still be
-        recorded - including a same-day rewatch a couple hours later (e.g.
-        watching a movie twice in a row to make sense of it)."""
+    async def test_any_existing_play_skips_the_import(self) -> None:
+        """Cloud pulls only ever record a FIRST play: MDBList re-stamps
+        pushed plays with its own times, so any window-based dedup
+        eventually re-imports the whole watched list on a later pull cycle
+        (push -> re-stamp -> pull echo). A title with ANY existing play is
+        skipped regardless of how far apart the timestamps are."""
         from routers.mdblist import _import_watched
 
         async def fake_resolve_media(db, kind, entry, api_key, external_cache):
@@ -537,18 +538,17 @@ class ImportWatchedDedupWindowTests(unittest.IsolatedAsyncioTestCase):
                 db, user_id=35, payload=payload, api_key=None, external_cache={}, stats=stats
             )
 
-        self.assertEqual({obj.media_id for obj in db.added}, {1})
-        self.assertEqual(stats["watched"], 1)
-        self.assertEqual(stats["skipped"], 0)
-        self.assertEqual(changed, {1})
+        self.assertEqual(db.added, [])
+        self.assertEqual(stats["watched"], 0)
+        self.assertEqual(stats["skipped"], 1)
+        self.assertEqual(changed, set())
 
-    async def test_null_dated_existing_watch_does_not_crash_the_window_check(self) -> None:
+    async def test_null_dated_existing_watch_also_skips_the_import(self) -> None:
         """A title can already have a completed WatchEvent with no date at
         all (explicit "mark watched without a date" - see
-        UnknownWatchDateTests in test_history.py). The window comparison
-        must not blow up comparing a real timestamp against that None, and
-        a null-dated existing watch can't be used to dedup against (there's
-        no timestamp to compare), so the new watch is still recorded."""
+        UnknownWatchDateTests in test_history.py). That still counts as an
+        existing play, so the pull import skips it without blowing up on
+        the None timestamp."""
         from routers.mdblist import _import_watched
 
         async def fake_resolve_media(db, kind, entry, api_key, external_cache):
@@ -567,9 +567,9 @@ class ImportWatchedDedupWindowTests(unittest.IsolatedAsyncioTestCase):
             )
 
         self.assertEqual(stats["errors"], 0)
-        self.assertEqual({obj.media_id for obj in db.added}, {1})
-        self.assertEqual(stats["watched"], 1)
-        self.assertEqual(changed, {1})
+        self.assertEqual(db.added, [])
+        self.assertEqual(stats["watched"], 0)
+        self.assertEqual(changed, set())
 
 
 class ImportWatchedSkipsShowRollupTests(unittest.IsolatedAsyncioTestCase):
@@ -624,3 +624,10 @@ class ImportWatchedSkipsShowRollupTests(unittest.IsolatedAsyncioTestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class MDBListPushLimitTests(unittest.TestCase):
+    def test_push_batch_size_within_mdblist_limit(self) -> None:
+        # MDBList rejects >200 shows per sync request (#176) - pin the
+        # contract so the constant can't silently drift above it again.
+        self.assertLessEqual(mdblist.PUSH_BATCH_SIZE, 200)


### PR DESCRIPTION
﻿Fixes #148. MDBList's `/sync/watched` returns a state snapshot whose `last_watched_at` gets re-stamped when plays are pushed back to it, so any window-based dedup eventually re-imports the entire watched list on a later pull (push -> re-stamp -> pull echo). Import now only records a play for titles that have no completed play yet - the unwatched -> watched transition. Rewatches keep coming from live scrobbling and play-log sources. The now-unused dedup window is removed and the tests are updated accordingly.
