### PR TITLE
fix(nuvio): preserve library added dates

### DIFF
--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -225,8 +225,8 @@ def provider_added_at(item: dict, source: CollectionSource) -> datetime | None:
     or unparseable, in which case the caller leaves the column on its server
     default. Sources are matched explicitly rather than through
     _MEDIA_BROWSER_ITEM_SOURCES: Nuvio and Stremio items are synthesized with
-    a fixed key set and carry no date, and matching them here would only wait
-    for a key rename to start feeding in something wrong."""
+    a fixed key set. Nuvio library records explicitly retain their source
+    add-date; Stremio has no library add-date."""
     if source is CollectionSource.plex:
         raw = item.get("addedAt")
         if raw is None:
@@ -245,6 +245,15 @@ def provider_added_at(item: dict, source: CollectionSource) -> datetime | None:
         except (TypeError, ValueError):
             return None
         return dt.astimezone(timezone.utc).replace(tzinfo=None) if dt.tzinfo else dt
+
+    if source is CollectionSource.nuvio:
+        raw = item.get("added_at")
+        if raw is None:
+            return None
+        try:
+            return datetime.fromtimestamp(int(raw) / 1000, tz=timezone.utc).replace(tzinfo=None)
+        except (TypeError, ValueError, OSError, OverflowError):
+            return None
 
     return None
 
@@ -3803,6 +3812,9 @@ def _normalize_nuvio_item(
         "SeriesName": title if is_episode else None,
         "ParentIndexNumber": int(season) if season is not None else None,
         "IndexNumber": int(episode) if episode is not None else None,
+        # Retain Nuvio's per-item epoch-millisecond library add-date so the
+        # generic collection sync can persist it on Collection.added_at.
+        "added_at": record.get("added_at"),
         "UserData": {
             "Played": watched,
             "PlayCount": 1 if watched else 0,

--- a/backend/tests/test_nuvio.py
+++ b/backend/tests/test_nuvio.py
@@ -702,6 +702,21 @@ class NuvioWatchHistoryTests(unittest.IsolatedAsyncioTestCase):
         )
 
 class NuvioNormalizationTests(unittest.TestCase):
+    def test_library_item_retains_added_at_for_collection_sync(self) -> None:
+        normalized = _normalize_nuvio_item(
+            {
+                "content_id": "tmdb:550",
+                "content_type": "movie",
+                "name": "Fight Club",
+                "added_at": 1711600000000,
+            },
+            profile_id=1,
+        )
+
+        self.assertIsNotNone(normalized)
+        _, item = normalized
+        self.assertEqual(item["added_at"], 1711600000000)
+
     def test_episode_history_maps_to_tmdb_series_and_watch_state(self) -> None:
         normalized = _normalize_nuvio_item(
             {

--- a/backend/tests/test_sync.py
+++ b/backend/tests/test_sync.py
@@ -704,9 +704,15 @@ class ProviderAddedAtTests(unittest.TestCase):
         )
         self.assertEqual(got, datetime(2026, 8, 1, 9, 30, 0))
 
+    def test_nuvio_epoch_milliseconds(self):
+        got = sync.provider_added_at(
+            {"added_at": 1711600000000}, sync.CollectionSource.nuvio
+        )
+        self.assertEqual(got, datetime(2024, 3, 28, 4, 26, 40))
+
     def test_sources_without_a_library_date_return_none(self):
-        # Nuvio and Stremio items are synthesized with a fixed key set, so they
-        # must never be read as if they were a media browser payload.
+        # Synthesized Nuvio/Stremio items must not be read as media-browser
+        # payloads. Nuvio's retained ``added_at`` has its own parser above.
         for source in (sync.CollectionSource.nuvio, sync.CollectionSource.stremio):
             self.assertIsNone(
                 sync.provider_added_at({"DateCreated": "2026-08-01T09:30:00Z"}, source)


### PR DESCRIPTION
## Summary

- carry Nuvio added_at values through library normalization
- parse Nuvio epoch-millisecond timestamps into collection add dates
- preserve the existing fallback for missing or malformed timestamps

Closes #244

## Verification

- uv run python -m unittest tests.test_sync tests.test_nuvio
- 77 tests passed
- git diff --check