### PR TITLE
feat(ui): confirm individual deletions

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",
-    "test": "node --test test/delete-confirmations.test.mjs",
+    "test": "node --test test/*.test.mjs",
     "preview": "astro preview",
     "astro": "astro"
   },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",
+    "test": "node --test test/delete-confirmations.test.mjs",
     "preview": "astro preview",
     "astro": "astro"
   },

--- a/frontend/src/components/HistoryCard.astro
+++ b/frontend/src/components/HistoryCard.astro
@@ -111,6 +111,12 @@ const href = isEpisode ? episodeHref(media) : `/media/movie/${media.tmdb_id}`;
     btn.addEventListener('click', async (e) => {
       e.stopPropagation();
 
+      const confirmed = await window.showConfirm(
+        'Remove history entry?',
+        'This will remove this recorded play.'
+      );
+      if (!confirmed) return;
+
       const eventId = card.dataset.eventId;
       const token = (window as any).__AUTH_TOKEN__ ?? '';
 

--- a/frontend/src/layouts/Base.astro
+++ b/frontend/src/layouts/Base.astro
@@ -1002,6 +1002,15 @@ const bottomNavItem = (active: boolean) =>
               if (seasonNumber != null) body.season_number = seasonNumber;
               await apiFetch(`/lists/${listId}/items`, 'POST', body);
             } else {
+              const confirmed = await showConfirm(
+                'Remove item from list?',
+                'This will remove this item from the list.'
+              );
+              if (!confirmed) {
+                cb.checked = true;
+                return;
+              }
+
               // Find the list_item id — need to fetch list detail
               const detail = await apiFetch(`/lists/${listId}`);
               const item = detail.items?.find((i: { media: { tmdb_id: number; season_number: number | null } }) => {
@@ -1543,6 +1552,12 @@ const bottomNavItem = (active: boolean) =>
     document.getElementById('watch-history-modal-events')!.addEventListener('click', async (e) => {
       const delBtn = (e.target as Element).closest<HTMLElement>('[data-delete-event]');
       if (!delBtn) return;
+      const confirmed = await showConfirm(
+        'Remove history entry?',
+        'This will remove this recorded play.'
+      );
+      if (!confirmed) return;
+
       delBtn.style.opacity = '0.4';
       delBtn.style.pointerEvents = 'none';
       try {

--- a/frontend/src/pages/list/[id].astro
+++ b/frontend/src/pages/list/[id].astro
@@ -469,6 +469,12 @@ const sonarrUrl = `${origin}/api/proxy/sonarr-compat/${list?.id}`;
       btn.addEventListener('click', async (e) => {
         e.preventDefault();
         const itemId = btn.getAttribute('data-item-id');
+        const confirmed = await window.showConfirm(
+          'Remove item from list?',
+          'This will remove this item from the list.'
+        );
+        if (!confirmed) return;
+
         btn.disabled = true;
         btn.innerHTML = `<svg class="animate-spin w-3.5 h-3.5 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"/></svg>`;
 

--- a/frontend/test/delete-confirmations.test.mjs
+++ b/frontend/test/delete-confirmations.test.mjs
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+const source = async (path) => readFile(new URL(path, import.meta.url), 'utf8');
+
+test('all individual history entry deletion controls require confirmation', async () => {
+  const [base, historyCard] = await Promise.all([
+    source('../src/layouts/Base.astro'),
+    source('../src/components/HistoryCard.astro'),
+  ]);
+  const handlerStart = base.indexOf("document.getElementById('watch-history-modal-events')!.addEventListener");
+  const modalRemoval = base.slice(
+    handlerStart,
+    base.indexOf("document.getElementById('watch-history-unwatch-btn')!.addEventListener", handlerStart)
+  );
+  const cardRemoval = historyCard.slice(
+    historyCard.indexOf("btn.addEventListener('click'"),
+    historyCard.indexOf('  });\n</script>')
+  );
+
+  for (const handler of [modalRemoval, cardRemoval]) {
+    assert.match(handler, /showConfirm\(\s*'Remove history entry\?'/);
+    assert.ok(handler.indexOf('if (!confirmed) return;') < handler.indexOf("'DELETE'"));
+  }
+});
+
+test('all individual list-item deletion controls require confirmation', async () => {
+  const [base, listPage] = await Promise.all([
+    source('../src/layouts/Base.astro'),
+    source('../src/pages/list/[id].astro'),
+  ]);
+  const popoverStart = base.indexOf('openListPopover');
+  const popoverRemoval = base.slice(
+    base.indexOf('            } else {', popoverStart),
+    base.indexOf('// Update button state', popoverStart)
+  );
+  const detailRemoval = listPage.slice(
+    listPage.indexOf('function bindRemoveButtons()'),
+    listPage.indexOf('  // --- Search & Add ---')
+  );
+
+  for (const handler of [popoverRemoval, detailRemoval]) {
+    assert.match(handler, /showConfirm\(\s*'Remove item from list\?'/);
+    assert.ok(handler.indexOf('if (!confirmed) return;') < handler.indexOf("'DELETE'"));
+  }
+  assert.match(popoverRemoval, /if \(!confirmed\) \{\s*cb\.checked = true;\s*return;/);
+});


### PR DESCRIPTION
## Summary

- ask for confirmation before deleting an individual history entry
- confirm list-item removal from both list detail cards and the global list picker
- restore the list checkbox when a removal is cancelled
- cover static and dynamically bound deletion controls

Closes #122

## Verification

- npm test (2 tests passed)
- npm run build
- git diff --check