### PR TITLE
fix(stremio): dedupe watched sync by media_id to prevent duplicate WatchEvents

### DIFF
--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -3662,6 +3662,7 @@ async def _apply_nuvio_watch_history(
     tmdb_ids: dict[str, int],
     *,
     include_unknown_dates: bool = False,
+    dedupe_by_media_id_only: bool = False,
 ) -> set[int]:
     standalone_tmdb_ids = {
         tmdb_id
@@ -3737,12 +3738,22 @@ async def _apply_nuvio_watch_history(
         )
     )
     existing = set(existing_result.all())
+    existing_by_media: dict[int, datetime | None] = {}
+    for existing_media_id, existing_watched_at in existing:
+        existing_by_media.setdefault(existing_media_id, existing_watched_at)
     added_media_ids: set[int] = set()
     new_events: list[WatchEvent] = []
     for media, watched_at in candidates:
-        key = (media.id, watched_at)
-        if key in existing:
-            continue
+        if dedupe_by_media_id_only:
+            if media.id in existing_by_media:
+                continue
+        else:
+            existing_watched_at = existing_by_media.get(media.id)
+            if watched_at is None:
+                if existing_watched_at is not None:
+                    continue
+            elif (media.id, watched_at) in existing:
+                continue
         event = WatchEvent(
             user_id=user_id,
             media_id=media.id,
@@ -3753,7 +3764,7 @@ async def _apply_nuvio_watch_history(
         )
         db.add(event)
         new_events.append(event)
-        existing.add(key)
+        existing_by_media[media.id] = watched_at
         added_media_ids.add(media.id)
     await db.commit()
     for event in new_events:
@@ -4574,6 +4585,7 @@ async def _run_stremio_sync(
                         show_map,
                         tmdb_ids,
                         include_unknown_dates=True,
+                        dedupe_by_media_id_only=True,
                     )
                 )
             if progress_records:

--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -3764,6 +3764,11 @@ async def _apply_nuvio_watch_history(
         )
         db.add(event)
         new_events.append(event)
+        # Keep both structures in sync - exact-match dedup (the default path)
+        # still checks `existing` directly, and without this an exact-duplicate
+        # row later in the same batch would no longer be caught, creating a
+        # second WatchEvent for it in one sync run.
+        existing.add((media.id, watched_at))
         existing_by_media[media.id] = watched_at
         added_media_ids.add(media.id)
     await db.commit()

--- a/backend/tests/test_stremio.py
+++ b/backend/tests/test_stremio.py
@@ -790,3 +790,86 @@ class StremioLinkReconnectTests(unittest.IsolatedAsyncioTestCase):
         added = db.add.call_args.args[0]
         self.assertEqual(added.token, "fresh-auth-key")
         self.assertEqual(added.name, "My Stremio")
+
+    async def test_stremio_sync_dedup_by_media_id_only_skips_existing_watched(self) -> None:
+        movie = Media(
+            id=10,
+            tmdb_id=603,
+            media_type=MediaType.movie,
+            title="The Matrix",
+        )
+        media_result = SimpleNamespace(
+            scalars=lambda: SimpleNamespace(all=lambda: [movie]),
+        )
+        existing_result = SimpleNamespace(
+            all=lambda: [(10, datetime(2026, 8, 13, 10, 0, 0))],
+        )
+        rewatch_media_result = SimpleNamespace(scalar_one_or_none=lambda: None)
+        db = SimpleNamespace(
+            execute=AsyncMock(side_effect=[media_result, existing_result, rewatch_media_result]),
+            add=MagicMock(),
+            commit=AsyncMock(),
+        )
+
+        added = await _apply_nuvio_watch_history(
+            db,
+            user_id=7,
+            rows=[
+                {
+                    "content_id": "tt0133093",
+                    "content_type": "movie",
+                    "watched_at": datetime(2026, 8, 15, 11, 0, 0).timestamp() * 1000,
+                }
+            ],
+            show_map={},
+            tmdb_ids={"tt0133093": 603},
+            include_unknown_dates=True,
+            dedupe_by_media_id_only=True,
+        )
+
+        self.assertEqual(added, set())
+        db.add.assert_not_called()
+
+    async def test_nuvio_sync_allows_new_timestamps_by_default(self) -> None:
+        movie = Media(
+            id=10,
+            tmdb_id=603,
+            media_type=MediaType.movie,
+            title="The Matrix",
+        )
+        media_result = SimpleNamespace(
+            scalars=lambda: SimpleNamespace(all=lambda: [movie]),
+        )
+        existing_result = SimpleNamespace(
+            all=lambda: [(10, datetime(2026, 8, 13, 10, 0, 0))],
+        )
+        rewatch_media_result = SimpleNamespace(scalar_one_or_none=lambda: None)
+        db = SimpleNamespace(
+            execute=AsyncMock(side_effect=[media_result, existing_result, rewatch_media_result]),
+            add=MagicMock(),
+            commit=AsyncMock(),
+        )
+
+        expected_watched_at = datetime(2026, 8, 15, 11, 0, 0)
+        added = await _apply_nuvio_watch_history(
+            db,
+            user_id=7,
+            rows=[
+                {
+                    "content_id": "tt0133093",
+                    "content_type": "movie",
+                    "watched_at": int(
+                        datetime(2026, 8, 15, 11, 0, 0, tzinfo=timezone.utc).timestamp() * 1000
+                    ),
+                }
+            ],
+            show_map={},
+            tmdb_ids={"tt0133093": 603},
+            include_unknown_dates=True,
+        )
+
+        self.assertEqual(added, {10})
+        db.add.assert_called_once()
+        event = db.add.call_args.args[0]
+        self.assertEqual(event.media_id, 10)
+        self.assertEqual(event.watched_at, expected_watched_at)


### PR DESCRIPTION
…tchEvents

Stremio sync was creating duplicate WatchEvents on every pull because lastWatched changes between syncs even without real rewatches. The old dedup only skipped exact (media_id, watched_at) matches.

Changes:
- Add dedupe_by_media_id_only flag to _apply_nuvio_watch_history
- When enabled (Stremio sync), skip creation if media_id already has any WatchEvent
- Preserve original behavior for Nuvio sync and tests
- Add tests covering both Stremio dedupe and default Nuvio behavior

Fixes #217