### PR TITLE
feat(calendar): honor hidden shows

### DIFF
--- a/backend/routers/calendar.py
+++ b/backend/routers/calendar.py
@@ -33,23 +33,25 @@ from models.collection import Collection
 from models.events import WatchEvent
 from models.media import Media
 from models.show import Show
-from models.users import User
+from models.users import User, UserSettings
 
 router = APIRouter()
 
 CALENDAR_TTL = timedelta(hours=24)
-CALENDAR_SCHEMA = 3
+CALENDAR_SCHEMA = 4
 CALENDAR_WINDOW_DAYS = 14
 FETCH_CONCURRENCY = 8
 
 _computing: set[int] = set()
 
 
-async def _candidate_shows(db: AsyncSession, user_id: int) -> list[Show]:
-    """Shows the user is either collecting or has watched at least one
-    episode of - the "no Plex connected" case still needs to show up via
-    watch history alone (Trakt/manual import/etc.), not just synced library
-    collection."""
+def _candidate_show_query(user_id: int, hidden_show_ids: list[int]):
+    """Build the per-user calendar candidate query.
+
+    Next Up's hidden-show list is the existing per-user show-hiding signal.
+    Calendar uses the same preference so it does not keep surfacing a show
+    the user explicitly dismissed elsewhere in the app.
+    """
     collected_show_ids = (
         select(Media.show_id)
         .join(Collection, Collection.media_id == Media.id)
@@ -73,12 +75,27 @@ async def _candidate_shows(db: AsyncSession, user_id: int) -> list[Show]:
         .where(Collection.user_id == user_id, Media.media_type == MediaType.series, Media.tmdb_id.isnot(None))
         .distinct()
     )
+    filters = [or_(
+        Show.id.in_(collected_show_ids),
+        Show.id.in_(watched_show_ids),
+        Show.tmdb_id.in_(direct_series_tmdb_ids),
+    )]
+    if hidden_show_ids:
+        filters.append(Show.id.notin_(hidden_show_ids))
+    return select(Show).where(*filters)
+
+
+async def _candidate_shows(db: AsyncSession, user_id: int) -> list[Show]:
+    """Shows the user is either collecting or has watched at least one
+    episode of - the "no Plex connected" case still needs to show up via
+    watch history alone (Trakt/manual import/etc.), not just synced library
+    collection."""
+    settings = (await db.execute(
+        select(UserSettings.next_up_hidden_shows).where(UserSettings.user_id == user_id)
+    )).scalar_one_or_none()
+    hidden_show_ids = list(settings or [])
     shows = (await db.execute(
-        select(Show).where(or_(
-            Show.id.in_(collected_show_ids),
-            Show.id.in_(watched_show_ids),
-            Show.tmdb_id.in_(direct_series_tmdb_ids),
-        ))
+        _candidate_show_query(user_id, hidden_show_ids)
     )).scalars().all()
     return [s for s in shows if s.tmdb_id and (s.status or "") not in ("Ended", "Canceled")]
 

--- a/backend/routers/history.py
+++ b/backend/routers/history.py
@@ -14,6 +14,7 @@ from models.events import WatchEvent
 from models.playback_session import PlaybackSession
 from models.playback_progress import PlaybackProgress
 from models.collection import Collection, CollectionFile
+from models.calendar_cache import UserCalendarCache
 from models.base import MediaType, CollectionSource
 from models.users import UserSettings
 from models.connections import MediaServerConnection
@@ -1046,6 +1047,7 @@ async def hide_next_up_show(
         hidden.append(body.show_id)
         settings.next_up_hidden_shows = hidden
         flag_modified(settings, "next_up_hidden_shows")
+        await db.execute(delete(UserCalendarCache).where(UserCalendarCache.user_id == current_user.id))
         await db.commit()
     return {"status": "ok"}
 
@@ -1064,6 +1066,7 @@ async def unhide_next_up_show(
             hidden.remove(show_id)
             settings.next_up_hidden_shows = hidden
             flag_modified(settings, "next_up_hidden_shows")
+            await db.execute(delete(UserCalendarCache).where(UserCalendarCache.user_id == current_user.id))
             await db.commit()
     return {"status": "ok"}
 

--- a/backend/tests/test_calendar.py
+++ b/backend/tests/test_calendar.py
@@ -1,0 +1,31 @@
+import os
+import unittest
+
+os.environ.setdefault("SECRET_KEY", "test-secret")
+os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://test:test@localhost/test")
+
+from sqlalchemy.dialects import postgresql
+
+from routers.calendar import _candidate_show_query
+
+
+class CalendarCandidateQueryTests(unittest.TestCase):
+    """A show hidden from Next Up is also hidden from Calendar (#258)."""
+
+    def test_excludes_the_users_hidden_shows(self):
+        rendered = str(
+            _candidate_show_query(12, [3, 7]).compile(dialect=postgresql.dialect())
+        )
+
+        self.assertIn("shows.id NOT IN", rendered)
+
+    def test_keeps_the_query_unrestricted_without_hidden_shows(self):
+        rendered = str(
+            _candidate_show_query(12, []).compile(dialect=postgresql.dialect())
+        )
+
+        self.assertNotIn("shows.id NOT IN", rendered)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_next_up.py
+++ b/backend/tests/test_next_up.py
@@ -1,11 +1,25 @@
 import os
 import unittest
 from datetime import date, datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 os.environ.setdefault("SECRET_KEY", "test-secret")
 os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://test:test@localhost/test")
 
-from routers.history import _compute_next_episode, _group_last_watched, _has_aired, _has_confirmed_air_date, _remaining_episode_stats
+from sqlalchemy.dialects import postgresql
+
+from models.users import UserSettings
+from routers.history import (
+    NextUpHideRequest,
+    _compute_next_episode,
+    _group_last_watched,
+    _has_aired,
+    _has_confirmed_air_date,
+    _remaining_episode_stats,
+    hide_next_up_show,
+    unhide_next_up_show,
+)
 
 
 class ComputeNextEpisodeTests(unittest.TestCase):
@@ -173,3 +187,50 @@ class RemainingEpisodeStatsTests(unittest.TestCase):
         stats = _remaining_episode_stats({1: 4}, {1: 1}, avg_runtime=42.5)
         self.assertEqual(stats["episodes_left"], 3)
         self.assertEqual(stats["remaining_runtime"], 128)
+
+
+class _HideResult:
+    def __init__(self, settings):
+        self.settings = settings
+
+    def scalar_one_or_none(self):
+        return self.settings
+
+
+class _HideDB:
+    def __init__(self, settings):
+        self.settings = settings
+        self.statements = []
+        self.commit = AsyncMock()
+
+    async def execute(self, statement):
+        self.statements.append(statement)
+        return _HideResult(self.settings)
+
+
+class NextUpCalendarInvalidationTests(unittest.IsolatedAsyncioTestCase):
+    """Changing the shared hidden-show list must invalidate Calendar's cache."""
+
+    async def test_hiding_a_show_invalidates_its_calendar(self):
+        settings = UserSettings(user_id=3, next_up_hidden_shows=[])
+        db = _HideDB(settings)
+
+        await hide_next_up_show(NextUpHideRequest(show_id=9), db, SimpleNamespace(id=3))
+
+        self.assertEqual(settings.next_up_hidden_shows, [9])
+        self.assertEqual(db.commit.await_count, 1)
+        self.assertEqual(len(db.statements), 2)
+        rendered = str(db.statements[1].compile(dialect=postgresql.dialect()))
+        self.assertIn("DELETE FROM user_calendar_cache", rendered)
+
+    async def test_restoring_a_show_invalidates_its_calendar(self):
+        settings = UserSettings(user_id=3, next_up_hidden_shows=[9])
+        db = _HideDB(settings)
+
+        await unhide_next_up_show(9, db, SimpleNamespace(id=3))
+
+        self.assertEqual(settings.next_up_hidden_shows, [])
+        self.assertEqual(db.commit.await_count, 1)
+        self.assertEqual(len(db.statements), 2)
+        rendered = str(db.statements[1].compile(dialect=postgresql.dialect()))
+        self.assertIn("DELETE FROM user_calendar_cache", rendered)

--- a/frontend/src/pages/next-up.astro
+++ b/frontend/src/pages/next-up.astro
@@ -144,7 +144,7 @@ Astro.response.headers.set("Cache-Control", "no-store");
       <button
         class="nextup-hide-btn absolute top-1.5 right-1.5 z-10 w-7 h-7 rounded-lg flex items-center justify-center transition-all duration-200 cursor-pointer ${isHidden ? 'bg-amber-900/60 border border-amber-600 text-amber-300 hover:bg-amber-700 hover:border-amber-500 hover:text-white' : 'bg-zinc-950/80 border border-zinc-800 text-zinc-500 hover:text-rose-200 hover:border-rose-700 hover:bg-rose-900'}"
         data-show-id="${esc(String(item.show_id))}"
-        title="${isHidden ? 'Restore to Next Up' : 'Hide from Next Up'}"
+        title="${isHidden ? 'Restore to Next Up and Calendar' : 'Hide from Next Up and Calendar'}"
       >${isHidden ? EYE : EYE_SLASH}</button>
     ` : '';
 
@@ -253,7 +253,7 @@ Astro.response.headers.set("Cache-Control", "no-store");
             wrapper.classList.remove('opacity-50', 'hidden');
             btn.classList.remove('bg-amber-900/60', 'border-amber-600', 'text-amber-300', 'hover:bg-amber-700', 'hover:border-amber-500', 'hover:text-white');
             btn.classList.add('bg-zinc-950/80', 'border-zinc-800', 'text-zinc-500', 'hover:text-white', 'hover:border-red-600', 'hover:bg-red-700');
-            btn.title = 'Hide from Next Up';
+            btn.title = 'Hide from Next Up and Calendar';
             btn.innerHTML = EYE_SLASH;
           } else {
             await fetch('/api/proxy/history/next-up/hide', {
@@ -271,7 +271,7 @@ Astro.response.headers.set("Cache-Control", "no-store");
             }
             btn.classList.remove('bg-zinc-950/80', 'border-zinc-800', 'text-zinc-500', 'hover:text-white', 'hover:border-red-600', 'hover:bg-red-700');
             btn.classList.add('bg-amber-900/60', 'border-amber-600', 'text-amber-300', 'hover:bg-amber-700', 'hover:border-amber-500', 'hover:text-white');
-            btn.title = 'Restore to Next Up';
+            btn.title = 'Restore to Next Up and Calendar';
             btn.innerHTML = EYE;
           }
           btn.disabled = false;


### PR DESCRIPTION
## Summary

- exclude shows hidden from Next Up from the episode Calendar as well
- invalidate the per-user calendar cache immediately on hide or restore
- invalidate old cached payloads through a calendar schema bump
- clarify in the Next Up UI that the control affects both views

Closes #258

## Verification

- uv run python -m unittest tests.test_calendar tests.test_next_up
- 28 tests passed
- ASTRO_TELEMETRY_DISABLED=1 npm run build
- git diff --check with CR-at-EOL handling for existing CRLF files