### PR TITLE
feat(history): add release-date watch option

### DIFF
--- a/backend/routers/history.py
+++ b/backend/routers/history.py
@@ -1074,6 +1074,9 @@ class SeasonWatchRequest(BaseModel):
     season_number: int
     episode_order: str | None = None
     watched_at: datetime | None = None  # omitted = now; explicit null = unknown date
+    # A season consists of episodes with distinct air dates. This is separate
+    # from watched_at, which applies one timestamp to every episode.
+    use_release_date: bool = False
 
 
 class ShowWatchRequest(BaseModel):
@@ -1537,6 +1540,9 @@ async def mark_season_watched(
     )
 
     all_season_episodes = []
+    # Use the dates just fetched for this operation. Existing Media rows can
+    # carry stale or incomplete metadata.
+    release_date_by_media_id: dict[int, datetime] = {}
     if tvdb_fallback_episodes is not None:
         existing_q = await db.execute(
             select(Media).where(
@@ -1550,12 +1556,26 @@ async def mark_season_watched(
             for media in existing_q.scalars().all()
         }
         for tvdb_ep in tvdb_fallback_episodes:
-            if tvdb_ep.get("episode_number") is None or not _has_aired(tvdb_ep.get("air_date"), today):
+            air_date_str = tvdb_ep.get("air_date")
+            release_watched_at = None
+            if air_date_str:
+                try:
+                    release_watched_at = datetime.strptime(air_date_str, "%Y-%m-%d")
+                except (TypeError, ValueError):
+                    pass
+            if tvdb_ep.get("episode_number") is None or not _has_aired(air_date_str, today):
+                continue
+            # TVDB may return an episode without an air date. Keep the existing
+            # bulk behavior for the other date modes, but a release-date action
+            # can only include episodes with a valid date to apply.
+            if body.use_release_date and release_watched_at is None:
                 continue
             position = (body.season_number, tvdb_ep["episode_number"])
             existing = existing_map.get(position)
             if existing:
                 all_season_episodes.append(existing)
+                if release_watched_at is not None:
+                    release_date_by_media_id[existing.id] = release_watched_at
                 continue
             new_ep = Media(
                 show_id=show.id,
@@ -1584,6 +1604,8 @@ async def mark_season_watched(
                     raise
                 new_ep = existing
             all_season_episodes.append(new_ep)
+            if release_watched_at is not None:
+                release_date_by_media_id[new_ep.id] = release_watched_at
     else:
         try:
             season_payloads = await asyncio.gather(
@@ -1629,6 +1651,9 @@ async def mark_season_watched(
                 existing = existing_map.get(position)
                 if existing:
                     all_season_episodes.append(existing)
+                    release_date_by_media_id[existing.id] = datetime.combine(
+                        air_date, datetime.min.time()
+                    )
                     continue
                 new_ep, _created = await create_media_safely(
                     db,
@@ -1643,6 +1668,9 @@ async def mark_season_watched(
                     tmdb_rating=ep.get("vote_average"),
                 )
                 all_season_episodes.append(new_ep)
+                release_date_by_media_id[new_ep.id] = datetime.combine(
+                    air_date, datetime.min.time()
+                )
 
     await db.flush() # Get IDs for new episodes
     
@@ -1658,10 +1686,13 @@ async def mark_season_watched(
     new_events = []
     for ep in all_season_episodes:
         if ep.id not in already_watched:
+            watched_at = resolved_watched_at
+            if body.use_release_date:
+                watched_at = release_date_by_media_id[ep.id]
             event = WatchEvent(
                 user_id=current_user.id,
                 media_id=ep.id,
-                watched_at=resolved_watched_at,
+                watched_at=watched_at,
                 completed=True,
                 play_count=1,
                 progress_percent=1.0,

--- a/backend/tests/test_history.py
+++ b/backend/tests/test_history.py
@@ -278,6 +278,52 @@ class MarkSeasonWatchedDateTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(response["count"], 1)
         self.assertEqual(event.watched_at, custom)
 
+    async def test_release_date_uses_the_episode_air_date(self) -> None:
+        response, event = await self._mark_season(use_release_date=True)
+        self.assertEqual(response["count"], 1)
+        self.assertEqual(event.watched_at, datetime(2020, 1, 1))
+
+    async def test_release_date_preserves_each_episode_air_date(self) -> None:
+        """A season release-date action creates one event per air date."""
+        show = Show(id=55, tmdb_id=100, title="Test Show")
+        db = _FakeSession([show, [], None, [], None])
+        db.info["tmdb_key_7"] = "test-key"
+        next_media_id = 100
+
+        def add_with_unique_media_ids(value):
+            nonlocal next_media_id
+            if isinstance(value, Media) and value.id is None:
+                next_media_id += 1
+                value.id = next_media_id
+            db.added.append(value)
+
+        db.add = add_with_unique_media_ids
+        payload = {
+            "episodes": [
+                {"episode_number": 1, "id": 999, "name": "Ep 1", "air_date": "2020-01-01", "vote_average": 8.0, "still_path": None},
+                {"episode_number": 2, "id": 1000, "name": "Ep 2", "air_date": "2020-01-08", "vote_average": 8.0, "still_path": None},
+            ]
+        }
+        with (
+            patch.object(history.tmdb, "get_season", AsyncMock(return_value=payload)),
+            patch("routers.history._push_watch_state", new_callable=AsyncMock),
+            patch("routers.history.record_rewatch_progress", new_callable=AsyncMock),
+        ):
+            response = await history.mark_season_watched(
+                history.SeasonWatchRequest(
+                    series_tmdb_id=100, season_number=1, use_release_date=True
+                ),
+                db,
+                SimpleNamespace(id=7),
+            )
+
+        events = [value for value in db.added if isinstance(value, WatchEvent)]
+        self.assertEqual(response["count"], 2)
+        self.assertEqual(
+            [event.watched_at for event in events],
+            [datetime(2020, 1, 1), datetime(2020, 1, 8)],
+        )
+
 
 class MarkShowWatchedDateTests(unittest.IsolatedAsyncioTestCase):
     """Same regression as MarkSeasonWatchedDateTests, but for mark_show_watched."""

--- a/frontend/src/components/EpisodeCard.astro
+++ b/frontend/src/components/EpisodeCard.astro
@@ -45,6 +45,7 @@ const collectionPct = item.collection_pct ?? (inLibrary ? 100 : 0);
   data-show-tvdb-id={item.show_tvdb_id ? String(item.show_tvdb_id) : ""}
   data-season={item.season_number != null ? String(item.season_number) : ""}
   data-episode-number={item.episode_number != null ? String(item.episode_number) : ""}
+  data-air-date={item.release_date ?? ""}
 >
   {href ? (
     <a href={href} class="block">

--- a/frontend/src/components/MediaCard.astro
+++ b/frontend/src/components/MediaCard.astro
@@ -57,6 +57,7 @@ const inLibrary = item.in_library ?? false;
   data-show-tvdb-id={item.show_tvdb_id ? String(item.show_tvdb_id) : ""}
   data-season={item.season_number != null ? String(item.season_number) : ""}
   data-episode-number={item.episode_number != null ? String(item.episode_number) : ""}
+  data-air-date={item.release_date ?? ""}
 >
   <!-- Clickable poster -->
   {href ? (
@@ -177,4 +178,3 @@ const inLibrary = item.in_library ?? false;
     </div>
   )}
 </div>
-

--- a/frontend/src/layouts/Base.astro
+++ b/frontend/src/layouts/Base.astro
@@ -436,10 +436,11 @@ const bottomNavItem = (active: boolean) =>
           Mark as unwatched
         </button>
         <p id="watch-history-add-play-label" class="text-[10px] font-bold uppercase tracking-wider text-zinc-500">Add a play</p>
-        <div class="flex gap-2">
+        <div id="watch-history-date-options" class="flex gap-2">
           <button id="watch-history-now-btn" class="flex-1 px-3 py-2 rounded-xl text-sm font-bold transition-all cursor-pointer bg-blue-600 text-white">Just now</button>
           <button id="watch-history-custom-btn" class="flex-1 px-3 py-2 rounded-xl text-sm font-bold transition-all cursor-pointer bg-zinc-800 text-zinc-400 border border-zinc-700 hover:text-zinc-200">Custom</button>
           <button id="watch-history-unknown-btn" class="flex-1 px-3 py-2 rounded-xl text-sm font-bold transition-all cursor-pointer bg-zinc-800 text-zinc-400 border border-zinc-700 hover:text-zinc-200">Unknown</button>
+          <button id="watch-history-release-btn" class="hidden flex-1 px-3 py-2 rounded-xl text-sm font-bold transition-all cursor-pointer bg-zinc-800 text-zinc-400 border border-zinc-700 hover:text-zinc-200">Release date</button>
         </div>
         <input type="datetime-local" id="watch-history-date-input" class="hidden w-full px-3 py-2 bg-zinc-800 border border-zinc-700 rounded-xl text-sm text-zinc-200 focus:outline-none focus:border-green-500 [color-scheme:dark]" />
         <button id="watch-history-log-btn" class="w-full px-4 py-2.5 bg-green-600 hover:bg-green-500 text-white font-bold text-sm rounded-xl transition-all cursor-pointer active:scale-95">
@@ -1388,7 +1389,12 @@ const bottomNavItem = (active: boolean) =>
     // ── Watch history modal ────────────────────────────────────────────────────
     let _watchHistoryTmdbId = '';
     let _watchHistoryMediaType = '';
-    let _watchHistoryDateMode: 'now' | 'custom' | 'unknown' = 'now';
+    let _watchHistoryDateMode: 'now' | 'custom' | 'unknown' | 'release' = 'now';
+    // An individual episode supplies this from its displayed air date. A
+    // season instead uses the explicit backend mode so each episode keeps its
+    // own air date rather than inheriting a season-wide timestamp.
+    let _watchHistoryReleaseDate = '';
+    let _watchHistoryReleaseAvailable = false;
     let _watchHistoryShowTmdbId = '';
     let _watchHistoryShowTvdbId = '';
     let _watchHistorySeasonNumber = '';
@@ -1413,18 +1419,23 @@ const bottomNavItem = (active: boolean) =>
       const nowBtn = document.getElementById('watch-history-now-btn')!;
       const customBtn = document.getElementById('watch-history-custom-btn')!;
       const unknownBtn = document.getElementById('watch-history-unknown-btn')!;
+      const releaseBtn = document.getElementById('watch-history-release-btn')!;
+      const dateOptions = document.getElementById('watch-history-date-options')!;
       const dateInput = document.getElementById('watch-history-date-input') as HTMLInputElement;
       const activeClass = 'flex-1 px-3 py-2 rounded-xl text-sm font-bold transition-all cursor-pointer bg-blue-600 text-white';
       const inactiveClass = 'flex-1 px-3 py-2 rounded-xl text-sm font-bold transition-all cursor-pointer bg-zinc-800 text-zinc-400 border border-zinc-700 hover:text-zinc-200';
       nowBtn.className = activeClass;
       customBtn.className = inactiveClass;
       unknownBtn.className = inactiveClass;
+      releaseBtn.className = inactiveClass;
+      releaseBtn.classList.toggle('hidden', !_watchHistoryReleaseAvailable);
+      dateOptions.className = _watchHistoryReleaseAvailable ? 'grid grid-cols-2 gap-2' : 'flex gap-2';
       dateInput.classList.add('hidden');
       dateInput.value = toLocal(new Date());
       dateInput.max = toLocal(new Date());
     }
 
-    async function openWatchHistoryModal(_btn: HTMLElement, tmdbId: string, mediaType: string, showTmdbId = '', seasonNumber = '', episodeNumber = '', showTvdbId = '') {
+    async function openWatchHistoryModal(_btn: HTMLElement, tmdbId: string, mediaType: string, showTmdbId = '', seasonNumber = '', episodeNumber = '', showTvdbId = '', releaseDate = '') {
       _watchHistoryBulkMode = null;
       _watchHistoryTmdbId = tmdbId;
       _watchHistoryMediaType = mediaType;
@@ -1432,6 +1443,14 @@ const bottomNavItem = (active: boolean) =>
       _watchHistoryShowTvdbId = showTvdbId;
       _watchHistorySeasonNumber = seasonNumber;
       _watchHistoryEpisodeNumber = episodeNumber;
+      _watchHistoryReleaseDate = releaseDate.slice(0, 10);
+      const releaseTimestamp = Date.parse(`${_watchHistoryReleaseDate}T00:00:00Z`);
+      const validReleaseDate = /^\d{4}-\d{2}-\d{2}$/.test(_watchHistoryReleaseDate)
+        && !Number.isNaN(releaseTimestamp)
+        && new Date(releaseTimestamp).toISOString().slice(0, 10) === _watchHistoryReleaseDate;
+      _watchHistoryReleaseAvailable = mediaType === 'episode'
+        && validReleaseDate
+        && _watchHistoryReleaseDate <= toLocal(new Date()).slice(0, 10);
 
       document.getElementById('watch-history-modal-title')!.textContent = 'Watch History';
       document.getElementById('watch-history-modal-events')!.classList.remove('hidden');
@@ -1445,6 +1464,8 @@ const bottomNavItem = (active: boolean) =>
 
     function openBulkWatchModal(btn: HTMLElement, kind: 'season' | 'show', seriesId: string, season = '', episodeOrder = '', tvdbId = '') {
       _watchHistoryBulkMode = { kind, seriesId, season, episodeOrder, btn, tvdbId };
+      _watchHistoryReleaseDate = '';
+      _watchHistoryReleaseAvailable = kind === 'season';
 
       document.getElementById('watch-history-modal-title')!.textContent = kind === 'season' ? 'Mark Season Watched' : 'Mark Show Watched';
       document.getElementById('watch-history-modal-events')!.classList.add('hidden');
@@ -1586,6 +1607,7 @@ const bottomNavItem = (active: boolean) =>
         (document.getElementById('watch-history-now-btn') as HTMLElement).className = activeClass;
         (document.getElementById('watch-history-custom-btn') as HTMLElement).className = inactiveClass;
         (document.getElementById('watch-history-unknown-btn') as HTMLElement).className = inactiveClass;
+        (document.getElementById('watch-history-release-btn') as HTMLElement).className = inactiveClass;
         document.getElementById('watch-history-date-input')!.classList.add('hidden');
       });
 
@@ -1594,6 +1616,7 @@ const bottomNavItem = (active: boolean) =>
         (document.getElementById('watch-history-now-btn') as HTMLElement).className = inactiveClass;
         (document.getElementById('watch-history-custom-btn') as HTMLElement).className = activeClass;
         (document.getElementById('watch-history-unknown-btn') as HTMLElement).className = inactiveClass;
+        (document.getElementById('watch-history-release-btn') as HTMLElement).className = inactiveClass;
         const input = document.getElementById('watch-history-date-input') as HTMLInputElement;
         input.max = toLocal(new Date());
         input.classList.remove('hidden');
@@ -1605,6 +1628,17 @@ const bottomNavItem = (active: boolean) =>
         (document.getElementById('watch-history-now-btn') as HTMLElement).className = inactiveClass;
         (document.getElementById('watch-history-custom-btn') as HTMLElement).className = inactiveClass;
         (document.getElementById('watch-history-unknown-btn') as HTMLElement).className = activeClass;
+        (document.getElementById('watch-history-release-btn') as HTMLElement).className = inactiveClass;
+        document.getElementById('watch-history-date-input')!.classList.add('hidden');
+      });
+
+      document.getElementById('watch-history-release-btn')!.addEventListener('click', () => {
+        if (!_watchHistoryReleaseAvailable) return;
+        _watchHistoryDateMode = 'release';
+        (document.getElementById('watch-history-now-btn') as HTMLElement).className = inactiveClass;
+        (document.getElementById('watch-history-custom-btn') as HTMLElement).className = inactiveClass;
+        (document.getElementById('watch-history-unknown-btn') as HTMLElement).className = inactiveClass;
+        (document.getElementById('watch-history-release-btn') as HTMLElement).className = activeClass;
         document.getElementById('watch-history-date-input')!.classList.add('hidden');
       });
 
@@ -1612,6 +1646,8 @@ const bottomNavItem = (active: boolean) =>
         const input = document.getElementById('watch-history-date-input') as HTMLInputElement;
         const watchedAt = _watchHistoryDateMode === 'unknown'
           ? null
+          : _watchHistoryDateMode === 'release'
+            ? `${_watchHistoryReleaseDate}T00:00:00`
           : _watchHistoryDateMode === 'now'
             ? toUTC(new Date())
             : toUTC(new Date(input.value || toLocal(new Date())));
@@ -1627,8 +1663,9 @@ const bottomNavItem = (active: boolean) =>
               const body: Record<string, unknown> = {
                 series_tmdb_id: Number(seriesId),
                 season_number: Number(season),
-                watched_at: watchedAt,
               };
+              if (_watchHistoryDateMode === 'release') body.use_release_date = true;
+              else body.watched_at = watchedAt;
               if (episodeOrder === 'tvdb') body.episode_order = 'tvdb';
               if (bulkTvdbId) body.series_tvdb_id = Number(bulkTvdbId);
               await apiFetch('/history/season', 'POST', body);
@@ -1670,6 +1707,7 @@ const bottomNavItem = (active: boolean) =>
           (document.getElementById('watch-history-now-btn') as HTMLElement).className = activeClass;
           (document.getElementById('watch-history-custom-btn') as HTMLElement).className = inactiveClass;
           (document.getElementById('watch-history-unknown-btn') as HTMLElement).className = inactiveClass;
+          (document.getElementById('watch-history-release-btn') as HTMLElement).className = inactiveClass;
           input.classList.add('hidden');
         } catch (err) {
           logBtn.textContent = idleLabel;
@@ -1713,7 +1751,7 @@ const bottomNavItem = (active: boolean) =>
         const seriesId = showTmdbId || tmdbId;
 
         if (mediaType === 'movie' || mediaType === 'episode') {
-          await openWatchHistoryModal(btn, tmdbId, mediaType, card.dataset.showTmdbId || '', card.dataset.season || '', card.dataset.episodeNumber || '', card.dataset.showTvdbId || '');
+          await openWatchHistoryModal(btn, tmdbId, mediaType, card.dataset.showTmdbId || '', card.dataset.season || '', card.dataset.episodeNumber || '', card.dataset.showTvdbId || '', card.dataset.airDate || '');
           return;
         }
 

--- a/frontend/src/pages/media/[type]/[id].astro
+++ b/frontend/src/pages/media/[type]/[id].astro
@@ -211,6 +211,7 @@ const refreshUrl = isEpisode
                   requestStatus={item.request_status ?? null}
                   mediaId={item.id}
                   userRating={item.user_rating ?? null}
+                  airDate={item.release_date}
                 />
               </div>
             )}

--- a/frontend/src/pages/show/[id]/season/[season_number]/[episode_number].astro
+++ b/frontend/src/pages/show/[id]/season/[season_number]/[episode_number].astro
@@ -179,6 +179,7 @@ const thumbnail = episode?.still_path || show?.poster_path || null;
                   episodeNumber={Number(episode_number)}
                   mediaId={episode.id ?? null}
                   userRating={episode.user_rating ?? null}
+                  airDate={episode.air_date}
                 />
               </div>
             )}

--- a/frontend/src/pages/show/tvdb/[id]/season/[season_number].astro
+++ b/frontend/src/pages/show/tvdb/[id]/season/[season_number].astro
@@ -272,6 +272,7 @@ const seasonTitle = season
                         tvdbId={Number(id)}
                         hideRequest={true}
                         userRating={ep.user_rating}
+                        airDate={ep.air_date}
                       />
                     )}
                   </div>

--- a/frontend/src/pages/show/tvdb/[id]/season/[season_number]/[episode_number].astro
+++ b/frontend/src/pages/show/tvdb/[id]/season/[season_number]/[episode_number].astro
@@ -180,6 +180,7 @@ const thumbnail = episode?.image_url || show?.poster_path || null;
                   mediaId={episode.id}
                   hideRequest={true}
                   userRating={episode.user_rating}
+                  airDate={episode.air_date}
                 />
               </div>
             ))}


### PR DESCRIPTION
## Summary

- add a Release date choice when logging an aired episode
- let season bulk actions stamp each episode with its own TMDB or TVDB air date
- omit missing, malformed, and future dates from release-date actions
- preserve the existing Just now, Custom, and Unknown flows

Closes #131

## Verification

- python -m unittest tests.test_history (18 tests passed)
- npm run build
- git diff --check