### PR TITLE
Fix: friends-only lists are now discoverable by mutual follows (#210)

### DIFF
--- a/backend/routers/lists.py
+++ b/backend/routers/lists.py
@@ -3,8 +3,8 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 from typing import Optional
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy import select, func
-from sqlalchemy.orm import selectinload
+from sqlalchemy import select, func, and_, or_
+from sqlalchemy.orm import selectinload, aliased
 
 from db import get_db
 from models.lists import List as ListModel, ListItem
@@ -158,11 +158,29 @@ async def get_public_lists(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user_or_api_key),
 ):
+    # Friends-only lists of mutual follows belong in discovery too — they were
+    # invisible to the very friends they're shared with (#210).
+    FollowBack = aliased(Follow)
+    mutual_rows = await db.execute(
+        select(Follow.following_id)
+        .join(FollowBack, and_(
+            FollowBack.follower_id == Follow.following_id,
+            FollowBack.following_id == Follow.follower_id,
+        ))
+        .where(Follow.follower_id == current_user.id)
+    )
+    mutual_ids = [r[0] for r in mutual_rows.all()]
+    visibility = ListModel.privacy_level == PrivacyLevel.public
+    if mutual_ids:
+        visibility = or_(visibility, and_(
+            ListModel.privacy_level == PrivacyLevel.friends_only,
+            ListModel.user_id.in_(mutual_ids),
+        ))
     result = await db.execute(
         select(ListModel, User.username)
         .join(User, User.id == ListModel.user_id)
         .options(selectinload(ListModel.items).selectinload(ListItem.media).selectinload(Media.show))
-        .where(ListModel.privacy_level == PrivacyLevel.public, ListModel.user_id != current_user.id)
+        .where(visibility, ListModel.user_id != current_user.id)
         .order_by(func.random())
         .limit(3)
     )

--- a/backend/routers/profile.py
+++ b/backend/routers/profile.py
@@ -769,11 +769,17 @@ async def get_public_profile(
     ]
 
     is_following = False
+    is_mutual_follow = False
     if current_user and current_user.id != user_id:
         follow_check = await db.execute(
             select(Follow).where(Follow.follower_id == current_user.id, Follow.following_id == user_id)
         )
         is_following = follow_check.scalar_one_or_none() is not None
+        if is_following:
+            follow_back = await db.execute(
+                select(Follow).where(Follow.follower_id == user_id, Follow.following_id == current_user.id)
+            )
+            is_mutual_follow = follow_back.scalar_one_or_none() is not None
 
     # --- Lists ---
     lists_query = (
@@ -791,7 +797,11 @@ async def get_public_profile(
         .order_by(ListModel.updated_at.desc())
     )
     if not (is_owner or is_admin):
-        lists_query = lists_query.where(ListModel.privacy_level == PrivacyLevel.public)
+        # Mutual follows also get this user's friends-only lists (#210).
+        visible = [PrivacyLevel.public]
+        if is_mutual_follow:
+            visible.append(PrivacyLevel.friends_only)
+        lists_query = lists_query.where(ListModel.privacy_level.in_(visible))
 
     lists_result = await db.execute(lists_query)
     lists_rows = lists_result.all()


### PR DESCRIPTION
﻿Fixes #210. List discovery and another user's profile page only ever surfaced `public` lists, so a friends-only list was invisible to the very friends it was shared with - even though opening it directly already worked via the mutual-follow check. Discovery and profile listings now include friends-only lists from mutual follows.
