### PR TITLE
Fix: metadata language not applied to list-only / non-library shows (#235)

### DIFF
--- a/backend/routers/shows.py
+++ b/backend/routers/shows.py
@@ -854,15 +854,18 @@ async def get_show(
             "where_to_watch": where_to_watch,
         }
 
-    # 2. If not local, fetch from TMDB
+    # 2. If not local, fetch from TMDB — pass the viewer's metadata language so
+    # list-only / non-library shows are translated too (in-library shows use the
+    # stored ShowTranslation instead; see the `if show:` branch above). #235.
     api_key = await get_user_tmdb_key(db, current_user.id)
     if not check_tmdb_key(api_key):
         raise HTTPException(
             status_code=404, detail="Show not found and TMDB key not configured"
         )
 
+    metadata_lang = await get_user_metadata_language(db, current_user.id)
     try:
-        data = await tmdb.get_show(series_tmdb_id, api_key=api_key)
+        data = await tmdb.get_show(series_tmdb_id, api_key=api_key, language=metadata_lang)
 
         cast = [
             {

--- a/backend/routers/shows.py
+++ b/backend/routers/shows.py
@@ -818,6 +818,13 @@ async def get_show(
                 val = tmdb_extra.get(tmdb_key)
                 if val:
                     show_dict[field] = val
+            # Use the language-specific poster when TMDB has one — its
+            # get_show(language=...) already returns the localized poster if it
+            # exists, or the default otherwise, so this only changes anything
+            # when a translated poster is actually available (#235 follow-up).
+            tmdb_poster = tmdb_extra.get("poster_path")
+            if tmdb_poster:
+                show_dict["poster_path"] = tmdb.poster_url(tmdb_poster)
 
         return {
             **show_dict,


### PR DESCRIPTION
Fixes #235. A show that's only in a list (not in the library) is fetched from TMDB on demand, but that path called `tmdb.get_show(...)` without the language param, so it always returned English metadata even when the user's Metadata Language has a translation available. In-library shows already use the stored ShowTranslation plus a language-aware TMDB call; the non-library path now passes `language` too. (Movie details already did this.)

Second commit: the in-library show detail already overlaid the localized title/overview/tagline from the language-aware TMDB fetch, but not the poster, so it kept showing the default (usually English) poster. It now also uses the language-specific poster. TMDB's `get_show(language=...)` returns the localized poster when one exists and the default otherwise, so this only changes the poster when a translated version is actually available.
