### PR TITLE
feat(settings): choose default media tab

### DIFF
--- a/backend/migrations/versions/s4t5u6v7w8x9_add_default_media_tab.py
+++ b/backend/migrations/versions/s4t5u6v7w8x9_add_default_media_tab.py
@@ -1,0 +1,32 @@
+"""add default media tab preference
+
+Revision ID: s4t5u6v7w8x9
+Revises: r3s4t5u6v7w8
+Create Date: 2026-08-20
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "s4t5u6v7w8x9"
+down_revision = "r3s4t5u6v7w8"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "user_settings",
+        sa.Column("default_media_tab", sa.String(length=20), nullable=False, server_default="explore"),
+    )
+    op.create_check_constraint(
+        "ck_user_settings_default_media_tab",
+        "user_settings",
+        "default_media_tab IN ('explore', 'collection')",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("ck_user_settings_default_media_tab", "user_settings", type_="check")
+    op.drop_column("user_settings", "default_media_tab")

--- a/backend/models/users.py
+++ b/backend/models/users.py
@@ -129,6 +129,9 @@ class UserSettings(Base):
     minimalist_next_up : Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="false")
     next_up_hidden_shows : Mapped[Optional[list[int]]] = mapped_column(JSONB, server_default="'[]'")
     hide_watched_from_recently_added : Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="false")
+    # Controls whether the Movies and Shows navigation links open Explore or
+    # the user's collection. Keep this constrained to known application tabs.
+    default_media_tab : Mapped[str] = mapped_column(String(20), nullable=False, default="explore", server_default="explore")
 
     # MDBList — API key authentication
     mdblist_api_key: Mapped[Optional[str]] = mapped_column(String(255))

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -355,6 +355,10 @@ async def delete_user_me(
 async def _settings_response(settings: UserSettings, db: AsyncSession) -> schemas.UserSettings:
     """Build a UserSettings schema response, injecting computed fields."""
     data = schemas.UserSettings.model_validate(settings)
+    # A server default covers persisted rows after the migration. The fallback
+    # also keeps the API stable for a newly constructed settings object before
+    # SQLAlchemy has applied its column default.
+    data.default_media_tab = settings.default_media_tab or "explore"
     data.trakt_connected = bool(settings.trakt_access_token)
     data.simkl_connected = bool(settings.simkl_access_token)
     data.mdblist_connected = bool(settings.mdblist_api_key)

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel, EmailStr, SecretStr, field_validator, model_validator
-from typing import Optional
+from typing import Literal, Optional
 from datetime import datetime
 from models.base import UserRole, MediaType, PrivacyLevel
 
@@ -155,6 +155,14 @@ class UserSettings(BaseModel):
     shuffle_next_up: Optional[bool] = None
     minimalist_next_up: Optional[bool] = None
     hide_watched_from_recently_added: Optional[bool] = None
+    default_media_tab: Literal["explore", "collection"] = "explore"
+
+    @field_validator("default_media_tab", mode="before")
+    @classmethod
+    def default_media_tab_falls_back_to_explore(cls, value):
+        # SQLAlchemy applies column defaults on insert, not when an object is
+        # constructed. Normalize that transient None for settings responses.
+        return "explore" if value is None else value
 
     class Config:
         from_attributes = True

--- a/backend/tests/test_auth_integration_credentials.py
+++ b/backend/tests/test_auth_integration_credentials.py
@@ -535,5 +535,51 @@ class RegisterRoleEscalationTests(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(new_user.is_admin)
 
 
+class DefaultMediaTabSettingsTests(unittest.IsolatedAsyncioTestCase):
+    """The navigation preference must only ever contain internal tab names."""
+
+    def test_api_schema_defaults_to_explore(self) -> None:
+        self.assertEqual(schemas.UserSettings().default_media_tab, "explore")
+
+    def test_external_default_tab_is_rejected_by_the_api_schema(self) -> None:
+        with self.assertRaises(ValueError):
+            schemas.UserSettings(default_media_tab="https://example.com")
+
+    async def test_explore_is_the_response_default_before_insert(self) -> None:
+        from models.users import UserSettings
+
+        response = await auth._settings_response(
+            UserSettings(user_id=1), _GlobalSettingsFakeDB(None),
+        )
+
+        self.assertEqual(response.default_media_tab, "explore")
+
+    async def test_update_persists_the_explore_choice(self) -> None:
+        from models.users import UserSettings
+
+        settings = UserSettings(user_id=1)
+        response = await auth.update_user_settings(
+            schemas.UserSettings(default_media_tab="explore"),
+            db=_SettingsFakeDB(settings),
+            current_user=SimpleNamespace(id=1),
+        )
+
+        self.assertEqual(settings.default_media_tab, "explore")
+        self.assertEqual(response.default_media_tab, "explore")
+
+    async def test_update_persists_the_collection_choice(self) -> None:
+        from models.users import UserSettings
+
+        settings = UserSettings(user_id=1)
+        response = await auth.update_user_settings(
+            schemas.UserSettings(default_media_tab="collection"),
+            db=_SettingsFakeDB(settings),
+            current_user=SimpleNamespace(id=1),
+        )
+
+        self.assertEqual(settings.default_media_tab, "collection")
+        self.assertEqual(response.default_media_tab, "collection")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/frontend/src/layouts/Base.astro
+++ b/frontend/src/layouts/Base.astro
@@ -11,16 +11,20 @@ const { user, token } = Astro.locals;
 let pendingRequestCount = 0;
 let radarrCustomizeOnAdd = false;
 let sonarrCustomizeOnAdd = false;
-if (user?.is_admin && token) {
-  try {
-    const data = await api.admin.getPendingCount(token);
-    pendingRequestCount = data.pending;
-  } catch {}
+let defaultMediaTab: "explore" | "collection" = "explore";
+if (user && token) {
   try {
     const settings = await api.auth.getSettings(token);
+    defaultMediaTab = settings.default_media_tab === "collection" ? "collection" : "explore";
     radarrCustomizeOnAdd = settings.radarr_customize_on_add === true;
     sonarrCustomizeOnAdd = settings.sonarr_customize_on_add === true;
   } catch {}
+  if (user.is_admin) {
+    try {
+      const data = await api.admin.getPendingCount(token);
+      pendingRequestCount = data.pending;
+    } catch {}
+  }
 }
 
 // Anonymous visitors get Movies/Shows nav links too, but only once the admin
@@ -40,6 +44,8 @@ const activeShows  = pathname.startsWith('/shows') || pathname.startsWith('/coll
 const activeHistory = pathname.startsWith('/history') || pathname === '/next-up';
 const activeLists  = pathname.startsWith('/lists') || pathname.startsWith('/list/');
 const activeHome   = !activeMovies && !activeShows && !activeHistory && !activeLists;
+const moviesHref = user && defaultMediaTab === "collection" ? "/collection/movies" : "/movies";
+const showsHref = user && defaultMediaTab === "collection" ? "/collection/shows" : "/shows";
 
 const navLink = (active: boolean) =>
   active
@@ -141,8 +147,8 @@ const bottomNavItem = (active: boolean) =>
           </a>
           {(user || showAnonNavLinks) && (
             <div class="hidden md:flex items-center gap-6 text-sm">
-              <a href="/movies" class={navLink(activeMovies)}>Movies</a>
-              <a href="/shows" class={navLink(activeShows)}>Shows</a>
+              <a href={moviesHref} class={navLink(activeMovies)}>Movies</a>
+              <a href={showsHref} class={navLink(activeShows)}>Shows</a>
               <a href="/lists" class={navLink(activeLists)}>Lists</a>
               {user && (
                 <a href="/history" class={navLink(activeHistory)}>History</a>
@@ -297,11 +303,11 @@ const bottomNavItem = (active: boolean) =>
         <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
         Home
       </a>
-      <a href="/movies" class={bottomNavItem(activeMovies)}>
+      <a href={moviesHref} class={bottomNavItem(activeMovies)}>
         <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="18" height="18" x="3" y="3" rx="2"/><path d="M7 3v18"/><path d="M3 7.5h4"/><path d="M3 12h18"/><path d="M3 16.5h4"/><path d="M17 3v18"/><path d="M17 7.5h4"/><path d="M17 16.5h4"/></svg>
         Movies
       </a>
-      <a href="/shows" class={bottomNavItem(activeShows)}>
+      <a href={showsHref} class={bottomNavItem(activeShows)}>
         <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="20" height="15" x="2" y="7" rx="2"/><polyline points="17 2 12 7 7 2"/></svg>
         Shows
       </a>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -457,6 +457,7 @@ export interface UserSettings {
   use_hls_player: boolean;
   shuffle_next_up: boolean;
   minimalist_next_up: boolean;
+  default_media_tab: "explore" | "collection";
 }
 
 export interface MediaServerConnection {

--- a/frontend/src/pages/settings.astro
+++ b/frontend/src/pages/settings.astro
@@ -195,6 +195,20 @@ if (me.totp_enabled) {
           </div>
           <div class="flex items-start justify-between gap-6 p-4 bg-zinc-900/60 rounded-xl border border-zinc-800">
             <div>
+              <p class="text-sm font-semibold text-zinc-100 mb-1">Default Movies &amp; Shows tab</p>
+              <p class="text-xs text-zinc-400">Choose whether Movies and Shows in the main navigation open My Collection or Explore. You can still switch tabs on either page.</p>
+            </div>
+            <select
+              id="default-media-tab-select"
+              data-previous-value={settings.default_media_tab === "collection" ? "collection" : "explore"}
+              class="shrink-0 bg-zinc-950 border border-zinc-700 rounded-lg px-3 py-2 text-sm text-zinc-100 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            >
+              <option value="collection" selected={settings.default_media_tab === "collection"}>My Collection</option>
+              <option value="explore" selected={settings.default_media_tab !== "collection"}>Explore</option>
+            </select>
+          </div>
+          <div class="flex items-start justify-between gap-6 p-4 bg-zinc-900/60 rounded-xl border border-zinc-800">
+            <div>
               <p class="text-sm font-semibold text-zinc-100 mb-1">Blur explicit content</p>
               <p class="text-xs text-zinc-400">Blur posters flagged as adult content by TMDB. Click a blurred poster to reveal it.</p>
             </div>
@@ -1608,6 +1622,29 @@ if (me.totp_enabled) {
         headers: { 'Authorization': `Bearer ${tok}`, 'Content-Type': 'application/json' },
         body: JSON.stringify({ hide_watched_from_recently_added: hideWatchedRecentlyAddedToggle.checked }),
       });
+    });
+  }
+
+  const defaultMediaTabSelect = document.getElementById('default-media-tab-select') as HTMLSelectElement | null;
+  if (defaultMediaTabSelect) {
+    defaultMediaTabSelect.addEventListener('change', async () => {
+      const tok = (document.getElementById('app-data') as HTMLElement | null)?.dataset.token ?? '';
+      const previousValue = defaultMediaTabSelect.dataset.previousValue ?? 'explore';
+      const selectedValue = defaultMediaTabSelect.value;
+      defaultMediaTabSelect.disabled = true;
+      try {
+        const res = await fetch('/api/proxy/auth/settings', {
+          method: 'PATCH',
+          headers: { 'Authorization': `Bearer ${tok}`, 'Content-Type': 'application/json' },
+          body: JSON.stringify({ default_media_tab: selectedValue }),
+        });
+        if (!res.ok) throw new Error('Failed to update default media tab');
+        defaultMediaTabSelect.dataset.previousValue = selectedValue;
+      } catch {
+        defaultMediaTabSelect.value = previousValue;
+      } finally {
+        defaultMediaTabSelect.disabled = false;
+      }
     });
   }
 


### PR DESCRIPTION
## Summary

- add an Explore or My Collection preference for Movies and Shows navigation
- apply it to desktop and mobile navigation while keeping explicit tab routes available
- preserve Explore as the default for existing users and make Collection opt-in
- validate the value in the API and database, with UI rollback on save failure

Closes #188

## Verification

- uv run python -m unittest tests/test_auth_integration_credentials.py (25 tests passed)
- uv run alembic heads
- python3 -m py_compile migrations/versions/s4t5u6v7w8x9_add_default_media_tab.py
- npm run build
- git diff --check