### PR TITLE
fix(plex): scope rating keys to connections

### DIFF
--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -1018,12 +1018,17 @@ async def _fan_out_changes_to_other_connections(
     if push_candidates:
         # Chunk the IN clause to stay under asyncpg's 32767-parameter limit.
         # A large first-time sync can produce tens of thousands of changed IDs.
-        source_ids_map: dict[tuple[CollectionSource, int], list[str]] = {}
+        source_ids_map: dict[tuple[CollectionSource, int | None, int], list[str]] = {}
         all_changed_list = list(all_changed_ids)
         for i in range(0, len(all_changed_list), _MAX_IN_PARAMS):
             chunk = all_changed_list[i : i + _MAX_IN_PARAMS]
             files_result = await db.execute(
-                select(CollectionFile.source_id, CollectionFile.source, Collection.media_id)
+                select(
+                    CollectionFile.source_id,
+                    CollectionFile.source,
+                    CollectionFile.connection_id,
+                    Collection.media_id,
+                )
                 .join(Collection, Collection.id == CollectionFile.collection_id)
                 .where(
                     Collection.user_id == user_id,
@@ -1031,8 +1036,11 @@ async def _fan_out_changes_to_other_connections(
                     CollectionFile.source_id.isnot(None),
                 )
             )
-            for source_id, source_type, media_id in files_result.all():
-                source_ids_map.setdefault((source_type, media_id), []).append(source_id)
+            for source_id, source_type, source_connection_id, media_id in files_result.all():
+                source_ids_map.setdefault(
+                    (source_type, source_connection_id, media_id),
+                    [],
+                ).append(source_id)
 
         import httpx as _httpx
         sem = asyncio.Semaphore(20)
@@ -1172,7 +1180,7 @@ async def _fan_out_changes_to_other_connections(
             conn_source = CollectionSource(conn.type)
             if conn.push_watched:
                 for mid in new_watched_ids:
-                    for sid in source_ids_map.get((conn_source, mid), []):
+                    for sid in source_ids_map.get((conn_source, conn.id, mid), []):
                         if conn.type == "plex":
                             push_tasks.append(_guarded(plex.mark_watched(conn.url, conn.token, sid)))
                         elif conn.type == "jellyfin":
@@ -1212,7 +1220,7 @@ async def _fan_out_changes_to_other_connections(
 
                             push_tasks.append(_guarded(_set_plex_season_rating()))
                         continue
-                    for sid in source_ids_map.get((conn_source, mid), []):
+                    for sid in source_ids_map.get((conn_source, conn.id, mid), []):
                         if conn.type == "plex":
                             push_tasks.append(_guarded(plex.set_rating(conn.url, conn.token, sid, rating)))
                         elif conn.type == "jellyfin":
@@ -6175,6 +6183,7 @@ async def _run_full_push(user_id: int, connection_id: int, job_id: int) -> None:
                         Collection.user_id == user_id,
                         Collection.media_id.in_(chunk),
                         CollectionFile.source == conn_source,
+                        CollectionFile.connection_id == conn.id,
                         CollectionFile.source_id.isnot(None),
                     )
                 )

--- a/backend/tests/test_season_ratings.py
+++ b/backend/tests/test_season_ratings.py
@@ -11,7 +11,7 @@ from models.base import MediaType
 from models.media import Media
 from routers.mdblist import _import_ratings
 from routers.trakt import _apply_imported_rating
-from routers.sync import _fan_out_changes_to_other_connections
+from routers.sync import _fan_out_changes_to_other_connections, _run_full_push
 
 
 def _scalar_result(items: list) -> MagicMock:
@@ -24,6 +24,23 @@ def _rows_result(items: list[tuple]) -> MagicMock:
     result = MagicMock()
     result.all.return_value = items
     return result
+
+
+def _scalar_one_or_none_result(item) -> MagicMock:
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = item
+    return result
+
+
+class _SessionCM:
+    def __init__(self, db) -> None:
+        self.db = db
+
+    async def __aenter__(self):
+        return self.db
+
+    async def __aexit__(self, *exc_info):
+        return False
 
 
 def _settings() -> SimpleNamespace:
@@ -57,7 +74,95 @@ def _plex_connection() -> SimpleNamespace:
     )
 
 
+def _plex_connection_with_id(connection_id: int) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=connection_id,
+        type="plex",
+        url=f"http://plex-{connection_id}.local",
+        token=f"plex-token-{connection_id}",
+        server_user_id=None,
+        push_watched=False,
+        push_ratings=True,
+        push_playback=False,
+    )
+
+
 class SeasonRatingFanoutTests(unittest.IsolatedAsyncioTestCase):
+    async def test_movie_rating_uses_only_the_target_plex_connection_rating_key(self) -> None:
+        """Plex ratingKeys are local to each server and must never cross fan-out targets."""
+        media = Media(
+            id=1,
+            tmdb_id=550,
+            media_type=MediaType.movie,
+            title="Fight Club",
+        )
+        first = _plex_connection_with_id(7)
+        second = _plex_connection_with_id(8)
+        db = SimpleNamespace(
+            execute=AsyncMock(
+                side_effect=[
+                    _scalar_result([media]),
+                    _scalar_result([first, second]),
+                    _rows_result([
+                        ("101", "plex", 7, 1),
+                        ("202", "plex", 8, 1),
+                    ]),
+                ]
+            ),
+            commit=AsyncMock(),
+        )
+
+        with patch("routers.sync.plex.set_rating", AsyncMock(return_value=True)) as set_plex:
+            await _fan_out_changes_to_other_connections(
+                db,
+                user_id=3,
+                exclude_connection_id=None,
+                new_watched_ids=set(),
+                new_ratings={(1, None): 8.0},
+                settings=None,
+            )
+
+        self.assertCountEqual(
+            set_plex.await_args_list,
+            [
+                unittest.mock.call("http://plex-7.local", "plex-token-7", "101", 8.0),
+                unittest.mock.call("http://plex-8.local", "plex-token-8", "202", 8.0),
+            ],
+        )
+
+    async def test_full_push_scopes_known_plex_rating_keys_to_the_connection(self) -> None:
+        conn = _plex_connection_with_id(8)
+        conn.plex_push_watchlist = False
+        db = SimpleNamespace(
+            execute=AsyncMock(
+                side_effect=[
+                    MagicMock(),
+                    _scalar_one_or_none_result(conn),
+                    _rows_result([(1, None, 8.0)]),
+                    _rows_result([("202", 1)]),
+                    MagicMock(),
+                    MagicMock(),
+                ]
+            ),
+            commit=AsyncMock(),
+        )
+
+        with (
+            patch("routers.sync.async_sessionmaker", return_value=lambda: _SessionCM(db)),
+            patch("routers.sync.plex.set_rating", AsyncMock(return_value=True)) as set_plex,
+        ):
+            await _run_full_push(user_id=3, connection_id=8, job_id=99)
+
+        set_plex.assert_awaited_once_with(
+            "http://plex-8.local",
+            "plex-token-8",
+            "202",
+            8.0,
+            client=unittest.mock.ANY,
+        )
+        source_id_query = db.execute.await_args_list[3].args[0]
+        self.assertIn("collection_files.connection_id", str(source_id_query))
+
     async def test_season_rating_fans_out_with_provider_specific_identity(self) -> None:
         media = Media(
             id=1,


### PR DESCRIPTION
## Summary

- scope automatic fan-out source IDs by provider connection as well as media
- restrict manual full-push CollectionFile lookups to the target Plex connection
- cover multiple Plex servers so each target receives only its own ratingKey

Closes #257

## Verification

- uv run python -m unittest tests.test_sync tests.test_season_ratings
- 61 tests passed
- git diff --check