### PR TITLE
fix(backend): listen on 0.0.0.0 instead of localhost

### DIFF
--- a/supervisord.conf
+++ b/supervisord.conf
@@ -14,7 +14,7 @@ logfile_maxbytes=0
 pidfile=/tmp/supervisord.pid
 
 [program:backend]
-command=/app/backend/.venv/bin/uvicorn main:app --host 127.0.0.1 --port %(ENV_BACKEND_PORT)s
+command=/app/backend/.venv/bin/uvicorn main:app --host 0.0.0.0 --port %(ENV_BACKEND_PORT)s
 directory=/app/backend
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0

--- a/supervisord.omnibus.conf
+++ b/supervisord.omnibus.conf
@@ -23,7 +23,7 @@ autorestart=true
 priority=0
 
 [program:backend]
-command=/bin/sh -c "until pg_isready -h 127.0.0.1 -q 2>/dev/null; do sleep 0.5; done && exec /app/backend/.venv/bin/uvicorn main:app --host 127.0.0.1 --port %(ENV_BACKEND_PORT)s"
+command=/bin/sh -c "until pg_isready -h 127.0.0.1 -q 2>/dev/null; do sleep 0.5; done && exec /app/backend/.venv/bin/uvicorn main:app --host 0.0.0.0 --port %(ENV_BACKEND_PORT)s"
 directory=/app/backend
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0


### PR DESCRIPTION
## Summary

Bind the backend (uvicorn) to `0.0.0.0` instead of `127.0.0.1` in both supervisord configs.

## Problem

The backend binds to `127.0.0.1` inside the container. Docker's port mapping forwards from the host to the container's network interface, but since uvicorn only listens on loopback (`127.0.0.1`), external connections (including `docker port` mappings to the host) are rejected with "Connection reset by peer".

This makes port `7331` unreachable from outside the container — blocking direct API access, Swagger/ReDoc documentation, and any external tooling that needs to hit the backend without going through the Astro proxy (`/api/proxy/*`).

## Changes

- **`supervisord.conf`** — `--host 127.0.0.1` → `--host 0.0.0.0`
- **`supervisord.omnibus.conf`** — same change

No other code changes. PostgreSQL in omnibus still binds to `127.0.0.1` (correct — it's internal-only).

## What this enables

After this change, port `7331` is accessible from outside the container when mapped in `docker-compose.yaml`:

```yaml
ports:
  - "7331:7331"
```

This allows:
- Direct API calls (`curl http://localhost:7331/health`)
- Swagger UI at `docs` and ReDoc at `/redoc`
- External tools/scripts to interact with the backend API without the Astro proxy