### PR TITLE
feat(nuvio): support self-hosted backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,18 +335,22 @@ The GitHub Actions workflow (`.github/workflows/docker-x64.yml`) automatically v
 
 ## Nuvio Cloud Synchronization
 
-Scrob connects to the [Nuvio public Cloud API](https://nuvio.tv/docs) at `https://api.nuvio.tv`. A TMDB Read Access Token must be configured in Scrob so Nuvio content identifiers can be matched to movies and shows.
+Scrob connects to the [Nuvio public Cloud API](https://nuvio.tv/docs) at `https://api.nuvio.tv` by default and also supports self-hosted Nuvio backends. A TMDB Read Access Token must be configured in Scrob so Nuvio content identifiers can be matched to movies and shows.
 
 ### Connect Nuvio
 
 1. Open **Connections → Media Players** and select **Add Connection**.
-2. Choose **Nuvio**, then enter a connection name, your Nuvio email, and your Nuvio password.
+2. Choose **Nuvio**, then enter a connection name, your Nuvio email, and your Nuvio password. To use a self-hosted backend, replace the default Cloud API URL with its Supabase project URL.
 3. Select **Test** to authenticate and load the profiles attached to the account.
 4. Select the Nuvio profile to synchronize, choose the pull and push options, then select **Add**.
 
 Scrob exchanges the email and password for a refresh token. The password is never persisted. Refresh-token rotation is handled automatically during connection checks and synchronization.
 
 Each connection targets one Nuvio profile. Add another connection if you need to synchronize another profile from the same account.
+
+### Self-hosted Backends
+
+Set `NUVIO_APP_ANON_KEY` to the anon/public key for your self-hosted Nuvio Supabase project, then enter that project's URL in the editable **Cloud API URL** field when adding the connection. If the variable is unset, Scrob continues to use the official Nuvio publishable key.
 
 ### Synchronization Directions
 

--- a/backend/core/nuvio.py
+++ b/backend/core/nuvio.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 from dataclasses import dataclass
 from typing import Any, Awaitable, Callable
 
@@ -6,7 +7,7 @@ import httpx
 
 
 DEFAULT_URL = "https://api.nuvio.tv"
-PUBLISHABLE_KEY = "sb_publishable_1Clq8rlTVACkdcZuqr6_AD__xUUC_EN"
+DEFAULT_APP_ANON_KEY = "sb_publishable_1Clq8rlTVACkdcZuqr6_AD__xUUC_EN"
 _PAGE_SIZE = 500
 
 
@@ -62,7 +63,10 @@ def _base_url(url: str) -> str:
 
 
 def _public_headers() -> dict[str, str]:
-    return {"apikey": PUBLISHABLE_KEY, "Content-Type": "application/json"}
+    return {
+        "apikey": os.getenv("NUVIO_APP_ANON_KEY") or DEFAULT_APP_ANON_KEY,
+        "Content-Type": "application/json",
+    }
 
 
 def _auth_headers(access_token: str) -> dict[str, str]:

--- a/backend/tests/test_nuvio.py
+++ b/backend/tests/test_nuvio.py
@@ -62,6 +62,31 @@ class _SessionCM:
 
 
 class NuvioClientTests(unittest.IsolatedAsyncioTestCase):
+    async def test_sign_in_uses_custom_app_anon_key(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            self.assertEqual(request.headers["apikey"], "self-hosted-anon-key")
+            return httpx.Response(
+                200,
+                json={
+                    "access_token": "access-token",
+                    "refresh_token": "refresh-token",
+                    "expires_in": 3600,
+                },
+            )
+
+        transport = httpx.MockTransport(handler)
+        with (
+            patch.dict(os.environ, {"NUVIO_APP_ANON_KEY": "self-hosted-anon-key"}),
+            patch.object(
+                nuvio.httpx,
+                "AsyncClient",
+                side_effect=lambda **kwargs: _REAL_ASYNC_CLIENT(transport=transport, **kwargs),
+            ),
+        ):
+            session = await nuvio.sign_in("https://nuvio.example.com", "user@example.com", "password")
+
+        self.assertEqual(session.refresh_token, "refresh-token")
+
     async def test_pull_sync_data_refreshes_session_and_paginates_library(self) -> None:
         library_offsets: list[int] = []
 

--- a/docker-compose.omnibus.yml
+++ b/docker-compose.omnibus.yml
@@ -15,6 +15,10 @@ services:
       # ENABLE_REGISTRATIONS: "true"
       # REGISTRATION_MAX_ALLOWED_USERS: "0"  # 0 = unlimited
 
+      # ── Nuvio (optional) ───────────────────────────────────────────────────
+      # Set this to the anon/public key when using a self-hosted Nuvio backend.
+      # NUVIO_APP_ANON_KEY: ""
+
       # ── OIDC (optional) ─────────────────────────────────────────────────────
       # OIDC_ENABLED: "false"
       # OIDC_PROVIDER_NAME: SSO

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -37,6 +37,10 @@ services:
       # ENABLE_REGISTRATIONS: "true"
       # REGISTRATION_MAX_ALLOWED_USERS: "0"  # 0 = unlimited
 
+      # ── Nuvio (optional) ───────────────────────────────────────────────────
+      # Set this to the anon/public key when using a self-hosted Nuvio backend.
+      # NUVIO_APP_ANON_KEY: ""
+
       # ── OIDC (optional) ─────────────────────────────────────────────────────
       # OIDC_ENABLED: "false"
       # OIDC_PROVIDER_NAME: SSO

--- a/frontend/src/pages/connections.astro
+++ b/frontend/src/pages/connections.astro
@@ -93,7 +93,7 @@ const sonarrConfigured   = !!(settings.sonarr_url && settings.sonarr_token);
                     <div class="space-y-4">
                       <div class={`space-y-2 ${conn.type === "stremio" ? "hidden" : ""}`}>
                         <label class="block text-sm font-medium text-zinc-400">{conn.type === "nuvio" || conn.type === "arvio" ? "Cloud API URL" : "Server URL"}</label>
-                        <input type="url" class="conn-url-input w-full bg-zinc-950 border border-zinc-800 rounded-lg px-4 py-3 text-zinc-100 focus:outline-none focus:ring-2 focus:ring-blue-500 transition-all disabled:opacity-70" value={conn.url} data-conn-id={conn.id} disabled={conn.type === "nuvio" || conn.type === "arvio"} />
+                        <input type="url" class="conn-url-input w-full bg-zinc-950 border border-zinc-800 rounded-lg px-4 py-3 text-zinc-100 focus:outline-none focus:ring-2 focus:ring-blue-500 transition-all disabled:opacity-70" value={conn.url} data-conn-id={conn.id} disabled={conn.type === "arvio"} />
                       </div>
                       <div class={`space-y-2 ${conn.type === "stremio" ? "hidden" : ""}`}>
                         <label class="block text-sm font-medium text-zinc-400">{conn.type === "plex" ? "X-Plex-Token" : conn.type === "nuvio" || conn.type === "arvio" ? "Refresh Token" : "API Token"}</label>
@@ -4089,7 +4089,7 @@ const sonarrConfigured   = !!(settings.sonarr_url && settings.sonarr_token);
       if (urlInput) {
         if (isNuvio) {
           urlInput.value = 'https://api.nuvio.tv';
-          urlInput.disabled = true;
+          urlInput.disabled = false;
         } else if (isArvio) {
           urlInput.value = 'https://auth.arvio.tv/.netlify/functions';
           urlInput.disabled = true;


### PR DESCRIPTION
## Summary
- make the Nuvio Cloud API URL editable for new and existing connections
- support NUVIO_APP_ANON_KEY for self-hosted Supabase projects while retaining the official key by default
- document the environment variable in both Docker Compose examples and the Nuvio setup guide

Closes #209

## Validation
- 513 backend tests passed
- frontend production build passed