### PR TITLE
Feature: upcoming episodes calendar (#194)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -9,7 +9,7 @@ from contextlib import asynccontextmanager
 from sqlalchemy.ext.asyncio import AsyncSession
 from db import engine, Base
 import models # noqa: F401
-from routers import webhooks, media, history, ratings, sync, shows, auth, lists, oidc, profile, trakt, simkl, mdblist, bingebase, comments, admin, compat, export, yamtrack
+from routers import webhooks, media, history, ratings, sync, shows, auth, lists, oidc, profile, trakt, simkl, mdblist, bingebase, comments, admin, compat, export, yamtrack, calendar
 
 from core.access_log import install as install_access_log_redaction
 install_access_log_redaction()
@@ -526,6 +526,7 @@ app.include_router(comments.router, prefix="/comments", tags=["comments"])
 app.include_router(admin.router, prefix="/admin", tags=["admin"])
 app.include_router(export.router, prefix="/export", tags=["export"])
 app.include_router(yamtrack.router, prefix="/yamtrack", tags=["yamtrack"])
+app.include_router(calendar.router, prefix="/calendar", tags=["calendar"])
 app.include_router(compat.router, tags=["compat"])
 
 @app.get("/health")

--- a/backend/migrations/versions/4d7a92e8f0c5_add_user_calendar_cache.py
+++ b/backend/migrations/versions/4d7a92e8f0c5_add_user_calendar_cache.py
@@ -1,0 +1,32 @@
+"""add user_calendar_cache for the episode calendar
+
+Revision ID: 4d7a92e8f0c5
+Revises: b2c3d4e5f6a8
+Create Date: 2026-08-16
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+
+revision = "4d7a92e8f0c5"
+down_revision = "b2c3d4e5f6a8"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "user_calendar_cache",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("computed_at", sa.DateTime(), server_default=sa.text("now()"), nullable=False),
+        sa.Column("payload", JSONB(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("user_id", name="uq_user_calendar_cache_user"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("user_calendar_cache")

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -26,6 +26,7 @@ from .media_translation import MediaTranslation
 from .show_translation import ShowTranslation
 from .episode_order import EpisodeOrderMapping, UserShowEpisodeOrder
 from .rewatch import ShowRewatch, RewatchProgress
+from .calendar_cache import UserCalendarCache
 
 __all__ = [
     "Base",

--- a/backend/models/calendar_cache.py
+++ b/backend/models/calendar_cache.py
@@ -1,0 +1,24 @@
+from datetime import datetime
+
+from sqlalchemy import DateTime, Integer
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from .base import Base
+
+
+class UserCalendarCache(Base):
+    """Cached episode calendar per user (#194).
+
+    Building the calendar costs one TMDB call per followed show, so the
+    computed payload is cached whole (schema-less JSON, one row per user) and
+    recomputed at most once per TTL or on explicit refresh — see
+    routers/calendar.py.
+    """
+
+    __tablename__ = "user_calendar_cache"
+
+    id          : Mapped[int]      = mapped_column(Integer, primary_key=True)
+    user_id     : Mapped[int]      = mapped_column(Integer, nullable=False, unique=True)
+    computed_at : Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+    payload     : Mapped[dict]     = mapped_column(JSONB, nullable=False, default=dict)

--- a/backend/routers/calendar.py
+++ b/backend/routers/calendar.py
@@ -1,0 +1,188 @@
+"""Episode calendar: recently aired and upcoming episodes for the user's
+shows (#194).
+
+Built from one TMDB base-details call per followed, still-running show
+(next/last_episode_to_air), which is why the result is cached whole in
+user_calendar_cache and recomputed at most once per TTL or on explicit
+refresh. `cached_only=true` (used by pages that must render instantly) never
+waits on TMDB: it serves whatever cache exists and warms it in the
+background otherwise.
+"""
+
+import asyncio
+from datetime import datetime, timedelta
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy import or_, select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from db import get_db
+from dependencies import get_current_user_or_api_key
+from models.base import MediaType
+from models.calendar_cache import UserCalendarCache
+from models.collection import Collection
+from models.media import Media
+from models.show import Show
+from models.users import User
+
+router = APIRouter()
+
+CALENDAR_TTL = timedelta(hours=24)
+CALENDAR_SCHEMA = 1
+AIRED_LOOKBACK_DAYS = 14
+FETCH_CONCURRENCY = 8
+
+_computing: set[int] = set()
+
+
+async def compute_calendar(db: AsyncSession, user_id: int) -> dict:
+    """Recently aired and upcoming episodes for the user's collected shows."""
+    from core import tmdb as tmdb_client
+    from routers.media import check_tmdb_key, get_user_tmdb_key
+
+    episode_show_ids = (
+        select(Media.show_id)
+        .join(Collection, Collection.media_id == Media.id)
+        .where(
+            Collection.user_id == user_id,
+            Media.show_id.isnot(None),
+            Media.media_type == MediaType.episode,
+        )
+        .distinct()
+    )
+    direct_series_tmdb_ids = (
+        select(Media.tmdb_id)
+        .join(Collection, Collection.media_id == Media.id)
+        .where(
+            Collection.user_id == user_id,
+            Media.media_type == MediaType.series,
+            Media.tmdb_id.isnot(None),
+        )
+        .distinct()
+    )
+    shows = (
+        await db.execute(
+            select(Show).where(
+                or_(
+                    Show.id.in_(episode_show_ids),
+                    Show.tmdb_id.in_(direct_series_tmdb_ids),
+                )
+            )
+        )
+    ).scalars().all()
+
+    candidates = [
+        s for s in shows
+        if s.tmdb_id and (s.status or "") not in ("Ended", "Canceled")
+    ]
+
+    now = datetime.utcnow()
+    entries: list[dict] = []
+    api_key = await get_user_tmdb_key(db, user_id)
+    if check_tmdb_key(api_key) and candidates:
+        sem = asyncio.Semaphore(FETCH_CONCURRENCY)
+
+        async def _fetch(s: Show):
+            async with sem:
+                try:
+                    d = await tmdb_client.get_show_light(s.tmdb_id, api_key=api_key)
+                except Exception:
+                    return
+                for kind, ep in (("aired", d.get("last_episode_to_air")), ("upcoming", d.get("next_episode_to_air"))):
+                    if not ep or not ep.get("air_date"):
+                        continue
+                    entries.append({
+                        "air_date": ep["air_date"],
+                        "kind": kind,
+                        "show_tmdb_id": s.tmdb_id,
+                        "show_tvdb_id": s.tvdb_id,
+                        "show_title": s.title,
+                        "poster_path": s.poster_path,
+                        "season": ep.get("season_number"),
+                        "episode": ep.get("episode_number"),
+                        "episode_name": ep.get("name"),
+                    })
+
+        await asyncio.gather(*(_fetch(s) for s in candidates))
+
+    today = now.date().isoformat()
+    aired_cutoff = (now - timedelta(days=AIRED_LOOKBACK_DAYS)).date().isoformat()
+    entries = [
+        e for e in entries
+        if (e["kind"] == "upcoming" and e["air_date"] >= today)
+        or (e["kind"] == "aired" and aired_cutoff <= e["air_date"])
+    ]
+    entries.sort(key=lambda e: (e["air_date"], e["show_title"] or ""))
+    return {
+        "schema": CALENDAR_SCHEMA,
+        "generated_at": now.isoformat(),
+        "shows_checked": len(candidates),
+        "entries": entries,
+    }
+
+
+async def _load_or_compute(db: AsyncSession, user_id: int, force: bool) -> dict:
+    row = (
+        await db.execute(select(UserCalendarCache).where(UserCalendarCache.user_id == user_id))
+    ).scalars().first()
+    if (
+        row and not force
+        and (datetime.utcnow() - row.computed_at) < CALENDAR_TTL
+        and (row.payload or {}).get("schema") == CALENDAR_SCHEMA
+    ):
+        return {"computed_at": row.computed_at.isoformat(), "cached": True, "calendar": row.payload}
+    payload = await compute_calendar(db, user_id)
+    if row:
+        row.payload = payload
+        row.computed_at = datetime.utcnow()
+    else:
+        row = UserCalendarCache(user_id=user_id, payload=payload, computed_at=datetime.utcnow())
+        db.add(row)
+    await db.commit()
+    return {"computed_at": row.computed_at.isoformat(), "cached": False, "calendar": payload}
+
+
+async def _background_compute(user_id: int) -> None:
+    """Warm the calendar cache without blocking the caller."""
+    if user_id in _computing:
+        return
+    _computing.add(user_id)
+    try:
+        from db import engine
+
+        maker = async_sessionmaker(engine, expire_on_commit=False)
+        async with maker() as bg_db:
+            await _load_or_compute(bg_db, user_id, force=False)
+    except Exception as e:
+        print(f"Calendar background compute failed: {e}")
+    finally:
+        _computing.discard(user_id)
+
+
+@router.get("")
+async def get_calendar(
+    cached_only: bool = Query(False),
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user_or_api_key),
+):
+    if cached_only:
+        row = (
+            await db.execute(select(UserCalendarCache).where(UserCalendarCache.user_id == current_user.id))
+        ).scalars().first()
+        if (
+            row
+            and (datetime.utcnow() - row.computed_at) < CALENDAR_TTL
+            and (row.payload or {}).get("schema") == CALENDAR_SCHEMA
+        ):
+            return {"computed_at": row.computed_at.isoformat(), "cached": True, "calendar": row.payload}
+        asyncio.create_task(_background_compute(current_user.id))
+        return {"computed_at": None, "cached": False, "calendar": {"entries": []}}
+    return await _load_or_compute(db, current_user.id, force=False)
+
+
+@router.post("/refresh")
+async def refresh_calendar(
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user_or_api_key),
+):
+    return await _load_or_compute(db, current_user.id, force=True)

--- a/frontend/src/layouts/Base.astro
+++ b/frontend/src/layouts/Base.astro
@@ -176,6 +176,7 @@ const bottomNavItem = (active: boolean) =>
               <div id="user-menu" class="hidden absolute top-full right-0 mt-2 w-48 z-50">
                 <div class="bg-zinc-900 border border-zinc-800 rounded-xl shadow-2xl p-2">
                   <a href="/discover" class="block px-3 py-2 text-zinc-400 hover:text-zinc-100 hover:bg-zinc-800 active:opacity-70 rounded-lg transition">Discover</a>
+                  <a href="/calendar" class="block px-3 py-2 text-zinc-400 hover:text-zinc-100 hover:bg-zinc-800 active:opacity-70 rounded-lg transition">Calendar</a>
                   <a href="/profile" class="block px-3 py-2 text-zinc-400 hover:text-zinc-100 hover:bg-zinc-800 active:opacity-70 rounded-lg transition">Profile</a>
                   <a href={`/stats/${user.id}`} class="block px-3 py-2 text-zinc-400 hover:text-zinc-100 hover:bg-zinc-800 active:opacity-70 rounded-lg transition">Statistics</a>
                   <a href="/user-settings" class="block px-3 py-2 text-zinc-400 hover:text-zinc-100 hover:bg-zinc-800 active:opacity-70 rounded-lg transition">Profile Settings</a>

--- a/frontend/src/pages/calendar.astro
+++ b/frontend/src/pages/calendar.astro
@@ -1,0 +1,126 @@
+---
+import Base from "../layouts/Base.astro";
+export const prerender = false;
+
+const { token } = Astro.locals;
+Astro.response.headers.set("Cache-Control", "no-store");
+---
+
+<Base title="Calendar">
+  <div class="mb-8 flex items-center justify-between gap-4">
+    <div>
+      <h1 class="page-title mb-2">Calendar</h1>
+      <p class="text-zinc-500">Upcoming episodes for your shows<span id="cal-meta"></span></p>
+    </div>
+    <button
+      id="cal-refresh-btn"
+      class="flex items-center gap-2 px-4 py-2 text-sm font-bold text-zinc-400 bg-zinc-900 border border-zinc-800 rounded-xl hover:border-zinc-600 hover:text-zinc-200 transition-all cursor-pointer shrink-0"
+    >
+      <svg id="cal-refresh-icon" xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M3 12a9 9 0 0 1 15-6.7L21 8"/><path d="M21 3v5h-5"/>
+        <path d="M21 12a9 9 0 0 1-15 6.7L3 16"/><path d="M3 21v-5h5"/>
+      </svg>
+      <span>Refresh</span>
+    </button>
+  </div>
+
+  <div id="cal-loading" class="py-20 text-center text-zinc-500">Checking air dates for your shows… (first time can take a minute)</div>
+  <div id="cal-error" class="hidden py-20 text-center text-zinc-500">Could not load the calendar.</div>
+  <div id="cal-body" class="hidden space-y-8"></div>
+</Base>
+
+<script define:vars={{ token }}>
+  const $ = (id) => document.getElementById(id);
+
+  function esc(s) {
+    if (s == null) return '';
+    return String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+  }
+
+  function dayLabel(iso) {
+    const today = new Date(); today.setHours(0, 0, 0, 0);
+    const d = new Date(iso + 'T00:00:00');
+    const diff = Math.round((d - today) / 86400000);
+    if (diff === 0) return 'Today';
+    if (diff === 1) return 'Tomorrow';
+    if (diff === -1) return 'Yesterday';
+    return d.toLocaleDateString(undefined, { weekday: 'long', day: 'numeric', month: 'long' });
+  }
+
+  function entryRow(e) {
+    const href = e.show_tmdb_id ? `/show/${e.show_tmdb_id}` : (e.show_tvdb_id ? `/show/tvdb/${e.show_tvdb_id}` : '#');
+    const sxe = e.season != null && e.episode != null
+      ? `S${String(e.season).padStart(2, '0')}E${String(e.episode).padStart(2, '0')}`
+      : '';
+    return `
+      <a href="${esc(href)}" class="flex items-center gap-4 p-3 bg-zinc-900 border border-zinc-800 rounded-xl hover:border-blue-500/50 transition-colors">
+        ${e.poster_path ? `<img src="${esc(e.poster_path)}" alt="" class="w-10 rounded-md object-cover shrink-0" loading="lazy" style="height:60px"/>`
+              : '<div class="w-10 shrink-0 text-2xl text-center opacity-30" style="height:60px;line-height:60px">📺</div>'}
+        <div class="min-w-0 flex-1">
+          <div class="font-bold text-zinc-100 truncate">${esc(e.show_title)}</div>
+          <div class="text-sm text-zinc-500 truncate">${sxe ? `<span class="font-bold text-blue-400">${sxe}</span> · ` : ''}${esc(e.episode_name || 'TBA')}</div>
+        </div>
+      </a>`;
+  }
+
+  function render(data) {
+    const cal = data.calendar || {};
+    const entries = cal.entries || [];
+    if (data.computed_at) {
+      $('cal-meta').textContent = ` · computed ${new Date(data.computed_at + 'Z').toLocaleString()}${data.cached ? ' (cached, max 24h old)' : ''}`;
+    }
+    const aired = entries.filter((e) => e.kind === 'aired');
+    const upcoming = entries.filter((e) => e.kind === 'upcoming');
+
+    const byDay = new Map();
+    for (const e of upcoming) {
+      if (!byDay.has(e.air_date)) byDay.set(e.air_date, []);
+      byDay.get(e.air_date).push(e);
+    }
+
+    const upcomingHtml = [...byDay.entries()].map(([day, list]) => `
+      <section>
+        <h2 class="text-sm font-bold uppercase tracking-widest text-zinc-400 mb-3">${esc(dayLabel(day))} <span class="text-zinc-600 normal-case tracking-normal font-medium">· ${esc(day)}</span></h2>
+        <div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-3">${list.map(entryRow).join('')}</div>
+      </section>`).join('');
+
+    const airedHtml = aired.length ? `
+      <details class="group">
+        <summary class="text-sm font-bold uppercase tracking-widest text-zinc-500 cursor-pointer hover:text-zinc-300 mb-3">Recently aired (last 14 days) — ${aired.length}</summary>
+        <div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-3 opacity-75">${aired.slice().reverse().map(entryRow).join('')}</div>
+      </details>` : '';
+
+    $('cal-body').innerHTML =
+      (upcomingHtml || '<p class="text-zinc-500 text-center py-10">No upcoming episodes found for your shows.</p>')
+      + airedHtml;
+    $('cal-loading').classList.add('hidden');
+    $('cal-error').classList.add('hidden');
+    $('cal-body').classList.remove('hidden');
+  }
+
+  async function load(refresh) {
+    try {
+      const res = await fetch(`/api/proxy/calendar${refresh ? '/refresh' : ''}`, {
+        method: refresh ? 'POST' : 'GET',
+        headers: { 'Authorization': `Bearer ${token}` },
+      });
+      if (!res.ok) throw new Error('failed');
+      render(await res.json());
+    } catch {
+      $('cal-loading').classList.add('hidden');
+      $('cal-body').classList.add('hidden');
+      $('cal-error').classList.remove('hidden');
+    }
+  }
+
+  $('cal-refresh-btn').addEventListener('click', async () => {
+    const icon = $('cal-refresh-icon');
+    icon.classList.add('animate-spin');
+    $('cal-refresh-btn').disabled = true;
+    await load(true);
+    icon.classList.remove('animate-spin');
+    $('cal-refresh-btn').disabled = false;
+  });
+
+  load(false);
+</script>


### PR DESCRIPTION
Fixes #194. Adds a Calendar page (linked from the user menu, next to Discover) showing upcoming episodes for the shows in the user's collection, grouped per day (Today / Tomorrow / weekday), plus a collapsed "Recently aired (last 14 days)" section for catching up.

**How it works:** one `get_show_light` TMDB call per followed, still-running show reads `next_episode_to_air` / `last_episode_to_air` (bounded concurrency of 8). Since that's a call per show, the computed payload is cached whole in a new `user_calendar_cache` table (alembic migration included, one JSONB row per user) with a 24h TTL and an explicit Refresh button on the page. A `cached_only=true` query mode never waits on TMDB — it serves whatever cache exists and warms it in the background — so the endpoint could also feed a future home-page "Upcoming" row (#196) without slowing the home page down.

Shows with status Ended/Canceled are skipped, and users without a TMDB key just get an empty calendar.

Note: the migration branches off the current alembic head (`b2c3d4e5f6a8`), same as my open #242 — whichever PR lands second needs its `down_revision` bumped to the other's revision id; happy to rebase whichever one is left.
