### PR TITLE
Feature: most watched titles, networks and people on the stats page (#124)

### DIFF
--- a/backend/core/credits.py
+++ b/backend/core/credits.py
@@ -1,0 +1,208 @@
+"""Background TMDB credits import and people/studio stat aggregation.
+
+Backs the "Most Watched Actors" / "Favorite Directors" / "Favorite Writers" /
+"Favorite Studios" groups on the profile stats page (#124). Credits are the
+same for every user, so they live in one instance-wide title_credits table,
+refreshed in the background at most once per TTL. The stats page triggers the
+backfill on view (own profile only) and the sections simply stay hidden until
+data is available.
+"""
+
+import asyncio
+from collections import defaultdict
+from datetime import datetime, timedelta
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from models.base import MediaType
+from models.events import WatchEvent
+from models.media import Media
+from models.show import Show
+from models.title_credits import TitleCredits
+
+CREDITS_TTL = timedelta(days=7)
+FETCH_CONCURRENCY = 8
+
+# TMDB crew jobs that count as "writer" for the stats.
+WRITER_JOBS = {"Writer", "Screenplay", "Story", "Teleplay"}
+
+_importing = False
+
+
+def _people(raw: list, jobs: set | None = None, limit: int | None = None) -> list[dict]:
+    """Reduce a TMDB cast/crew/company list to unique {id, name} pairs."""
+    out, seen = [], set()
+    for p in raw or []:
+        if jobs is not None and p.get("job") not in jobs:
+            continue
+        pid = p.get("id")
+        if pid is None or pid in seen:
+            continue
+        seen.add(pid)
+        out.append({"id": pid, "name": p.get("name")})
+        if limit and len(out) >= limit:
+            break
+    return out
+
+
+async def _import_credits(api_key: str) -> None:
+    """Fetch cast/crew/studios for every watched movie/show missing from
+    title_credits (or older than the TTL). Own DB session; runs in background.
+    get_movie/get_show already append credits, so this costs one TMDB call per
+    title and nothing extra per user."""
+    from core import tmdb as tmdb_client
+    from db import engine
+
+    maker = async_sessionmaker(engine, expire_on_commit=False)
+    async with maker() as db:
+        movie_rows = (await db.execute(
+            select(Media.tmdb_id).distinct()
+            .join(WatchEvent, WatchEvent.media_id == Media.id)
+            .where(Media.media_type == MediaType.movie, Media.tmdb_id.isnot(None))
+        )).all()
+        show_rows = (await db.execute(
+            select(Show.tmdb_id).distinct()
+            .join(Media, Media.show_id == Show.id)
+            .join(WatchEvent, WatchEvent.media_id == Media.id)
+            .where(Show.tmdb_id.isnot(None))
+        )).all()
+        wanted = [("movie", r[0]) for r in movie_rows] + [("series", r[0]) for r in show_rows]
+
+        existing = {
+            (mt, tid): fetched
+            for tid, mt, fetched in (await db.execute(
+                select(TitleCredits.tmdb_id, TitleCredits.media_type, TitleCredits.fetched_at)
+            )).all()
+        }
+        cutoff = datetime.utcnow() - CREDITS_TTL
+        todo = [(mt, tid) for (mt, tid) in wanted
+                if (mt, tid) not in existing or existing[(mt, tid)] < cutoff]
+        if not todo:
+            return
+
+        sem = asyncio.Semaphore(FETCH_CONCURRENCY)
+
+        async def _one(mt: str, tid: int):
+            async with sem:
+                try:
+                    if mt == "movie":
+                        data = await tmdb_client.get_movie(tid, api_key=api_key)
+                    else:
+                        data = await tmdb_client.get_show(tid, api_key=api_key)
+                except Exception:
+                    return None
+                credits = data.get("credits") or {}
+                cast = _people(credits.get("cast"), limit=10)
+                directors = _people(credits.get("crew"), jobs={"Director"})
+                writers = _people(credits.get("crew"), jobs=WRITER_JOBS)
+                if mt == "series" and not writers:
+                    writers = _people(data.get("created_by"))
+                studios = _people(data.get("production_companies"))
+                return mt, tid, cast, directors, writers, studios
+
+        results = await asyncio.gather(*[_one(mt, tid) for mt, tid in todo])
+        for res in results:
+            if not res:
+                continue
+            mt, tid, cast, directors, writers, studios = res
+            row = (await db.execute(
+                select(TitleCredits).where(TitleCredits.tmdb_id == tid, TitleCredits.media_type == mt)
+            )).scalars().first()
+            if row:
+                row.cast, row.directors, row.writers, row.studios = cast, directors, writers, studios
+                row.fetched_at = datetime.utcnow()
+            else:
+                db.add(TitleCredits(tmdb_id=tid, media_type=mt, cast=cast,
+                                    directors=directors, writers=writers, studios=studios))
+        await db.commit()
+
+
+async def _background_import(api_key: str) -> None:
+    global _importing
+    if _importing:
+        return
+    _importing = True
+    try:
+        await _import_credits(api_key)
+    except Exception as e:
+        print(f"Credits import failed: {e}")
+    finally:
+        _importing = False
+
+
+async def maybe_backfill_credits(db: AsyncSession, user_id: int) -> None:
+    """Kick off the credits backfill in the background when the table is empty
+    or stale. Non-blocking: the stats page fills the people/studio groups on
+    the next load once the import finishes."""
+    if _importing:
+        return
+    newest = (await db.execute(select(func.max(TitleCredits.fetched_at)))).scalar_one_or_none()
+    if newest and (datetime.utcnow() - newest) < CREDITS_TTL:
+        return
+    from routers.media import check_tmdb_key, get_user_tmdb_key
+
+    api_key = await get_user_tmdb_key(db, user_id)
+    if check_tmdb_key(api_key):
+        asyncio.create_task(_background_import(api_key))
+
+
+async def credits_stats(db: AsyncSession, user_id: int, date_filters: list) -> dict:
+    """Aggregate watched titles' cast/crew/studios into ranked lists. Each
+    title contributes its people once; ranked by distinct titles then plays.
+    date_filters are the same WatchEvent filters the stats endpoint uses."""
+    rows = (await db.execute(
+        select(
+            Media.media_type, Media.tmdb_id, Show.tmdb_id.label("show_tmdb"),
+            func.count(WatchEvent.id).label("plays"),
+        )
+        .join(WatchEvent, WatchEvent.media_id == Media.id)
+        .outerjoin(Show, Media.show_id == Show.id)
+        .where(WatchEvent.user_id == user_id, *date_filters)
+        .group_by(Media.media_type, Media.tmdb_id, Show.tmdb_id)
+    )).all()
+
+    # Weight per (media_type, tmdb): a movie by its own tmdb, an episode by its show.
+    weight: dict[tuple, int] = defaultdict(int)
+    for media_type, tmdb_id, show_tmdb, plays in rows:
+        if media_type == MediaType.movie and tmdb_id:
+            weight[("movie", tmdb_id)] += plays
+        elif media_type == MediaType.episode and show_tmdb:
+            weight[("series", show_tmdb)] += plays
+    empty = {"actors": [], "directors": [], "writers": [], "studios": []}
+    if not weight:
+        return empty
+
+    credits = (await db.execute(select(TitleCredits))).scalars().all()
+    by_key = {(c.media_type, c.tmdb_id): c for c in credits}
+
+    buckets = {"actors": {}, "directors": {}, "writers": {}, "studios": {}}
+
+    def _add(bucket: str, person: dict, plays: int):
+        pid = person.get("id")
+        if pid is None:
+            return
+        e = buckets[bucket].setdefault(pid, {"name": person.get("name"), "titles": 0, "plays": 0})
+        e["titles"] += 1
+        e["plays"] += plays
+
+    for key, plays in weight.items():
+        c = by_key.get(key)
+        if not c:
+            continue
+        for p in c.cast or []:
+            _add("actors", p, plays)
+        for p in c.directors or []:
+            _add("directors", p, plays)
+        for p in c.writers or []:
+            _add("writers", p, plays)
+        for p in c.studios or []:
+            _add("studios", p, plays)
+
+    def _top(bucket: str, limit: int = 15) -> list[dict]:
+        return sorted(
+            ({"id": pid, **v} for pid, v in buckets[bucket].items()),
+            key=lambda x: (x["titles"], x["plays"]), reverse=True,
+        )[:limit]
+
+    return {k: _top(k) for k in buckets}

--- a/backend/migrations/versions/9f3e51c7ab24_add_title_credits.py
+++ b/backend/migrations/versions/9f3e51c7ab24_add_title_credits.py
@@ -1,0 +1,43 @@
+"""add title_credits for people/studio stats
+
+Revision ID: 9f3e51c7ab24
+Revises: b2c3d4e5f6a8
+Create Date: 2026-08-16
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+
+revision = "9f3e51c7ab24"
+down_revision = "b2c3d4e5f6a8"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "title_credits",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("tmdb_id", sa.Integer(), nullable=False),
+        sa.Column("media_type", sa.String(length=16), nullable=False),
+        sa.Column("cast", JSONB(), nullable=False),
+        sa.Column("directors", JSONB(), nullable=False),
+        sa.Column("writers", JSONB(), nullable=False),
+        sa.Column("studios", JSONB(), nullable=False),
+        sa.Column("fetched_at", sa.DateTime(), server_default=sa.text("now()"), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("tmdb_id", "media_type", name="uq_title_credits_title"),
+    )
+    op.create_index(
+        op.f("ix_title_credits_tmdb_id"),
+        "title_credits",
+        ["tmdb_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_title_credits_tmdb_id"), table_name="title_credits")
+    op.drop_table("title_credits")

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -26,6 +26,7 @@ from .media_translation import MediaTranslation
 from .show_translation import ShowTranslation
 from .episode_order import EpisodeOrderMapping, UserShowEpisodeOrder
 from .rewatch import ShowRewatch, RewatchProgress
+from .title_credits import TitleCredits
 
 __all__ = [
     "Base",

--- a/backend/models/title_credits.py
+++ b/backend/models/title_credits.py
@@ -1,0 +1,29 @@
+from datetime import datetime
+
+from sqlalchemy import DateTime, Integer, String, UniqueConstraint
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from .base import Base
+
+
+class TitleCredits(Base):
+    """Cast/crew/studios per title, fetched from TMDB.
+
+    Feeds the people/studio stats on the profile stats page (#124). One row
+    per (tmdb_id, media_type), instance-wide (not per user) since credits are
+    the same for everyone. Lists are stored as [{"id": int, "name": str}].
+    Refreshed in the background at most once per TTL (see core/credits.py).
+    """
+
+    __tablename__ = "title_credits"
+    __table_args__ = (UniqueConstraint("tmdb_id", "media_type", name="uq_title_credits_title"),)
+
+    id         : Mapped[int]      = mapped_column(Integer, primary_key=True)
+    tmdb_id    : Mapped[int]      = mapped_column(Integer, nullable=False, index=True)
+    media_type : Mapped[str]      = mapped_column(String(16), nullable=False)  # movie | series
+    cast       : Mapped[list]     = mapped_column(JSONB, nullable=False, default=list)
+    directors  : Mapped[list]     = mapped_column(JSONB, nullable=False, default=list)
+    writers    : Mapped[list]     = mapped_column(JSONB, nullable=False, default=list)
+    studios    : Mapped[list]     = mapped_column(JSONB, nullable=False, default=list)
+    fetched_at : Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)

--- a/backend/routers/profile.py
+++ b/backend/routers/profile.py
@@ -12,6 +12,7 @@ from typing import Optional
 
 from db import get_db, AsyncSessionLocal
 from core import tmdb as tmdb_client
+from core.credits import credits_stats, maybe_backfill_credits
 from core.translations import upsert_media_translation, upsert_show_translation
 
 from dependencies import get_current_user, get_current_user_or_api_key, get_optional_user_or_api_key
@@ -1168,6 +1169,83 @@ async def get_user_stats(
     )
     shows_watched_collected = watched_shows_collected_q.scalar_one()
 
+    # ── Top titles, networks and people (#124) ──────────────────────────────
+    # Own-profile views kick the TMDB credits backfill (background, throttled
+    # by a TTL in core/credits.py); the people/studio groups on the page stay
+    # hidden until credits data exists.
+    if current_user and current_user.id == user_id:
+        await maybe_backfill_credits(db, user_id)
+
+    top_rows = (await db.execute(
+        select(
+            Media.media_type, Media.id, Media.title, Media.poster_path,
+            Media.tmdb_id, Media.show_id, effective_runtime.label("runtime"),
+        )
+        .join(WatchEvent, WatchEvent.media_id == Media.id)
+        .where(
+            WatchEvent.user_id == user_id,
+            Media.media_type.in_(["movie", "episode"]),
+            *date_filters,
+        )
+    )).all()
+
+    per_show: dict[int, dict] = defaultdict(lambda: {"plays": 0, "minutes": 0, "episodes": set()})
+    per_movie: dict[int, dict] = {}
+    for media_type, mid, m_title, m_poster, m_tmdb_id, show_id, runtime in top_rows:
+        minutes = runtime or 0
+        if media_type == "episode" and show_id:
+            s = per_show[show_id]
+            s["plays"] += 1
+            s["minutes"] += minutes
+            s["episodes"].add(mid)
+        elif media_type == "movie":
+            m = per_movie.setdefault(mid, {
+                "title": m_title, "poster_path": m_poster, "tmdb_id": m_tmdb_id,
+                "plays": 0, "minutes": 0,
+            })
+            m["plays"] += 1
+            m["minutes"] += minutes
+
+    show_meta: dict[int, dict] = {}
+    network_stats: dict[str, dict] = defaultdict(lambda: {"plays": 0, "minutes": 0, "titles": set()})
+    network_logos: dict[str, str] = {}
+    if per_show:
+        top_show_rows = (await db.execute(
+            select(ShowModel).where(ShowModel.id.in_(per_show.keys()))
+        )).scalars().all()
+        for sh in top_show_rows:
+            show_meta[sh.id] = {
+                "title": sh.title, "poster_path": sh.poster_path,
+                "tmdb_id": sh.tmdb_id, "tvdb_id": sh.tvdb_id,
+            }
+            for net in (sh.tmdb_data or {}).get("networks") or []:
+                # Networks appear in tmdb_data both as TMDB's {"name", "logo_path"}
+                # dicts and as plain strings, depending on which sync path stored it.
+                name = net.get("name") if isinstance(net, dict) else (net if isinstance(net, str) else None)
+                if not name:
+                    continue
+                st = network_stats[name]
+                st["plays"] += per_show[sh.id]["plays"]
+                st["minutes"] += per_show[sh.id]["minutes"]
+                st["titles"].add(sh.id)
+                if isinstance(net, dict) and net.get("logo_path"):
+                    network_logos[name] = net["logo_path"]
+
+    top_shows = sorted(
+        ({**show_meta.get(sid, {"title": None, "poster_path": None, "tmdb_id": None, "tvdb_id": None}),
+          "plays": s["plays"], "minutes": s["minutes"], "episodes": len(s["episodes"])}
+         for sid, s in per_show.items()),
+        key=lambda x: x["minutes"], reverse=True,
+    )[:12]
+    top_movies = sorted(per_movie.values(), key=lambda x: (x["plays"], x["minutes"]), reverse=True)[:12]
+    top_networks = sorted(
+        ({"name": name, "plays": v["plays"], "minutes": v["minutes"],
+          "titles": len(v["titles"]), "logo_path": network_logos.get(name)}
+         for name, v in network_stats.items()),
+        key=lambda x: (x["plays"], x["titles"]), reverse=True,
+    )[:15]
+    top_people = await credits_stats(db, user_id, date_filters)
+
     return {
         # Watching
         "granularity": "day" if use_daily else "month",
@@ -1193,4 +1271,9 @@ async def get_user_stats(
         "movies_unwatched_collected": unwatched_movies,
         "shows_watched_collected": shows_watched_collected,
         "shows_unwatched_collected": max(shows_collected - shows_watched_collected, 0),
+        # Top titles & people (#124)
+        "top_shows": top_shows,
+        "top_movies": top_movies,
+        "top_networks": top_networks,
+        "top_people": top_people,
     }

--- a/frontend/src/pages/stats/[id].astro
+++ b/frontend/src/pages/stats/[id].astro
@@ -153,6 +153,41 @@ const isOwnStats = currentUser && String(currentUser.id) === String(id);
         </div>
       </section>
 
+      <!-- Most Watched: top titles, networks and people (#124) -->
+      <section id="top-stats" style="display:none">
+        <h2 class="section-headline mb-6">Most Watched</h2>
+        <div class="space-y-6">
+          <div class="bg-zinc-900/60 border border-zinc-800 rounded-2xl p-6" id="top-shows-card">
+            <h3 class="group-label mb-5">Top Shows</h3>
+            <div id="top-shows" class="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 gap-4"></div>
+          </div>
+          <div class="bg-zinc-900/60 border border-zinc-800 rounded-2xl p-6" id="top-movies-card">
+            <h3 class="group-label mb-5">Top Movies</h3>
+            <div id="top-movies" class="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 gap-4"></div>
+          </div>
+          <div class="bg-zinc-900/60 border border-zinc-800 rounded-2xl p-6" id="top-networks-card">
+            <h3 class="group-label mb-5">Favourite Networks</h3>
+            <div id="top-networks" class="flex flex-wrap gap-3"></div>
+          </div>
+          <div class="bg-zinc-900/60 border border-zinc-800 rounded-2xl p-6" id="top-actors-card">
+            <h3 class="group-label mb-5">Most Watched Actors</h3>
+            <div id="top-actors" class="flex flex-wrap gap-2"></div>
+          </div>
+          <div class="bg-zinc-900/60 border border-zinc-800 rounded-2xl p-6" id="top-directors-card">
+            <h3 class="group-label mb-5">Favourite Directors</h3>
+            <div id="top-directors" class="flex flex-wrap gap-2"></div>
+          </div>
+          <div class="bg-zinc-900/60 border border-zinc-800 rounded-2xl p-6" id="top-writers-card">
+            <h3 class="group-label mb-5">Favourite Writers</h3>
+            <div id="top-writers" class="flex flex-wrap gap-2"></div>
+          </div>
+          <div class="bg-zinc-900/60 border border-zinc-800 rounded-2xl p-6" id="top-studios-card">
+            <h3 class="group-label mb-5">Favourite Studios</h3>
+            <div id="top-studios" class="flex flex-wrap gap-2"></div>
+          </div>
+        </div>
+      </section>
+
       <!-- Collection Statistics -->
       <section>
         <h2 class="section-headline mb-6">Collection</h2>
@@ -657,7 +692,56 @@ const isOwnStats = currentUser && String(currentUser.id) === String(id);
         donut(mwPct,     'rgba(34,197,94,0.85)',  'rgba(63,63,70,0.6)',   'Movies Watched',  'Watched', 'Unwatched', data.movies_watched_collected, data.movies_unwatched_collected) +
         donut(swPct,     'rgba(34,197,94,0.85)',  'rgba(63,63,70,0.6)',   'Shows Watched',   'Watched', 'Unwatched', data.shows_watched_collected,  data.shows_unwatched_collected);
     }
+    renderTopStats(data);
   } // end renderStats
+
+  // ── Most Watched: top titles, networks and people (#124) ──────────────────
+  function renderTopStats(data) {
+    const section = document.getElementById('top-stats');
+    if (!section) return;
+    const esc = (s) => String(s ?? '').replace(/[&<>"]/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c]));
+    const fmtH = (min) => { const h = Math.floor(min / 60); const m = min % 60; return h > 0 ? (m > 0 ? `${h}h ${m}m` : `${h}h`) : `${m}m`; };
+    const card = (id, has) => { const el = document.getElementById(id + '-card'); if (el) el.style.display = has ? '' : 'none'; return has; };
+
+    const posters = (items) => (items || []).filter(it => it.title).map(it => `
+      <a href="/media/${it.episodes != null ? 'series' : 'movie'}/${it.tmdb_id}" class="group block">
+        <div class="aspect-[2/3] rounded-xl overflow-hidden bg-zinc-800">
+          ${it.poster_path ? `<img src="${esc(it.poster_path)}" alt="${esc(it.title)}" loading="lazy" class="w-full h-full object-cover group-hover:scale-105 transition-transform">` : ''}
+        </div>
+        <div class="text-xs text-zinc-300 font-semibold mt-1.5 truncate">${esc(it.title)}</div>
+        <div class="text-[11px] text-zinc-500">${it.plays} play${it.plays === 1 ? '' : 's'} · ${fmtH(it.minutes || 0)}</div>
+      </a>`).join('');
+    document.getElementById('top-shows').innerHTML = posters(data.top_shows);
+    document.getElementById('top-movies').innerHTML = posters(data.top_movies);
+
+    document.getElementById('top-networks').innerHTML = (data.top_networks || []).map(n => `
+      <div class="flex items-center gap-2 bg-white/90 rounded-lg px-3 py-2" title="${esc(n.name)} · ${n.plays} plays">
+        ${n.logo_path ? `<img src="https://image.tmdb.org/t/p/w92${esc(n.logo_path)}" alt="${esc(n.name)}" class="h-5 object-contain">` : `<span class="text-sm font-bold text-zinc-800">${esc(n.name)}</span>`}
+        <span class="text-xs font-semibold text-zinc-500">${n.plays}</span>
+      </div>`).join('');
+
+    const chips = (items) => (items || []).map(p => `
+      <span class="inline-flex items-baseline gap-1.5 bg-zinc-900 border border-zinc-800 rounded-lg px-3 py-1.5" title="${esc(p.name)} · ${p.titles} title${p.titles === 1 ? '' : 's'} · ${p.plays} play${p.plays === 1 ? '' : 's'}">
+        <span class="text-sm font-semibold text-zinc-200">${esc(p.name)}</span>
+        <span class="text-[11px] text-zinc-500">${p.titles}×</span>
+      </span>`).join('');
+    const people = data.top_people || {};
+    document.getElementById('top-actors').innerHTML = chips(people.actors);
+    document.getElementById('top-directors').innerHTML = chips(people.directors);
+    document.getElementById('top-writers').innerHTML = chips(people.writers);
+    document.getElementById('top-studios').innerHTML = chips(people.studios);
+
+    const any = [
+      card('top-shows', (data.top_shows || []).length > 0),
+      card('top-movies', (data.top_movies || []).length > 0),
+      card('top-networks', (data.top_networks || []).length > 0),
+      card('top-actors', (people.actors || []).length > 0),
+      card('top-directors', (people.directors || []).length > 0),
+      card('top-writers', (people.writers || []).length > 0),
+      card('top-studios', (people.studios || []).length > 0),
+    ].some(Boolean);
+    section.style.display = any ? '' : 'none';
+  }
 
   // ── Fetch ──────────────────────────────────────────────────────────────────
   async function loadStats(since, until) {


### PR DESCRIPTION
Implements a chunk of #124: the stats page gets a "Most Watched" section between Watching and Collection, and it follows the existing period/date filter like everything else on the page.

**New groups** (each hidden when empty):
- **Top Shows** and **Top Movies** — poster grids ranked by watch time / plays, linking to the detail pages
- **Favourite Networks** — network chips with TMDB logos, aggregated from the shows' `tmdb_data`
- **Most Watched Actors / Favourite Directors / Favourite Writers / Favourite Studios** — ranked by distinct titles watched, then plays; each title contributes its people once so long shows don't drown everything

**How the people stats work:** a new instance-wide `title_credits` table (one row per TMDB title; alembic migration included) caches cast (top 10), directors, writers (Writer/Screenplay/Story/Teleplay, falling back to `created_by` for shows) and production companies. `get_movie`/`get_show` already append `credits`, so the backfill costs one TMDB call per watched title, runs in the background (concurrency 8), and refreshes at most weekly. It's triggered from the stats endpoint on own-profile views only; the groups simply stay hidden until data exists, no UI blocking.

Everything is computed inside the existing `GET /profile/{user_id}/stats` with the same `date_filters`, so no new endpoints and the access checks stay as they are.
