### PR TITLE
fix(docker): report baked image version

### DIFF
--- a/.github/workflows/docker-x64.yml
+++ b/.github/workflows/docker-x64.yml
@@ -41,13 +41,22 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Resolve image version
+        id: version
+        shell: bash
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            echo "value=${GITHUB_REF_NAME#v}" >> "${GITHUB_OUTPUT}"
+          else
+            echo "value=dev" >> "${GITHUB_OUTPUT}"
+          fi
+
       - name: Extract Docker metadata (standard image)
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
-            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
             type=ref,event=branch
             type=semver,pattern={{version}}
             type=sha,format=short
@@ -59,6 +68,8 @@ jobs:
           file: Dockerfile
           platforms: linux/amd64
           push: true
+          build-args: |
+            APP_VERSION=${{ steps.version.outputs.value }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=docker-x64
@@ -72,7 +83,6 @@ jobs:
           flavor: |
             suffix=-omnibus
           tags: |
-            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
             type=ref,event=branch
             type=semver,pattern={{version}}
             type=sha,format=short
@@ -84,6 +94,8 @@ jobs:
           file: Dockerfile.omnibus
           platforms: linux/amd64
           push: true
+          build-args: |
+            APP_VERSION=${{ steps.version.outputs.value }}
           tags: ${{ steps.meta-omnibus.outputs.tags }}
           labels: ${{ steps.meta-omnibus.outputs.labels }}
           cache-from: type=gha,scope=docker-omnibus-x64

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,8 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 # ── Backend ───────────────────────────────────────────────────────────────────
 WORKDIR /app/backend
 
+RUN printf '%s\n' "$APP_VERSION" > /app/APP_VERSION
+
 COPY backend/pyproject.toml backend/uv.lock ./
 RUN uv sync --frozen --no-dev --no-cache
 

--- a/Dockerfile.omnibus
+++ b/Dockerfile.omnibus
@@ -37,6 +37,8 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 # ── Backend ───────────────────────────────────────────────────────────────────
 WORKDIR /app/backend
 
+RUN printf '%s\n' "$APP_VERSION" > /app/APP_VERSION
+
 COPY backend/pyproject.toml backend/uv.lock ./
 RUN uv sync --frozen --no-dev --no-cache
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",
+    "test": "node --test tests/*.test.mjs",
     "preview": "astro preview",
     "astro": "astro"
   },

--- a/frontend/src/lib/imageVersion.mjs
+++ b/frontend/src/lib/imageVersion.mjs
@@ -1,0 +1,17 @@
+import { readFile } from "node:fs/promises";
+
+const IMAGE_VERSION_FILE = "/app/APP_VERSION";
+
+/**
+ * Read the version baked into the image filesystem. This intentionally does
+ * not let APP_VERSION override the baked value: some container updaters carry
+ * the previous container's environment into a replacement container. The
+ * environment remains a fallback for bare-metal development and deployments.
+ */
+export async function readImageVersion(readFileFn = readFile, env = process.env) {
+  try {
+    const bakedVersion = (await readFileFn(IMAGE_VERSION_FILE, "utf8")).trim();
+    if (bakedVersion) return bakedVersion;
+  } catch {}
+  return env.APP_VERSION?.trim() || "dev";
+}

--- a/frontend/src/pages/about.astro
+++ b/frontend/src/pages/about.astro
@@ -1,9 +1,10 @@
 ---
 import Base from "../layouts/Base.astro";
+import { readImageVersion } from "../lib/imageVersion.mjs";
 
 Astro.response.headers.set("Cache-Control", "no-store");
 
-const currentVersion = process.env.APP_VERSION ?? 'dev';
+const currentVersion = await readImageVersion();
 
 let latestVersion: string | null = null;
 let releaseUrl: string | null = null;

--- a/frontend/tests/dockerWorkflow.test.mjs
+++ b/frontend/tests/dockerWorkflow.test.mjs
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const workflowUrl = new URL("../../.github/workflows/docker-x64.yml", import.meta.url);
+
+test("the development workflow cannot overwrite release latest tags", async () => {
+  const workflow = await readFile(workflowUrl, "utf8");
+
+  assert.doesNotMatch(workflow, /type=raw,value=latest/);
+  assert.equal(
+    workflow.match(/APP_VERSION=\$\{\{ steps\.version\.outputs\.value \}\}/g)?.length,
+    2,
+  );
+});

--- a/frontend/tests/imageVersion.test.mjs
+++ b/frontend/tests/imageVersion.test.mjs
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { readImageVersion } from "../src/lib/imageVersion.mjs";
+
+test("uses the trimmed version baked into the image", async () => {
+  assert.equal(
+    await readImageVersion(async () => "1.53.1\n", { APP_VERSION: "1.52.1" }),
+    "1.53.1",
+  );
+});
+
+test("falls back to the environment outside an image", async () => {
+  assert.equal(
+    await readImageVersion(async () => { throw new Error("missing"); }, { APP_VERSION: "2.1.0" }),
+    "2.1.0",
+  );
+});
+
+test("uses dev when neither source has a version", async () => {
+  assert.equal(await readImageVersion(async () => "   \n", {}), "dev");
+  assert.equal(await readImageVersion(async () => { throw new Error("missing"); }, {}), "dev");
+});


### PR DESCRIPTION
## Summary

- bake the build-time version into both official image filesystems
- make About prefer that immutable image version over stale runtime environment values
- retain APP_VERSION as a fallback for bare-metal deployments
- stop the fast x64 development workflow from racing semantic release for latest tags
- pass explicit version values to x64 tag builds

Closes #140

## Verification

- npm test
- 4 tests passed
- ASTRO_TELEMETRY_DISABLED=1 npm run build
- Docker workflow YAML parsed successfully
- git diff --check