### PR TITLE
Fix: Nuvio account cannot be added - profile select was filled with the row id instead of profile_index (#211)

### DIFF
--- a/frontend/src/pages/connections.astro
+++ b/frontend/src/pages/connections.astro
@@ -2624,7 +2624,7 @@ const sonarrConfigured   = !!(settings.sonarr_url && settings.sonarr_token);
           if (profileSelect) {
             const selectedProfile = profileSelect.value;
             profileSelect.innerHTML = cs.profiles.map((profile: any) => {
-              const pid = String(profile.id !== undefined ? profile.id : (profile.profile_index !== undefined ? profile.profile_index : '0'));
+              const pid = String(profile.profile_index !== undefined && profile.profile_index !== null ? profile.profile_index : (profile.id !== undefined ? profile.id : '0'));
               const pname = profile.name || `Profile ${pid}`;
               return `<option value="${esc(pid)}">${esc(pname)}</option>`;
             }).join('');
@@ -3914,7 +3914,7 @@ const sonarrConfigured   = !!(settings.sonarr_url && settings.sonarr_token);
           const previousProfileId = profileSelect?.value || '';
           if (profileSelect) {
             profileSelect.innerHTML = profiles.map((profile: any) => {
-              const pid = String(profile.id !== undefined ? profile.id : (profile.profile_index !== undefined ? profile.profile_index : '0'));
+              const pid = String(profile.profile_index !== undefined && profile.profile_index !== null ? profile.profile_index : (profile.id !== undefined ? profile.id : '0'));
               const pname = profile.name || `Profile ${pid}`;
               return `<option value="${esc(pid)}">${esc(pname)}</option>`;
             }).join('');
@@ -4182,7 +4182,7 @@ const sonarrConfigured   = !!(settings.sonarr_url && settings.sonarr_token);
       pendingNuvioRefreshToken = data.refresh_token || password;
       if (nuvioProfileSelect) {
         nuvioProfileSelect.innerHTML = (data.profiles || []).map((profile: any) => {
-          const pid = String(profile.id !== undefined ? profile.id : profile.profile_index);
+          const pid = String(profile.profile_index !== undefined && profile.profile_index !== null ? profile.profile_index : profile.id);
           const pname = profile.name || `Profile ${pid}`;
           return `<option value="${esc(pid)}">${esc(pname)}</option>`;
         }).join('');


### PR DESCRIPTION
﻿Fixes #211. The profile dropdowns preferred `profile.id` over `profile_index` when filling options; Nuvio profile rows carry a non-numeric row id, so connecting always failed validation with "Nuvio profile must be an integer from 1 to 6". Prefer `profile_index` and fall back to `id`, which keeps ARVIO (string ids, no profile_index) working.
