### PR TITLE
fix(collection): order Recently Added by the library add-date, not the sync time

### DIFF
--- a/backend/core/jellyfin.py
+++ b/backend/core/jellyfin.py
@@ -64,7 +64,7 @@ async def get_movies(library_id: str, url: str, token: str, user_id: str) -> lis
             "ParentId": library_id,
             "IncludeItemTypes": "Movie",
             "Recursive": True,
-            "Fields": "ProviderIds,MediaStreams,Overview,Genres,CommunityRating,OfficialRating,RunTimeTicks,PremiereDate,UserData",
+            "Fields": "ProviderIds,MediaStreams,Overview,Genres,CommunityRating,OfficialRating,RunTimeTicks,PremiereDate,UserData,DateCreated",
             "Limit": page_size,
             "StartIndex": start,
         })
@@ -103,7 +103,7 @@ async def get_episodes(library_id: str, url: str, token: str, user_id: str) -> l
             # never be imported into a user's collection.
             "ExcludeLocationTypes": "Virtual",
             "IsMissing": False,
-            "Fields": "ProviderIds,MediaStreams,Overview,Genres,CommunityRating,RunTimeTicks,PremiereDate,UserData",
+            "Fields": "ProviderIds,MediaStreams,Overview,Genres,CommunityRating,RunTimeTicks,PremiereDate,UserData,DateCreated",
             "Limit": page_size,
             "StartIndex": start,
         })

--- a/backend/core/scrob_import.py
+++ b/backend/core/scrob_import.py
@@ -203,6 +203,17 @@ def _parse_iso(value: str | None) -> datetime | None:
     return parsed
 
 
+def _parse_collected_at(entry: dict) -> datetime | None:
+    """The collected date the exporter wrote for this entry, if it is usable.
+
+    A malformed date shouldn't cost the user the whole entry, so it falls back
+    to None and the row keeps its default."""
+    try:
+        return _parse_iso(entry.get("collected_at"))
+    except (TypeError, ValueError):
+        return None
+
+
 async def apply_scrob_import(
     db: AsyncSession,
     job_id: int,
@@ -406,12 +417,14 @@ async def apply_scrob_import(
 
     # ── Collection ─────────────────────────────────────────────────────
     if include_collection:
-        async def _add_to_collection(media: Media) -> bool:
+        async def _add_to_collection(media: Media, collected_at: datetime | None = None) -> bool:
             existing = await db.execute(select(Collection).where(Collection.user_id == user_id, Collection.media_id == media.id))
             coll = existing.scalars().first()
             if coll:
                 return False
-            coll = Collection(user_id=user_id, media_id=media.id)
+            # Keep the exported collected date, otherwise restoring a backup
+            # silently restamps the whole collection as added today.
+            coll = Collection(user_id=user_id, media_id=media.id, added_at=collected_at)
             db.add(coll)
             await db.flush()
             db.add(CollectionFile(collection_id=coll.id, source=CollectionSource.manual, source_id=str(media.tmdb_id)))
@@ -426,7 +439,7 @@ async def apply_scrob_import(
                 try:
                     async with db.begin_nested():
                         media = await _get_or_create_movie_media(db, tmdb_id, entry.get("movie", {}).get("title", ""), api_key)
-                        if media and await _add_to_collection(media):
+                        if media and await _add_to_collection(media, _parse_collected_at(entry)):
                             stats["collected"] += 1
                         else:
                             stats["skipped"] += 1
@@ -457,7 +470,7 @@ async def apply_scrob_import(
                             stats["errors"] += 1
                             continue
                         media = await _get_or_create_episode_media(db, show.id, show_tmdb_id, season_number, episode_number, api_key, season_cache)
-                        if media and await _add_to_collection(media):
+                        if media and await _add_to_collection(media, _parse_collected_at(entry)):
                             stats["collected"] += 1
                         else:
                             stats["skipped"] += 1

--- a/backend/routers/media.py
+++ b/backend/routers/media.py
@@ -920,6 +920,8 @@ async def list_media(
     total_pages = (total_count + page_size - 1) // page_size
 
     # Sort and Paginate
+    # Every sort here is paginated, so each one needs a unique final key or rows
+    # shift between pages and items get shown twice or skipped entirely.
     if sort == "last_watched":
         last_watched_sq = (
             select(WatchEvent.media_id, func.max(WatchEvent.watched_at).label("last_watched_at"))
@@ -930,7 +932,7 @@ async def list_media(
         query = (
             base_query
             .outerjoin(last_watched_sq, last_watched_sq.c.media_id == Media.id)
-            .order_by(last_watched_sq.c.last_watched_at.desc().nulls_last())
+            .order_by(last_watched_sq.c.last_watched_at.desc().nulls_last(), Media.id.desc())
             .offset(offset).limit(page_size)
         )
     else:
@@ -941,7 +943,7 @@ async def list_media(
             "created_at": Collection.added_at.desc(),
         }
         order = sort_map.get(sort, Collection.added_at.desc())
-        query = base_query.order_by(order).offset(offset).limit(page_size)
+        query = base_query.order_by(order, Media.id.desc()).offset(offset).limit(page_size)
     result = await db.execute(query)
     items = result.scalars().all()
 
@@ -1594,6 +1596,25 @@ async def airing_today_collected(
     return {"results": results}
 
 
+def recently_added_order(max_added):
+    """Ordering for the Recently Added rail.
+
+    The add-date leads, but media servers stamp a batch of files with the same
+    second, so without the rest of these keys Postgres is free to return a
+    different arrangement every time and a season comes back shuffled. Grouping
+    on show_id keeps one show's episodes together inside a shared timestamp,
+    season and episode descending put the newest one first, and the id makes
+    the result fully deterministic. Movies have no season/episode, hence
+    nulls_last: a DESC sort in Postgres puts NULLs first otherwise."""
+    return [
+        max_added.desc(),
+        Media.show_id.desc().nulls_last(),
+        Media.season_number.desc().nulls_last(),
+        Media.episode_number.desc().nulls_last(),
+        Media.id.desc(),
+    ]
+
+
 @router.get("/recently-added")
 async def recently_added(
     type: MediaType | None = Query(None),
@@ -1632,7 +1653,7 @@ async def recently_added(
         .join(coll_subq, coll_subq.c.media_id == Media.id)
         .options(joinedload(Media.show))
         .where(*media_filters)
-        .order_by(coll_subq.c.max_added.desc())
+        .order_by(*recently_added_order(coll_subq.c.max_added))
         .limit(limit)
     )
     result = await db.execute(query)
@@ -4757,7 +4778,9 @@ async def get_media_details(
                     select(CollectionFile)
                     .join(Collection, Collection.id == CollectionFile.collection_id)
                     .where(Collection.media_id == local_ep.id, Collection.user_id == current_user.id)
-                    .order_by(CollectionFile.added_at.desc())
+                    # Rows from sources with no file details (Nuvio, Stremio) carry no
+                    # quality at all, so keep them behind real files or the badge blanks out.
+                    .order_by(CollectionFile.resolution.is_(None).asc(), CollectionFile.added_at.desc())
                 )
                 coll_res = await db.execute(coll_q)
                 coll_files = coll_res.scalars().all()
@@ -4848,7 +4871,9 @@ async def get_media_details(
                 select(CollectionFile)
                 .join(Collection, Collection.id == CollectionFile.collection_id)
                 .where(Collection.media_id.in_(all_media_ids), Collection.user_id == current_user.id)
-                .order_by(CollectionFile.added_at.desc())
+                # Rows from sources with no file details (Nuvio, Stremio) carry no
+                # quality at all, so keep them behind real files or the badge blanks out.
+                .order_by(CollectionFile.resolution.is_(None).asc(), CollectionFile.added_at.desc())
             )
             coll_res = await db.execute(coll_q)
             coll_files = coll_res.scalars().all()

--- a/backend/routers/shows.py
+++ b/backend/routers/shows.py
@@ -1504,7 +1504,9 @@ async def get_episode_detail(
                     select(CollectionFile)
                     .join(Collection, Collection.id == CollectionFile.collection_id)
                     .where(Collection.media_id == local_ep.id, Collection.user_id == current_user.id)
-                    .order_by(CollectionFile.added_at.desc())
+                    # Rows from sources with no file details (Nuvio, Stremio) carry no
+                    # quality at all, so keep them behind real files or the badge blanks out.
+                    .order_by(CollectionFile.resolution.is_(None).asc(), CollectionFile.added_at.desc())
                 )
                 coll_res = await db.execute(coll_q)
                 coll_file = coll_res.scalars().first()
@@ -2690,7 +2692,9 @@ async def get_tvdb_episode(
                         Collection.media_id == local_ep.id,
                         Collection.user_id == current_user.id,
                     )
-                    .order_by(CollectionFile.added_at.desc())
+                    # Rows from sources with no file details (Nuvio, Stremio) carry no
+                    # quality at all, so keep them behind real files or the badge blanks out.
+                    .order_by(CollectionFile.resolution.is_(None).asc(), CollectionFile.added_at.desc())
                 )
                 coll_file = coll_file_q.scalars().first()
                 if coll_file:

--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -5,7 +5,7 @@ from typing import Any
 from fastapi import APIRouter, Depends, Query, HTTPException, BackgroundTasks
 from pydantic import BaseModel, model_validator
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
-from sqlalchemy import select, update, delete, func, cast
+from sqlalchemy import select, update, delete, func, cast, bindparam, DateTime
 from sqlalchemy.orm import selectinload
 from sqlalchemy.orm.attributes import flag_modified
 from sqlalchemy.dialects.postgresql import insert, JSONB
@@ -215,6 +215,55 @@ def extract_watch_state(item: dict, source: CollectionSource) -> dict:
             state["user_rating"] = float(r)
 
     return state
+
+
+def provider_added_at(item: dict, source: CollectionSource) -> datetime | None:
+    """When the media server added this item to its library, as naive UTC.
+
+    Returns None when the source has no such concept or the value is missing
+    or unparseable, in which case the caller leaves the column on its server
+    default. Sources are matched explicitly rather than through
+    _MEDIA_BROWSER_ITEM_SOURCES: Nuvio and Stremio items are synthesized with
+    a fixed key set and carry no date, and matching them here would only wait
+    for a key rename to start feeding in something wrong."""
+    if source is CollectionSource.plex:
+        raw = item.get("addedAt")
+        if raw is None:
+            return None
+        try:
+            return datetime.fromtimestamp(int(raw), tz=timezone.utc).replace(tzinfo=None)
+        except (TypeError, ValueError, OSError, OverflowError):
+            return None
+
+    if source in (CollectionSource.jellyfin, CollectionSource.emby, CollectionSource.arvio):
+        raw = item.get("DateCreated")
+        if not raw:
+            return None
+        try:
+            dt = parser.isoparse(raw)
+        except (TypeError, ValueError):
+            return None
+        return dt.astimezone(timezone.utc).replace(tzinfo=None) if dt.tzinfo else dt
+
+    return None
+
+
+def collection_added_at_heal_stmt():
+    """Lower Collection.added_at towards the provider's date, in SQL.
+
+    LEAST is deliberate. Taking the minimum in Python would go wrong in three
+    ways: a multi-episode file expands into several items sharing one
+    collection, so last-write-wins could raise the value; a preloaded snapshot
+    goes stale after the first batch commit; and a concurrent webhook could
+    interleave. Doing it in the database makes the write monotonic and
+    idempotent, so a run that dies half way just leaves the rest for the next
+    one."""
+    table = Collection.__table__
+    return (
+        update(table)
+        .where(table.c.id == bindparam("b_id"))
+        .values(added_at=func.least(table.c.added_at, bindparam("b_added", type_=DateTime)))
+    )
 
 
 def is_fresh_rewatch_play(
@@ -1852,6 +1901,19 @@ async def sync_items(
     new_media_for_enrichment: list[tuple] = []  # (Media, series_tmdb_id | None)
     skipped_warnings: list[dict] = []
 
+    # collection_id → earliest add-date seen this run, applied in batches so a
+    # large library costs one statement per batch rather than one per item.
+    collection_heals: dict[int, datetime] = {}
+
+    async def flush_collection_heals() -> None:
+        if not collection_heals:
+            return
+        await db.execute(
+            collection_added_at_heal_stmt(),
+            [{"b_id": cid, "b_added": dt} for cid, dt in collection_heals.items()],
+        )
+        collection_heals.clear()
+
     for i, item in enumerate(items):
         new_media: Media | None = None
         try:
@@ -1873,11 +1935,14 @@ async def sync_items(
                     season_num = item.get("parentIndex")
                     episode_num = item.get("index")
 
+                added_at = provider_added_at(item, source)
+
                 if seen_source_ids is not None:
                     seen_source_ids.add(source_id)
 
                 file_entry = existing_files.get((source_id, episode_num))
                 media_id_for_watch: int | None = None
+                heal_collection_id: int | None = None
                 show_id: int | None = None  # (re)assigned below for episodes; stays None for movies
 
                 # Detect re-match: same Plex ratingKey but TMDB ID changed.
@@ -1921,6 +1986,9 @@ async def sync_items(
                         existing_file.file_path = quality.get("file_path")
                         if connection_id is not None:
                             existing_file.connection_id = connection_id
+                        if added_at is not None:
+                            existing_file.added_at = added_at
+                        heal_collection_id = existing_file.collection_id
                     stats["skipped"] += 1
                     media_id_for_watch = existing_media_id
 
@@ -2019,11 +2087,14 @@ async def sync_items(
                             existing_alt_file.file_path = quality.get("file_path")
                             if connection_id is not None:
                                 existing_alt_file.connection_id = connection_id
+                            if added_at is not None:
+                                existing_alt_file.added_at = added_at
                             # Keep in-memory maps consistent
                             old_source_id = existing_alt_file.source_id
                             existing_files.pop((old_source_id, episode_num), None)
                             existing_files[(source_id, episode_num)] = (existing_alt_file, media.id, tmdb_id)
                             files_by_media_source[(media.id, source)] = existing_alt_file
+                            heal_collection_id = existing_alt_file.collection_id
                         stats["skipped"] += 1
                         media_id_for_watch = media.id
                     else:
@@ -2108,11 +2179,22 @@ async def sync_items(
                         if sync_collection:
                             coll_id = existing_coll_by_media_id.get(media.id)
                             if coll_id is None:
-                                # Upsert: ON CONFLICT DO NOTHING guards against races
-                                # between concurrent webhooks / savepoint rollbacks that
-                                # desynchronise the in-memory dict from the DB.
-                                coll_stmt = insert(Collection).values(user_id=user_id, media_id=media.id)
-                                coll_stmt = coll_stmt.on_conflict_do_nothing(constraint="uq_collection_user_media")
+                                # Upsert guards against races between concurrent
+                                # webhooks / savepoint rollbacks that desynchronise the
+                                # in-memory dict from the DB. On conflict the row already
+                                # exists, so keep whichever add-date is earlier rather
+                                # than leaving it on the row's insert time.
+                                coll_values = {"user_id": user_id, "media_id": media.id}
+                                if added_at is not None:
+                                    coll_values["added_at"] = added_at
+                                coll_stmt = insert(Collection).values(**coll_values)
+                                if added_at is not None:
+                                    coll_stmt = coll_stmt.on_conflict_do_update(
+                                        constraint="uq_collection_user_media",
+                                        set_={"added_at": func.least(Collection.added_at, coll_stmt.excluded.added_at)},
+                                    )
+                                else:
+                                    coll_stmt = coll_stmt.on_conflict_do_nothing(constraint="uq_collection_user_media")
                                 await db.execute(coll_stmt)
                                 await db.flush()
                                 coll_result = await db.execute(
@@ -2133,6 +2215,7 @@ async def sync_items(
                                 connection_id=connection_id,
                                 source=source,
                                 source_id=source_id,
+                                added_at=added_at,
                                 file_path=quality.get("file_path"),
                                 resolution=quality.get("resolution"),
                                 video_codec=quality.get("video_codec"),
@@ -2141,6 +2224,7 @@ async def sync_items(
                                 audio_languages=quality.get("audio_languages"),
                                 subtitle_languages=quality.get("subtitle_languages"),
                             ))
+                            heal_collection_id = coll_id
                         media_id_for_watch = media.id
 
                 if ratingkey_to_media_id is not None and media_id_for_watch is not None:
@@ -2189,6 +2273,14 @@ async def sync_items(
                         if new_ratings is not None:
                             new_ratings[(media_id_for_watch, None)] = watch_state["user_rating"]
 
+            # Savepoint committed, so queue the collection's add-date only now:
+            # an item that rolled back must not leave a heal behind for work
+            # that was undone.
+            if heal_collection_id is not None and added_at is not None:
+                queued = collection_heals.get(heal_collection_id)
+                if queued is None or added_at < queued:
+                    collection_heals[heal_collection_id] = added_at
+
             # Savepoint committed — update pre-loaded caches so duplicates within the
             # same sync batch reuse the newly created media instead of creating another.
             if new_media:
@@ -2207,6 +2299,7 @@ async def sync_items(
             print(f"    Error syncing item {i}: {e}")
 
         if (i + 1) % BATCH_SIZE == 0:
+            await flush_collection_heals()
             await db.commit()
             if job_id:
                 await db.execute(
@@ -2218,6 +2311,7 @@ async def sync_items(
                 await _raise_if_cancelled(db, job_id)
             print(f"    Processed {i+1}/{len(items)} items...")
 
+    await flush_collection_heals()
     await db.commit()
     processed_remainder = len(items) % BATCH_SIZE
     if job_id and processed_remainder > 0:

--- a/backend/tests/test_jellyfin.py
+++ b/backend/tests/test_jellyfin.py
@@ -33,6 +33,32 @@ class JellyfinEpisodeQueryTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(requested_params["IncludeItemTypes"], "Episode")
         self.assertEqual(requested_params["ExcludeLocationTypes"], "Virtual")
         self.assertEqual(requested_params["IsMissing"], "false")
+        # Jellyfin omits DateCreated unless it is asked for, and without it
+        # every collected episode falls back to its Scrob insert time.
+        self.assertIn("DateCreated", requested_params["Fields"])
+
+
+class JellyfinMovieQueryTests(unittest.IsolatedAsyncioTestCase):
+    async def test_get_movies_requests_the_library_add_date(self) -> None:
+        requested_params: dict[str, str] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            requested_params.update(request.url.params)
+            return httpx.Response(200, json={"Items": [], "TotalRecordCount": 0})
+
+        transport = httpx.MockTransport(handler)
+        with patch.object(
+            jellyfin.httpx,
+            "AsyncClient",
+            side_effect=lambda **kwargs: _REAL_ASYNC_CLIENT(transport=transport, **kwargs),
+        ):
+            movies = await jellyfin.get_movies(
+                "library-id", "http://jellyfin.local", "token", "user-id"
+            )
+
+        self.assertEqual(movies, [])
+        self.assertEqual(requested_params["IncludeItemTypes"], "Movie")
+        self.assertIn("DateCreated", requested_params["Fields"])
 
 
 class JellyfinSetRatingTests(unittest.IsolatedAsyncioTestCase):

--- a/backend/tests/test_recently_added_order.py
+++ b/backend/tests/test_recently_added_order.py
@@ -1,0 +1,59 @@
+import os
+import unittest
+
+os.environ.setdefault("SECRET_KEY", "test-secret")
+os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://test:test@localhost/test")
+
+from sqlalchemy import func, select
+from sqlalchemy.dialects import postgresql
+
+from models.collection import Collection
+from models.media import Media
+from routers.media import recently_added_order
+
+
+def _rendered_order_by():
+    max_added = (
+        select(Collection.media_id, func.max(Collection.added_at).label("max_added"))
+        .group_by(Collection.media_id)
+        .subquery()
+        .c.max_added
+    )
+    query = select(Media).order_by(*recently_added_order(max_added))
+    return str(query.compile(dialect=postgresql.dialect())).split("ORDER BY")[1]
+
+
+class RecentlyAddedOrderTests(unittest.TestCase):
+    """Media servers stamp a whole batch of files with the same second, so the
+    add-date alone leaves Postgres free to return a different arrangement on
+    every request - which is how a season ends up shuffled on the rail."""
+
+    def test_add_date_leads(self):
+        # The subquery column renders with its generated alias prefix.
+        first_key = _rendered_order_by().split(",")[0].strip()
+        self.assertTrue(first_key.endswith("max_added DESC"), first_key)
+
+    def test_every_remaining_key_is_present_and_descending(self):
+        rendered = _rendered_order_by()
+        for column in ("media.show_id", "media.season_number", "media.episode_number", "media.id"):
+            self.assertIn(f"{column} DESC", rendered)
+
+    def test_a_shows_episodes_group_before_they_are_ordered(self):
+        rendered = _rendered_order_by()
+        self.assertLess(rendered.index("media.show_id"), rendered.index("media.season_number"))
+        self.assertLess(rendered.index("media.season_number"), rendered.index("media.episode_number"))
+
+    def test_media_id_is_the_final_key_so_the_order_is_total(self):
+        keys = [part.strip() for part in _rendered_order_by().split(",")]
+        self.assertTrue(keys[-1].startswith("media.id"))
+
+    def test_nullable_episode_columns_sort_last(self):
+        # A DESC sort puts NULLs first in Postgres, which would float every
+        # movie above the episodes sharing its timestamp.
+        rendered = _rendered_order_by()
+        for column in ("media.show_id", "media.season_number", "media.episode_number"):
+            self.assertIn(f"{column} DESC NULLS LAST", rendered)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_scrob_import.py
+++ b/backend/tests/test_scrob_import.py
@@ -392,5 +392,24 @@ class ImportEndpointValidationTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(ctx.exception.status_code, 400)
 
 
+class ParseCollectedAtTests(unittest.TestCase):
+    """The exporter writes collected_at for every collection entry, so a
+    restore should keep those dates instead of restamping the whole
+    collection as added today."""
+
+    def test_reads_the_date_the_exporter_writes(self):
+        # Format comes from core/data_export.py's _iso().
+        entry = {"collected_at": "2019-05-01T08:00:00.000Z"}
+        self.assertEqual(scrob_import._parse_collected_at(entry), datetime(2019, 5, 1, 8, 0, 0))
+
+    def test_offsets_are_converted_to_naive_utc(self):
+        entry = {"collected_at": "2019-05-01T10:00:00+02:00"}
+        self.assertEqual(scrob_import._parse_collected_at(entry), datetime(2019, 5, 1, 8, 0, 0))
+
+    def test_missing_or_malformed_dates_fall_back_to_the_default(self):
+        for entry in ({}, {"collected_at": None}, {"collected_at": ""}, {"collected_at": "nonsense"}):
+            self.assertIsNone(scrob_import._parse_collected_at(entry), entry)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/backend/tests/test_sync.py
+++ b/backend/tests/test_sync.py
@@ -679,5 +679,61 @@ class ConnectionUpdateBaselineResetTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(conn.plex_watchlist_synced_keys, ["movie:1"])
 
 
+class ProviderAddedAtTests(unittest.TestCase):
+    """The library add-date each media server reports, normalised to naive UTC
+    like every other timestamp Scrob stores."""
+
+    def test_plex_epoch_seconds(self):
+        got = sync.provider_added_at({"addedAt": 1754179200}, sync.CollectionSource.plex)
+        self.assertEqual(got, datetime(2025, 8, 3, 0, 0, 0))
+
+    def test_plex_accepts_the_value_as_a_string(self):
+        got = sync.provider_added_at({"addedAt": "1754179200"}, sync.CollectionSource.plex)
+        self.assertEqual(got, datetime(2025, 8, 3, 0, 0, 0))
+
+    def test_jellyfin_iso_with_dotnet_fractional_seconds(self):
+        got = sync.provider_added_at(
+            {"DateCreated": "2026-08-01T09:30:00.0000000Z"}, sync.CollectionSource.jellyfin
+        )
+        self.assertEqual(got, datetime(2026, 8, 1, 9, 30, 0))
+        self.assertIsNone(got.tzinfo)
+
+    def test_emby_iso_is_converted_to_utc(self):
+        got = sync.provider_added_at(
+            {"DateCreated": "2026-08-01T11:30:00+02:00"}, sync.CollectionSource.emby
+        )
+        self.assertEqual(got, datetime(2026, 8, 1, 9, 30, 0))
+
+    def test_sources_without_a_library_date_return_none(self):
+        # Nuvio and Stremio items are synthesized with a fixed key set, so they
+        # must never be read as if they were a media browser payload.
+        for source in (sync.CollectionSource.nuvio, sync.CollectionSource.stremio):
+            self.assertIsNone(
+                sync.provider_added_at({"DateCreated": "2026-08-01T09:30:00Z"}, source)
+            )
+
+    def test_missing_or_unusable_values_return_none(self):
+        cases = [
+            ({}, sync.CollectionSource.plex),
+            ({"addedAt": None}, sync.CollectionSource.plex),
+            ({"addedAt": "not-a-number"}, sync.CollectionSource.plex),
+            ({}, sync.CollectionSource.jellyfin),
+            ({"DateCreated": ""}, sync.CollectionSource.jellyfin),
+            ({"DateCreated": "yesterday"}, sync.CollectionSource.jellyfin),
+        ]
+        for item, source in cases:
+            self.assertIsNone(sync.provider_added_at(item, source), (item, source))
+
+
+class CollectionAddedAtHealTests(unittest.TestCase):
+    """The heal has to lower Collection.added_at without ever raising it, which
+    is why the comparison happens in SQL rather than in Python."""
+
+    def test_statement_takes_the_lesser_of_stored_and_provider_dates(self):
+        rendered = str(sync.collection_added_at_heal_stmt().compile(dialect=_pg.dialect()))
+        self.assertIn("UPDATE collections SET added_at=least(collections.added_at,", rendered)
+        self.assertIn("WHERE collections.id =", rendered)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION

## Problem

`Collection.added_at` and `CollectionFile.added_at` have a `server_default` and are never assigned, so they hold the time Scrob inserted the row rather than the time the item reached the library. Recently Added therefore means recently synced, and a full pull presents an entire existing library as new.

Because `sync_items` commits in batches, large groups of rows also share one timestamp, and the rail ordered on that timestamp alone. With no tie-breaker the arrangement is left to Postgres and changes between requests, so a season appears shuffled. The same column is the default sort for the paginated collection pages, where an unstable order also repeats and skips items across pages.

## Fix

Take the date from the media server. Plex already returns `addedAt`; Jellyfin and Emby omit `DateCreated` unless it is requested, so it is added to the two library-scan `Fields` lists (Emby re-exports them). Sources without the concept return `None` and behave as before.

`CollectionFile.added_at` keeps the date reported by its own source, and `Collection.added_at` keeps the earliest of them, since a title held on one server for years is not new because a second server picked it up today. Existing rows are repaired as syncs re-encounter them, batched at the commit points `sync_items` already has and written with SQL `LEAST` so a value can only move earlier. That makes the repair idempotent and safe to interrupt, and needs no migration.

Ordering is then made total: the rail falls back to show, season and episode descending, then media id, and every sort on `GET /media` gains a final key.

Two adjacent defects had to be fixed or this change would have regressed them. The quality lookups pick a file by `added_at`, where detail-less rows from Nuvio and Stremio would have started winning and blanking the b `collected_at` while the importer ignored it, resettingcollection dates on every restore.

## Upgrade impact

The first sync rewrites these timestamps in place and the previous values are not recoverable. The first full push afterwards restates `collected_at` to
MDBList and `added_at` to Nuvio once for the whole library; incd. Items with no media-server source keep their insert time andwill sort above repaired ones. Webhook-created rows are left alone, since `ItemAdded` does mean just added and playback-created rows are repaired by the
next sync.