### PR TITLE
fix(history): expose Next Up watch activity

### DIFF
--- a/backend/routers/history.py
+++ b/backend/routers/history.py
@@ -620,6 +620,15 @@ def _group_last_watched(
     return last_per_show, last_watched_at
 
 
+def _attach_next_up_last_watched(
+    items: list[dict], last_watched_at: dict[int, datetime]
+) -> None:
+    """Expose the timestamp used to order Next Up items in the API response."""
+    for item in items:
+        watched_at = last_watched_at.get(item.get("show_id"))
+        item["last_watched_at"] = watched_at.isoformat() if watched_at else None
+
+
 def _has_aired(release_date: str | None, today: date) -> bool:
     """True if release_date (ISO 8601, e.g. from TMDB air_date) is on or before
     today, or unknown. ISO 8601 strings sort lexicographically the same as their
@@ -1001,6 +1010,7 @@ async def get_next_up(
     )
 
     items = [_format_media_item(m) for m in next_up]
+    _attach_next_up_last_watched(items, last_watched_at)
     for item in items:
         item["next_up_hidden"] = item.get("show_id") in hidden_set
         show_stats = remaining_stats.get(item.get("show_id"))

--- a/backend/tests/test_next_up.py
+++ b/backend/tests/test_next_up.py
@@ -5,7 +5,14 @@ from datetime import date, datetime, timezone
 os.environ.setdefault("SECRET_KEY", "test-secret")
 os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://test:test@localhost/test")
 
-from routers.history import _compute_next_episode, _group_last_watched, _has_aired, _has_confirmed_air_date, _remaining_episode_stats
+from routers.history import (
+    _attach_next_up_last_watched,
+    _compute_next_episode,
+    _group_last_watched,
+    _has_aired,
+    _has_confirmed_air_date,
+    _remaining_episode_stats,
+)
 
 
 class ComputeNextEpisodeTests(unittest.TestCase):
@@ -84,6 +91,25 @@ class GroupLastWatchedTests(unittest.TestCase):
         rows = [(1, None, 1, None), (1, None, 2, None)]
         last_per_show, last_watched_at = _group_last_watched(rows)
         self.assertNotIn(1, last_per_show)
+
+
+class AttachNextUpLastWatchedTests(unittest.TestCase):
+    """Regression tests for #237: expose the timestamp used for Next Up order."""
+
+    def test_adds_iso_timestamp_for_each_show(self):
+        watched_at = datetime(2026, 8, 16, 14, 30, tzinfo=timezone.utc)
+        items = [{"show_id": 12}]
+
+        _attach_next_up_last_watched(items, {12: watched_at})
+
+        self.assertEqual(items[0]["last_watched_at"], "2026-08-16T14:30:00+00:00")
+
+    def test_adds_null_when_watch_history_has_no_timestamp(self):
+        items = [{"show_id": 12}]
+
+        _attach_next_up_last_watched(items, {})
+
+        self.assertIsNone(items[0]["last_watched_at"])
 
 
 class HasAiredTests(unittest.TestCase):

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -583,6 +583,8 @@ export interface MediaItem {
   tvdb_season_number?: number | null;
   tvdb_episode_number?: number | null;
   next_up_hidden?: boolean;
+  // Most recent watched episode timestamp used to order Next Up (#237).
+  last_watched_at?: string | null;
   // Next Up remaining-content estimate (#170) — released unwatched episodes
   // for the show and their estimated total runtime in minutes.
   episodes_left?: number | null;


### PR DESCRIPTION
## Summary

- expose the existing Next Up ordering timestamp as `last_watched_at`
- return an ISO 8601 timestamp or `null` for history without a date
- document the field in the frontend `MediaItem` type

Closes #237

## Verification

- `uv run python -m unittest tests.test_next_up -v` (26 tests)
- `ASTRO_TELEMETRY_DISABLED=1 npm run build`
- `git -c core.whitespace=cr-at-eol diff --check`
