### PR TITLE
Feature: filter movies and shows by list membership (#255)

### DIFF
--- a/backend/routers/media.py
+++ b/backend/routers/media.py
@@ -890,12 +890,22 @@ async def list_media(
     genre: list[str] = Query(default=[]),
     year: list[int] = Query(default=[]),
     watched: list[str] = Query(default=[]),
+    # in_list = in|out: membership of any of the user's lists (#255).
+    in_list: str | None = Query(None),
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user_or_api_key),
 ):
     offset = (page - 1) * page_size
 
     filters = [Collection.user_id == current_user.id]
+    if in_list in ("in", "out"):
+        in_list_exists = (
+            select(ListItem.id)
+            .join(UserList, UserList.id == ListItem.list_id)
+            .where(ListItem.media_id == Media.id, UserList.user_id == current_user.id)
+            .exists()
+        )
+        filters.append(in_list_exists if in_list == "in" else ~in_list_exists)
     if type:
         filters.append(Media.media_type == type)
     if genre:
@@ -2054,10 +2064,16 @@ _ARR_CHECKS = {
     "added": lambda i: bool(i.get("is_monitored")),
     "notadded": lambda i: not i.get("is_monitored"),
 }
+# in_list = in|out: membership of any of the user's lists (#255).
+_IN_LIST_CHECKS = {
+    "in": lambda i: bool(i.get("in_lists")),
+    "out": lambda i: not i.get("in_lists"),
+}
 
 
 def _apply_local_filters(
     items: list[dict], collection: list[str], watch: list[str], arr: list[str], year: list[int] | None = None,
+    in_list: list[str] | None = None,
 ) -> list[dict]:
     """Local-only filters get_tmdb_list applies after TMDB enrichment.
 
@@ -2072,7 +2088,7 @@ def _apply_local_filters(
     no check, so a category made up entirely of unrecognized values is a
     no-op rather than matching nothing.
     """
-    for values, checks in ((collection, _COLLECTION_CHECKS), (watch, _WATCH_CHECKS), (arr, _ARR_CHECKS)):
+    for values, checks in ((collection, _COLLECTION_CHECKS), (watch, _WATCH_CHECKS), (arr, _ARR_CHECKS), (in_list or [], _IN_LIST_CHECKS)):
         if not values:
             continue
         active = [checks[v] for v in values if v in checks]
@@ -2116,6 +2132,8 @@ async def get_tmdb_list(
     collection: list[str] = Query(default=[]),
     watch: list[str] = Query(default=[]),
     arr: list[str] = Query(default=[]),
+    # in_list = in|out: membership of any of the user's lists (#255).
+    in_list: list[str] = Query(default=[]),
     db: AsyncSession = Depends(get_db),
     current_user: User | None = Depends(get_optional_user_or_api_key),
 ):
@@ -2237,7 +2255,7 @@ async def get_tmdb_list(
                 await enrich_with_state(db, current_user.id, enriched)
             return enriched
 
-        if not (collection or watch or arr or year):
+        if not (collection or watch or arr or year or in_list):
             data = await _fetch_tmdb_page(page)
             enriched = await _build_enriched(data.get("results", []))
             return {
@@ -2276,7 +2294,7 @@ async def get_tmdb_list(
                         batch_results.append(res)
             if batch_results:
                 enriched = await _build_enriched(batch_results)
-                matched.extend(_apply_local_filters(enriched, collection, watch, arr, year))
+                matched.extend(_apply_local_filters(enriched, collection, watch, arr, year, in_list))
             scan_page = batch_end + 1
             if total_tmdb_pages is not None and scan_page > total_tmdb_pages:
                 break

--- a/backend/routers/shows.py
+++ b/backend/routers/shows.py
@@ -209,6 +209,9 @@ async def list_shows(
     year: list[int] = Query(default=[]),
     status: list[str] = Query(default=[]),
     watched: list[str] = Query(default=[]),
+    # in_list = in|out: membership of any of the user's lists (#255;
+    # season-level list items live on the same series Media row and count too).
+    in_list: str | None = Query(None),
 ):
     offset = (page - 1) * page_size
 
@@ -247,6 +250,19 @@ async def list_shows(
             ShowModel.tmdb_id.in_(select(direct_series_tmdb_ids)),
         )
     )
+    if in_list in ("in", "out"):
+        series_in_list = (
+            select(ListItem.id)
+            .join(UserList, UserList.id == ListItem.list_id)
+            .join(Media, Media.id == ListItem.media_id)
+            .where(
+                UserList.user_id == current_user.id,
+                Media.media_type == MediaType.series,
+                Media.tmdb_id == ShowModel.tmdb_id,
+            )
+            .exists()
+        )
+        base_query = base_query.where(series_in_list if in_list == "in" else ~series_in_list)
     if genre:
         base_query = base_query.where(or_(*[
             sa_cast(ShowModel.tmdb_data["genres"], Text).contains(f'"{g}"') for g in genre

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1108,7 +1108,7 @@ export const api = {
   },
 
   media: {
-    list: (params?: { type?: string; sort?: string; page?: number; genre?: string[]; year?: number[]; watched?: string[] }, token?: string) =>
+    list: (params?: { type?: string; sort?: string; page?: number; genre?: string[]; year?: number[]; watched?: string[]; in_list?: string }, token?: string) =>
       get<{ page: number; page_size: number; total_pages: number; total_results: number; results: MediaItem[] }>("/media", params, token),
 
     years: (type: string, token?: string) =>
@@ -1137,7 +1137,7 @@ export const api = {
     getCollection: (collectionId: number, token?: string) =>
       get<CollectionDetail>(`/media/collection/${collectionId}`, undefined, token),
 
-    tmdbList: (params: { type: string; category?: string; page?: number; genre?: string[]; year?: number[]; min_rating?: number; status?: string; collection?: string[]; watch?: string[]; arr?: string[]; original_language?: string }, token?: string) =>
+    tmdbList: (params: { type: string; category?: string; page?: number; genre?: string[]; year?: number[]; min_rating?: number; status?: string; collection?: string[]; watch?: string[]; arr?: string[]; original_language?: string; in_list?: string[] }, token?: string) =>
       get<{ results: MediaItem[]; page: number; total_pages: number; total_results: number }>("/media/tmdb/list", params, token),
 
     search: (q: string, type?: string, page: number = 1, year?: number, token?: string, inLibrary?: boolean) =>
@@ -1199,7 +1199,7 @@ export const api = {
   },
 
   shows: {
-    list: (params?: { sort?: string; page?: number; page_size?: number; genre?: string[]; year?: number[]; status?: string[]; watched?: string[] }, token?: string) =>
+    list: (params?: { sort?: string; page?: number; page_size?: number; genre?: string[]; year?: number[]; status?: string[]; watched?: string[]; in_list?: string }, token?: string) =>
       get<{ page: number; page_size: number; total_results: number; total_pages: number; results: any[] }>("/shows", params, token),
 
     years: (token?: string) =>

--- a/frontend/src/pages/collection/movies.astro
+++ b/frontend/src/pages/collection/movies.astro
@@ -11,6 +11,7 @@ const sort = Astro.url.searchParams.get("sort") ?? "title";
 const genres = Astro.url.searchParams.getAll("genre");
 const years = Astro.url.searchParams.getAll("year").map(Number).filter((n) => !Number.isNaN(n));
 const watched = Astro.url.searchParams.getAll("watched");
+const inList = Astro.url.searchParams.get("in_list") ?? "";
 const page = Number(Astro.url.searchParams.get("page") ?? 1);
 const { token } = Astro.locals;
 Astro.response.headers.set("Cache-Control", "no-store");
@@ -22,6 +23,7 @@ const data = await api.media.list({
   genre: genres,
   year: years,
   watched,
+  ...(inList ? { in_list: inList } : {}),
 }, token);
 
 const MOVIE_GENRES = [
@@ -30,7 +32,7 @@ const MOVIE_GENRES = [
   "Romance", "Science Fiction", "Thriller", "War", "Western",
 ];
 
-const hasFilters = genres.length > 0 || years.length > 0 || watched.length > 0;
+const hasFilters = genres.length > 0 || years.length > 0 || watched.length > 0 || !!inList;
 
 // Build base URL preserving active filters (without page)
 const baseParams = new URLSearchParams();
@@ -38,6 +40,7 @@ baseParams.set("sort", sort);
 genres.forEach((g) => baseParams.append("genre", g));
 years.forEach((y) => baseParams.append("year", String(y)));
 watched.forEach((w) => baseParams.append("watched", w));
+if (inList) baseParams.set("in_list", inList);
 const baseUrl = `/collection/movies?${baseParams.toString()}`;
 ---
 
@@ -73,6 +76,7 @@ const baseUrl = `/collection/movies?${baseParams.toString()}`;
           { key: "genre", label: "Genre", options: MOVIE_GENRES.map((g) => ({ value: g, label: g })), selected: genres },
           { key: "year", label: "Year", selected: years.map(String), dynamic: true, endpoint: "/api/proxy/media/years?type=movie" },
           { key: "watched", label: "Watched", options: [{ value: "watched", label: "Watched" }, { value: "unwatched", label: "Unwatched" }], selected: watched },
+          { key: "in_list", label: "Lists", options: [{ value: "in", label: "In a List" }, { value: "out", label: "Not In a List" }], selected: inList ? [inList] : [], multi: false },
         ]}
       />
     </div>

--- a/frontend/src/pages/collection/shows.astro
+++ b/frontend/src/pages/collection/shows.astro
@@ -12,6 +12,7 @@ const genres = Astro.url.searchParams.getAll("genre");
 const years = Astro.url.searchParams.getAll("year").map(Number).filter((n) => !Number.isNaN(n));
 const statuses = Astro.url.searchParams.getAll("status");
 const watched = Astro.url.searchParams.getAll("watched");
+const inList = Astro.url.searchParams.get("in_list") ?? "";
 const page = Number(Astro.url.searchParams.get("page") ?? 1);
 const { token } = Astro.locals;
 Astro.response.headers.set("Cache-Control", "no-store");
@@ -23,6 +24,7 @@ const data = await api.shows.list({
   year: years,
   status: statuses,
   watched,
+  ...(inList ? { in_list: inList } : {}),
 }, token);
 
 const TV_GENRES = [
@@ -33,7 +35,7 @@ const TV_GENRES = [
 
 const TV_STATUSES = ["Returning Series", "In Production", "Planned", "Ended", "Canceled"];
 
-const hasFilters = genres.length > 0 || years.length > 0 || statuses.length > 0 || watched.length > 0;
+const hasFilters = genres.length > 0 || years.length > 0 || statuses.length > 0 || watched.length > 0 || !!inList;
 
 // Build base URL preserving active filters (without page)
 const baseParams = new URLSearchParams();
@@ -42,6 +44,7 @@ genres.forEach((g) => baseParams.append("genre", g));
 years.forEach((y) => baseParams.append("year", String(y)));
 statuses.forEach((s) => baseParams.append("status", s));
 watched.forEach((w) => baseParams.append("watched", w));
+if (inList) baseParams.set("in_list", inList);
 const baseUrl = `/collection/shows?${baseParams.toString()}`;
 ---
 
@@ -78,6 +81,7 @@ const baseUrl = `/collection/shows?${baseParams.toString()}`;
           { key: "year", label: "Year", selected: years.map(String), dynamic: true, endpoint: "/api/proxy/shows/years" },
           { key: "status", label: "Status", options: TV_STATUSES.map((s) => ({ value: s, label: s })), selected: statuses },
           { key: "watched", label: "Progress", options: [{ value: "watched", label: "Started" }, { value: "unwatched", label: "Not Started" }], selected: watched },
+          { key: "in_list", label: "Lists", options: [{ value: "in", label: "In a List" }, { value: "out", label: "Not In a List" }], selected: inList ? [inList] : [], multi: false },
         ]}
       />
     </div>

--- a/frontend/src/pages/movies.astro
+++ b/frontend/src/pages/movies.astro
@@ -15,6 +15,7 @@ const collection = Astro.url.searchParams.getAll("collection");
 const watch = Astro.url.searchParams.getAll("watch");
 const arr = Astro.url.searchParams.getAll("arr");
 const langs = Astro.url.searchParams.getAll("lang");
+const inList = Astro.url.searchParams.getAll("in_list");
 const page = Number(Astro.url.searchParams.get("page") ?? 1);
 const { token, user } = Astro.locals;
 Astro.response.headers.set("Cache-Control", "no-store");
@@ -46,6 +47,7 @@ if (hasTmdbKey) {
       ...(watch.length ? { watch } : {}),
       ...(hasRadarr && arr.length ? { arr } : {}),
       ...(langs.length ? { original_language: langs.join("|") } : {}),
+      ...(inList.length ? { in_list: inList } : {}),
     }, token);
   } catch (e) {
     console.error("Failed to fetch TMDB movie list:", e);
@@ -82,6 +84,7 @@ collection.forEach((v) => baseParams.append("collection", v));
 watch.forEach((v) => baseParams.append("watch", v));
 if (hasRadarr) arr.forEach((v) => baseParams.append("arr", v));
 langs.forEach((l) => baseParams.append("lang", l));
+inList.forEach((v) => baseParams.append("in_list", v));
 const baseUrl = `/movies?${baseParams.toString()}`;
 ---
 
@@ -126,6 +129,7 @@ const baseUrl = `/movies?${baseParams.toString()}`;
             ] : []),
             ...(hasRadarr ? [{ key: "arr", label: "Radarr", options: [{ value: "added", label: "In Radarr" }, { value: "notadded", label: "Not In Radarr" }], selected: arr }] : []),
             { key: "lang", label: "Language", options: LANGUAGES, selected: langs },
+            { key: "in_list", label: "Lists", options: [{ value: "in", label: "In a List" }, { value: "out", label: "Not In a List" }], selected: inList },
           ]}
         />
       </div>

--- a/frontend/src/pages/shows.astro
+++ b/frontend/src/pages/shows.astro
@@ -16,6 +16,7 @@ const collection = Astro.url.searchParams.getAll("collection");
 const watch = Astro.url.searchParams.getAll("watch");
 const arr = Astro.url.searchParams.getAll("arr");
 const langs = Astro.url.searchParams.getAll("lang");
+const inList = Astro.url.searchParams.getAll("in_list");
 const page = Number(Astro.url.searchParams.get("page") ?? 1);
 const { token, user } = Astro.locals;
 Astro.response.headers.set("Cache-Control", "no-store");
@@ -48,6 +49,7 @@ if (hasTmdbKey) {
       ...(watch.length ? { watch } : {}),
       ...(hasSonarr && arr.length ? { arr } : {}),
       ...(langs.length ? { original_language: langs.join("|") } : {}),
+      ...(inList.length ? { in_list: inList } : {}),
     }, token);
   } catch (e) {
     console.error("Failed to fetch TMDB show list:", e);
@@ -87,6 +89,7 @@ collection.forEach((v) => baseParams.append("collection", v));
 watch.forEach((v) => baseParams.append("watch", v));
 if (hasSonarr) arr.forEach((v) => baseParams.append("arr", v));
 langs.forEach((l) => baseParams.append("lang", l));
+inList.forEach((v) => baseParams.append("in_list", v));
 const baseUrl = `/shows?${baseParams.toString()}`;
 ---
 
@@ -132,6 +135,7 @@ const baseUrl = `/shows?${baseParams.toString()}`;
             ] : []),
             ...(hasSonarr ? [{ key: "arr", label: "Sonarr", options: [{ value: "added", label: "In Sonarr" }, { value: "notadded", label: "Not In Sonarr" }], selected: arr }] : []),
             { key: "lang", label: "Language", options: LANGUAGES, selected: langs },
+            { key: "in_list", label: "Lists", options: [{ value: "in", label: "In a List" }, { value: "out", label: "Not In a List" }], selected: inList },
           ]}
         />
       </div>


### PR DESCRIPTION
Closes #255. Adds a "Lists" filter (**In a List** / **Not in a List** — membership of any of the user's own lists) to the four browse pages: Explore Movies, Explore Shows, My Collection movies and My Collection shows.

How it works per page:
- **My Collection (movies)**: an `in_list=in|out` query param on `GET /media`, implemented as an EXISTS subquery on the user's list items — no extra round trips.
- **My Collection (shows)**: same param on `GET /shows`; a show counts as "in a list" when its series Media row is on one of the user's lists (season-level list items live on that same series row, so they count too).
- **Explore (both)**: TMDB results don't know about local lists, so this reuses the existing post-enrichment local-filter pass (`_apply_local_filters`) that already handles the collection/watched/arr filters — the enrichment already computes `in_lists` per item.

Frontend: one extra single-select section in the existing FilterPanel on each page, same interaction as the other filters. No schema changes, no new endpoints.
