### PR TITLE
Feature: filter Explore Movies/Shows by original language (#230)

### DIFF
--- a/backend/routers/media.py
+++ b/backend/routers/media.py
@@ -1873,6 +1873,7 @@ async def get_tmdb_list(
     year: list[int] = Query(default=[]),
     min_rating: float | None = Query(None),
     status: str | None = Query(None),
+    original_language: str | None = Query(None),
     # Local-state filters, applied after TMDB enrichment (OR'd within each,
     # same convention as genre above): collection = in|out,
     # watch = watched|unwatched|started, arr = added|notadded.
@@ -1892,7 +1893,7 @@ async def get_tmdb_list(
             "top_rated": "vote_average.desc",
             "trending": "popularity.desc",
         }
-        has_filters = bool(genre or min_rating or status)
+        has_filters = bool(genre or min_rating or status or original_language)
 
         async def _fetch_tmdb_page(fetch_page: int) -> dict:
             if has_filters:
@@ -1901,14 +1902,16 @@ async def get_tmdb_list(
                     genre_ids = [MOVIE_GENRE_IDS[g] for g in genre if g in MOVIE_GENRE_IDS]
                     return await tmdb.discover_movies(
                         page=fetch_page, genre_ids=genre_ids or None,
-                        min_rating=min_rating, sort_by=sort_by, api_key=tmdb_key,
+                        min_rating=min_rating, sort_by=sort_by,
+                        with_original_language=original_language, api_key=tmdb_key,
                     )
                 genre_ids = [TV_GENRE_IDS[g] for g in genre if g in TV_GENRE_IDS]
                 status_id = TV_STATUS_IDS.get(status) if status else None
                 return await tmdb.discover_shows(
                     page=fetch_page, genre_ids=genre_ids or None,
                     min_rating=min_rating, sort_by=sort_by,
-                    status=status_id, api_key=tmdb_key,
+                    status=status_id, with_original_language=original_language,
+                    api_key=tmdb_key,
                 )
             if type == MediaType.movie:
                 if category == "top_rated":

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1125,7 +1125,7 @@ export const api = {
     getCollection: (collectionId: number, token?: string) =>
       get<CollectionDetail>(`/media/collection/${collectionId}`, undefined, token),
 
-    tmdbList: (params: { type: string; category?: string; page?: number; genre?: string[]; year?: number[]; min_rating?: number; status?: string; collection?: string[]; watch?: string[]; arr?: string[] }, token?: string) =>
+    tmdbList: (params: { type: string; category?: string; page?: number; genre?: string[]; year?: number[]; min_rating?: number; status?: string; collection?: string[]; watch?: string[]; arr?: string[]; original_language?: string }, token?: string) =>
       get<{ results: MediaItem[]; page: number; total_pages: number; total_results: number }>("/media/tmdb/list", params, token),
 
     search: (q: string, type?: string, page: number = 1, year?: number, token?: string, inLibrary?: boolean) =>

--- a/frontend/src/pages/movies.astro
+++ b/frontend/src/pages/movies.astro
@@ -14,6 +14,7 @@ const minRating = Astro.url.searchParams.get("min_rating") ? Number(Astro.url.se
 const collection = Astro.url.searchParams.getAll("collection");
 const watch = Astro.url.searchParams.getAll("watch");
 const arr = Astro.url.searchParams.getAll("arr");
+const langs = Astro.url.searchParams.getAll("lang");
 const page = Number(Astro.url.searchParams.get("page") ?? 1);
 const { token } = Astro.locals;
 Astro.response.headers.set("Cache-Control", "no-store");
@@ -35,6 +36,7 @@ if (hasTmdbKey) {
       ...(collection.length ? { collection } : {}),
       ...(watch.length ? { watch } : {}),
       ...(hasRadarr && arr.length ? { arr } : {}),
+      ...(langs.length ? { original_language: langs.join("|") } : {}),
     }, token);
   } catch (e) {
     console.error("Failed to fetch TMDB movie list:", e);
@@ -45,6 +47,17 @@ const MOVIE_GENRES = [
   "Action", "Adventure", "Animation", "Comedy", "Crime", "Documentary",
   "Drama", "Family", "Fantasy", "History", "Horror", "Music", "Mystery",
   "Romance", "Science Fiction", "Thriller", "War", "Western",
+];
+
+const LANGUAGES = [
+  { value: "en", label: "English" }, { value: "nl", label: "Dutch" },
+  { value: "fr", label: "French" }, { value: "de", label: "German" },
+  { value: "es", label: "Spanish" }, { value: "it", label: "Italian" },
+  { value: "pt", label: "Portuguese" }, { value: "ja", label: "Japanese" },
+  { value: "ko", label: "Korean" }, { value: "zh", label: "Chinese" },
+  { value: "sv", label: "Swedish" }, { value: "da", label: "Danish" },
+  { value: "no", label: "Norwegian" }, { value: "tr", label: "Turkish" },
+  { value: "hi", label: "Hindi" },
 ];
 
 const currentYear = new Date().getFullYear();
@@ -59,6 +72,7 @@ if (minRating) baseParams.set("min_rating", String(minRating));
 collection.forEach((v) => baseParams.append("collection", v));
 watch.forEach((v) => baseParams.append("watch", v));
 if (hasRadarr) arr.forEach((v) => baseParams.append("arr", v));
+langs.forEach((l) => baseParams.append("lang", l));
 const baseUrl = `/movies?${baseParams.toString()}`;
 ---
 
@@ -98,6 +112,7 @@ const baseUrl = `/movies?${baseParams.toString()}`;
             { key: "collection", label: "Collection", options: [{ value: "in", label: "In My Collection" }, { value: "out", label: "Not In My Collection" }], selected: collection },
             { key: "watch", label: "Watched", options: [{ value: "watched", label: "Watched" }, { value: "unwatched", label: "Unwatched" }], selected: watch },
             ...(hasRadarr ? [{ key: "arr", label: "Radarr", options: [{ value: "added", label: "In Radarr" }, { value: "notadded", label: "Not In Radarr" }], selected: arr }] : []),
+            { key: "lang", label: "Language", options: LANGUAGES, selected: langs },
           ]}
         />
       </div>

--- a/frontend/src/pages/shows.astro
+++ b/frontend/src/pages/shows.astro
@@ -15,6 +15,7 @@ const status = Astro.url.searchParams.get("status") ?? "";
 const collection = Astro.url.searchParams.getAll("collection");
 const watch = Astro.url.searchParams.getAll("watch");
 const arr = Astro.url.searchParams.getAll("arr");
+const langs = Astro.url.searchParams.getAll("lang");
 const page = Number(Astro.url.searchParams.get("page") ?? 1);
 const { token } = Astro.locals;
 Astro.response.headers.set("Cache-Control", "no-store");
@@ -37,6 +38,7 @@ if (hasTmdbKey) {
       ...(collection.length ? { collection } : {}),
       ...(watch.length ? { watch } : {}),
       ...(hasSonarr && arr.length ? { arr } : {}),
+      ...(langs.length ? { original_language: langs.join("|") } : {}),
     }, token);
   } catch (e) {
     console.error("Failed to fetch TMDB show list:", e);
@@ -51,6 +53,17 @@ const TV_GENRES = [
 
 const TV_STATUSES = ["Returning Series", "In Production", "Planned", "Ended", "Canceled"];
 
+const LANGUAGES = [
+  { value: "en", label: "English" }, { value: "nl", label: "Dutch" },
+  { value: "fr", label: "French" }, { value: "de", label: "German" },
+  { value: "es", label: "Spanish" }, { value: "it", label: "Italian" },
+  { value: "pt", label: "Portuguese" }, { value: "ja", label: "Japanese" },
+  { value: "ko", label: "Korean" }, { value: "zh", label: "Chinese" },
+  { value: "sv", label: "Swedish" }, { value: "da", label: "Danish" },
+  { value: "no", label: "Norwegian" }, { value: "tr", label: "Turkish" },
+  { value: "hi", label: "Hindi" },
+];
+
 const currentYear = new Date().getFullYear();
 const years = Array.from({ length: currentYear - 1949 }, (_, i) => currentYear - i);
 
@@ -64,6 +77,7 @@ if (status) baseParams.set("status", status);
 collection.forEach((v) => baseParams.append("collection", v));
 watch.forEach((v) => baseParams.append("watch", v));
 if (hasSonarr) arr.forEach((v) => baseParams.append("arr", v));
+langs.forEach((l) => baseParams.append("lang", l));
 const baseUrl = `/shows?${baseParams.toString()}`;
 ---
 
@@ -104,6 +118,7 @@ const baseUrl = `/shows?${baseParams.toString()}`;
             { key: "collection", label: "Collection", options: [{ value: "in", label: "In My Collection" }, { value: "out", label: "Not In My Collection" }], selected: collection },
             { key: "watch", label: "Watched", options: [{ value: "watched", label: "Watched" }, { value: "unwatched", label: "Unwatched" }, { value: "started", label: "In Progress" }], selected: watch },
             ...(hasSonarr ? [{ key: "arr", label: "Sonarr", options: [{ value: "added", label: "In Sonarr" }, { value: "notadded", label: "Not In Sonarr" }], selected: arr }] : []),
+            { key: "lang", label: "Language", options: LANGUAGES, selected: langs },
           ]}
         />
       </div>


### PR DESCRIPTION
﻿Closes #230. Adds a multi-select Language section to the Explore Movies and Explore Shows filter panels. The selection is passed to TMDB discover as `with_original_language` (pipe-separated ISO 639-1 codes, OR'd by TMDB), so it filters server-side and combines with the existing genre/year/rating/status filters and pagination.
