### PR TITLE
Feature: poll the Emby Sessions API to keep Now Playing progress live (#240)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -293,6 +293,78 @@ async def _manual_session_completer():
             print(f"Manual session completer error: {e}")
 
 
+async def _emby_progress_poller():
+    """Emby's webhook system has no progress event (only start/pause/unpause/
+    stop), so a PlaybackSession opened by an Emby webhook freezes at the last
+    event's position until the next one (#240). Jellyfin doesn't need this:
+    its Webhook plugin can send PlaybackProgress, which /webhook/jellyfin
+    already handles.
+
+    Polls the Emby Sessions API for connections with playback sync enabled and
+    refreshes the progress/state of sessions the webhooks already opened.
+    Sessions without a matching PlaybackSession row are ignored, so the
+    webhook flow stays the source of truth."""
+    import logging
+    log = logging.getLogger("uvicorn.error")
+
+    try:
+        import httpx
+        from datetime import datetime
+        from db import AsyncSessionLocal
+        from models.connections import MediaServerConnection
+    except Exception as e:
+        log.error(f"Emby progress poller: failed to import dependencies: {e}")
+        return
+
+    POLL_INTERVAL = 30
+    log.info("Emby progress poller: started")
+
+    while True:
+        await asyncio.sleep(POLL_INTERVAL)
+        try:
+            async with AsyncSessionLocal() as db:
+                conns = (await db.execute(
+                    select(MediaServerConnection).where(
+                        MediaServerConnection.type == "emby",
+                        MediaServerConnection.sync_playback.is_(True),
+                    )
+                )).scalars().all()
+                changed = False
+                for conn in conns:
+                    try:
+                        async with httpx.AsyncClient(timeout=10.0) as client:
+                            resp = await client.get(
+                                f"{conn.url.rstrip('/')}/Sessions",
+                                headers={"X-Emby-Token": conn.token},
+                            )
+                            resp.raise_for_status()
+                            sessions = resp.json()
+                    except Exception:
+                        continue
+                    for s in sessions:
+                        item = s.get("NowPlayingItem") or {}
+                        play_state = s.get("PlayState") or {}
+                        runtime = item.get("RunTimeTicks") or 0
+                        position = play_state.get("PositionTicks") or 0
+                        if not runtime or not position:
+                            continue
+                        key = f"emby:{conn.user_id}:{s.get('Id')}"
+                        row = (await db.execute(
+                            select(PlaybackSession).where(PlaybackSession.session_key == key)
+                        )).scalar_one_or_none()
+                        if not row:
+                            continue
+                        row.progress_percent = round(position / runtime, 4)
+                        row.progress_seconds = int(position / 10_000_000)
+                        row.state = "paused" if play_state.get("IsPaused") else "playing"
+                        row.updated_at = datetime.utcnow()
+                        changed = True
+                if changed:
+                    await db.commit()
+        except Exception as e:
+            log.error(f"Emby progress poller: {e}")
+
+
 async def _watchlist_poller():
     import logging
     log = logging.getLogger("uvicorn.error")
@@ -452,12 +524,14 @@ async def lifespan(app: FastAPI):
     scheduler_task = asyncio.create_task(_auto_sync_scheduler())
     watchlist_task = asyncio.create_task(_watchlist_poller())
     manual_session_task = asyncio.create_task(_manual_session_completer())
+    emby_progress_task = asyncio.create_task(_emby_progress_poller())
 
     yield
 
     scheduler_task.cancel()
     watchlist_task.cancel()
     manual_session_task.cancel()
+    emby_progress_task.cancel()
     try:
         await scheduler_task
     except asyncio.CancelledError:
@@ -468,6 +542,10 @@ async def lifespan(app: FastAPI):
         pass
     try:
         await manual_session_task
+    except asyncio.CancelledError:
+        pass
+    try:
+        await emby_progress_task
     except asyncio.CancelledError:
         pass
 


### PR DESCRIPTION
Fixes #240. Emby's webhook system has no progress event (only start/pause/unpause/stop), so the Now Playing bar freezes at the last event's position. Jellyfin doesn't have this problem: its Webhook plugin can send `PlaybackProgress`, which the Jellyfin webhook handler already processes.

This adds a small background poller next to the existing ones in `main.py` (`_watchlist_poller`, `_manual_session_completer`): every 30 seconds it queries the Emby Sessions API (`GET /Sessions`, `X-Emby-Token`) for Emby connections with playback sync enabled, and updates progress/state on `PlaybackSession` rows that the webhooks already opened (matched on the existing `emby:{user_id}:{session_id}` key). Sessions without a matching row are ignored, so the webhook flow stays the source of truth; if there are no Emby connections the loop is effectively a no-op. Errors are logged and never break the loop.

Running on my own instance for a few days now; the Now Playing bar tracks Emby playback smoothly.
