### PR TITLE
Fix: Explore cards ignore the configured Metadata Language (#235 follow-up)

### DIFF
--- a/backend/core/tmdb.py
+++ b/backend/core/tmdb.py
@@ -168,12 +168,18 @@ async def get_episode_external_ids(
     )
 
 
-async def get_trending_movies(time_window: str = "day", page: int = 1, api_key: str = None) -> dict:
-    return await _get(f"{TMDB_BASE}/trending/movie/{time_window}", headers=get_headers(api_key), params={"page": page})
+async def get_trending_movies(time_window: str = "day", page: int = 1, api_key: str = None, language: str | None = None) -> dict:
+    params: dict = {"page": page}
+    if language:
+        params["language"] = language
+    return await _get(f"{TMDB_BASE}/trending/movie/{time_window}", headers=get_headers(api_key), params=params)
 
 
-async def get_trending_shows(time_window: str = "day", page: int = 1, api_key: str = None) -> dict:
-    return await _get(f"{TMDB_BASE}/trending/tv/{time_window}", headers=get_headers(api_key), params={"page": page})
+async def get_trending_shows(time_window: str = "day", page: int = 1, api_key: str = None, language: str | None = None) -> dict:
+    params: dict = {"page": page}
+    if language:
+        params["language"] = language
+    return await _get(f"{TMDB_BASE}/trending/tv/{time_window}", headers=get_headers(api_key), params=params)
 
 
 async def get_show_light(tmdb_id: int, api_key: str = None, language: str | None = None) -> dict:
@@ -196,20 +202,32 @@ async def get_on_air_today(page: int = 1, api_key: str = None, timezone: str = "
     return await _get(f"{TMDB_BASE}/tv/airing_today", headers=get_headers(api_key), params={"page": page, "timezone": timezone})
 
 
-async def get_popular_movies(page: int = 1, api_key: str = None) -> dict:
-    return await _get(f"{TMDB_BASE}/movie/popular", headers=get_headers(api_key), params={"page": page})
+async def get_popular_movies(page: int = 1, api_key: str = None, language: str | None = None) -> dict:
+    params: dict = {"page": page}
+    if language:
+        params["language"] = language
+    return await _get(f"{TMDB_BASE}/movie/popular", headers=get_headers(api_key), params=params)
 
 
-async def get_top_rated_movies(page: int = 1, api_key: str = None) -> dict:
-    return await _get(f"{TMDB_BASE}/movie/top_rated", headers=get_headers(api_key), params={"page": page})
+async def get_top_rated_movies(page: int = 1, api_key: str = None, language: str | None = None) -> dict:
+    params: dict = {"page": page}
+    if language:
+        params["language"] = language
+    return await _get(f"{TMDB_BASE}/movie/top_rated", headers=get_headers(api_key), params=params)
 
 
-async def get_popular_shows(page: int = 1, api_key: str = None) -> dict:
-    return await _get(f"{TMDB_BASE}/tv/popular", headers=get_headers(api_key), params={"page": page})
+async def get_popular_shows(page: int = 1, api_key: str = None, language: str | None = None) -> dict:
+    params: dict = {"page": page}
+    if language:
+        params["language"] = language
+    return await _get(f"{TMDB_BASE}/tv/popular", headers=get_headers(api_key), params=params)
 
 
-async def get_top_rated_shows(page: int = 1, api_key: str = None) -> dict:
-    return await _get(f"{TMDB_BASE}/tv/top_rated", headers=get_headers(api_key), params={"page": page})
+async def get_top_rated_shows(page: int = 1, api_key: str = None, language: str | None = None) -> dict:
+    params: dict = {"page": page}
+    if language:
+        params["language"] = language
+    return await _get(f"{TMDB_BASE}/tv/top_rated", headers=get_headers(api_key), params=params)
 
 
 async def search_multi(q: str, page: int = 1, api_key: str = None, language: str | None = None) -> dict:
@@ -296,6 +314,7 @@ async def discover_movies(
     watch_region: str = "US",
     with_original_language: str | None = None,
     api_key: str = None,
+    language: str | None = None,
 ) -> dict:
     params: dict = {
         "page": page,
@@ -318,6 +337,8 @@ async def discover_movies(
         params["watch_region"] = watch_region
     if with_original_language:
         params["with_original_language"] = with_original_language
+    if language:
+        params["language"] = language
     return await _get(f"{TMDB_BASE}/discover/movie", headers=get_headers(api_key), params=params)
 
 
@@ -335,6 +356,7 @@ async def discover_shows(
     watch_region: str = "US",
     with_original_language: str | None = None,
     api_key: str = None,
+    language: str | None = None,
 ) -> dict:
     params: dict = {
         "page": page,
@@ -359,6 +381,8 @@ async def discover_shows(
         params["watch_region"] = watch_region
     if with_original_language:
         params["with_original_language"] = with_original_language
+    if language:
+        params["language"] = language
     return await _get(f"{TMDB_BASE}/discover/tv", headers=get_headers(api_key), params=params)
 
 

--- a/backend/routers/media.py
+++ b/backend/routers/media.py
@@ -1975,6 +1975,12 @@ async def get_tmdb_list(
         }
         has_filters = bool(genre or min_rating or status or original_language)
 
+        # Explore cards render straight from these TMDB responses, so ask TMDB
+        # for the user's Metadata Language directly - detail pages and list
+        # cards already translate, Explore was the one place still hardcoded
+        # to TMDB's default English (#235 follow-up).
+        metadata_lang = await get_user_metadata_language(db, current_user.id)
+
         async def _fetch_tmdb_page(fetch_page: int) -> dict:
             if has_filters:
                 sort_by = category_sort_map.get(category, "popularity.desc")
@@ -1984,6 +1990,7 @@ async def get_tmdb_list(
                         page=fetch_page, genre_ids=genre_ids or None,
                         min_rating=min_rating, sort_by=sort_by,
                         with_original_language=original_language, api_key=tmdb_key,
+                        language=metadata_lang,
                     )
                 genre_ids = [TV_GENRE_IDS[g] for g in genre if g in TV_GENRE_IDS]
                 status_id = TV_STATUS_IDS.get(status) if status else None
@@ -1991,20 +1998,20 @@ async def get_tmdb_list(
                     page=fetch_page, genre_ids=genre_ids or None,
                     min_rating=min_rating, sort_by=sort_by,
                     status=status_id, with_original_language=original_language,
-                    api_key=tmdb_key,
+                    api_key=tmdb_key, language=metadata_lang,
                 )
             if type == MediaType.movie:
                 if category == "top_rated":
-                    return await tmdb.get_top_rated_movies(page=fetch_page, api_key=tmdb_key)
+                    return await tmdb.get_top_rated_movies(page=fetch_page, api_key=tmdb_key, language=metadata_lang)
                 if category == "trending":
-                    return await tmdb.get_trending_movies(page=fetch_page, api_key=tmdb_key)
-                return await tmdb.get_popular_movies(page=fetch_page, api_key=tmdb_key)
+                    return await tmdb.get_trending_movies(page=fetch_page, api_key=tmdb_key, language=metadata_lang)
+                return await tmdb.get_popular_movies(page=fetch_page, api_key=tmdb_key, language=metadata_lang)
             # series/episode
             if category == "top_rated":
-                return await tmdb.get_top_rated_shows(page=fetch_page, api_key=tmdb_key)
+                return await tmdb.get_top_rated_shows(page=fetch_page, api_key=tmdb_key, language=metadata_lang)
             if category == "trending":
-                return await tmdb.get_trending_shows(page=fetch_page, api_key=tmdb_key)
-            return await tmdb.get_popular_shows(page=fetch_page, api_key=tmdb_key)
+                return await tmdb.get_trending_shows(page=fetch_page, api_key=tmdb_key, language=metadata_lang)
+            return await tmdb.get_popular_shows(page=fetch_page, api_key=tmdb_key, language=metadata_lang)
 
         async def _build_enriched(results: list[dict]) -> list[dict]:
             tmdb_ids = [res["id"] for res in results]


### PR DESCRIPTION
Third and final piece of the #235 follow-ups (after #236 and #245): Explore cards still showed TMDB's default English title/poster even with a Metadata Language configured — OUARZA's "56 Days" vs "56 jours" example in the #235 thread.

Explore renders straight from TMDB's list/discover responses, so no stored translation can help there; the fix is simply asking TMDB for the user's language. The eight list/discover helpers in `core/tmdb.py` (popular/top-rated/trending for movies and shows, plus both discover endpoints) get an optional `language` parameter — same pattern as `get_show_light` / `search_multi` already have — and `get_tmdb_list` passes the user's Metadata Language to all of them.

No behavior change for users without a Metadata Language configured: the parameter is omitted entirely, so those requests are byte-identical to today's (and keep sharing the same response cache entries).
