### PR TITLE
feat(collection): add browse-view safety lock

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",
+    "test": "node --test test/*.test.mjs",
     "preview": "astro preview",
     "astro": "astro"
   },

--- a/frontend/src/components/CardActionBar.astro
+++ b/frontend/src/components/CardActionBar.astro
@@ -6,12 +6,14 @@ interface Props {
   collectionPct: number;
   watchPct: number;
   isSeries: boolean;
+  collectionReadOnly?: boolean;
 }
 
-const { watched, inLists, inLibrary, collectionPct, watchPct, isSeries } = Astro.props;
+const { watched, inLists, inLibrary, collectionPct, watchPct, isSeries, collectionReadOnly = false } = Astro.props;
 
 const watchActive = isSeries ? watchPct > 0 : watched;
 const collectActive = isSeries ? collectionPct > 0 : inLibrary;
+const collectedTitle = isSeries ? `${collectionPct}% in library` : (inLibrary ? 'Remove from collection' : 'Add to collection');
 ---
 
 <div class="grid grid-cols-3 flex-shrink-0">
@@ -53,11 +55,15 @@ const collectActive = isSeries ? collectionPct > 0 : inLibrary;
   <!-- Collected (purple) -->
   <button
     data-action="collected"
+    data-collection-mutation={collectionReadOnly ? "" : undefined}
+    data-default-title={collectionReadOnly ? collectedTitle : undefined}
     data-in-library={String(inLibrary)}
     data-collection-pct={String(collectionPct)}
     data-state={collectActive ? 'active' : 'inactive'}
-    title={isSeries ? `${collectionPct}% in library` : (inLibrary ? 'Remove from collection' : 'Add to collection')}
-    class={`flex flex-col items-center justify-center gap-1 py-2.5 transition-all cursor-pointer hover:brightness-125 ${collectActive ? 'bg-purple-500/20 text-purple-400' : 'bg-zinc-900 text-zinc-400 hover:bg-purple-500/10 hover:text-purple-400'}`}
+    title={collectionReadOnly ? 'Collection view is locked. Unlock it to change collection items.' : collectedTitle}
+    disabled={collectionReadOnly}
+    aria-disabled={collectionReadOnly ? 'true' : undefined}
+    class={`flex flex-col items-center justify-center gap-1 py-2.5 transition-all cursor-pointer hover:brightness-125 disabled:cursor-not-allowed disabled:opacity-60 ${collectActive ? 'bg-purple-500/20 text-purple-400' : 'bg-zinc-900 text-zinc-400 hover:bg-purple-500/10 hover:text-purple-400'}`}
   >
     <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
       <path d="m2 7 4.41-4.41A2 2 0 0 1 7.83 2h8.34a2 2 0 0 1 1.42.59L22 7"/>

--- a/frontend/src/components/CollectionViewLock.astro
+++ b/frontend/src/components/CollectionViewLock.astro
@@ -1,0 +1,77 @@
+---
+---
+
+<button
+  type="button"
+  data-collection-lock-toggle
+  aria-pressed="true"
+  title="Collection view locked. Unlock to change collection items."
+  class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium text-amber-300 hover:text-amber-200 hover:bg-amber-400/10 transition-colors active:scale-95 active:opacity-70"
+>
+  <svg data-collection-lock-closed-icon xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <rect width="18" height="11" x="3" y="11" rx="2" ry="2"/>
+    <path d="M7 11V7a5 5 0 0 1 10 0v4"/>
+  </svg>
+  <svg data-collection-lock-open-icon class="hidden" xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <rect width="18" height="11" x="3" y="11" rx="2" ry="2"/>
+    <path d="M7 11V7a5 5 0 0 1 9.9-1"/>
+  </svg>
+  <span data-collection-lock-label>Locked</span>
+</button>
+
+<span class="sr-only" data-collection-lock-status aria-live="polite">Collection changes are locked on this page.</span>
+
+<script>
+  const lockToggle = document.querySelector<HTMLButtonElement>('[data-collection-lock-toggle]');
+  const lockLabel = document.querySelector<HTMLElement>('[data-collection-lock-label]');
+  const lockStatus = document.querySelector<HTMLElement>('[data-collection-lock-status]');
+  const closedIcon = document.querySelector<SVGElement>('[data-collection-lock-closed-icon]');
+  const openIcon = document.querySelector<SVGElement>('[data-collection-lock-open-icon]');
+  const storageKey = 'scrob.collection-view-locked';
+
+  function setCollectionLocked(locked: boolean) {
+    document.querySelectorAll<HTMLButtonElement>('[data-collection-mutation]').forEach((button) => {
+      button.disabled = locked;
+      button.setAttribute('aria-disabled', String(locked));
+      button.title = locked
+        ? 'Collection view is locked. Unlock it to change collection items.'
+        : (button.dataset.defaultTitle ?? 'Change collection');
+      button.classList.toggle('cursor-not-allowed', locked);
+      button.classList.toggle('opacity-60', locked);
+    });
+
+    closedIcon?.classList.toggle('hidden', !locked);
+    openIcon?.classList.toggle('hidden', locked);
+
+    if (!lockToggle || !lockLabel || !lockStatus) return;
+    lockToggle.setAttribute('aria-pressed', String(locked));
+    lockToggle.title = locked
+      ? 'Collection view locked. Unlock to change collection items.'
+      : 'Collection view unlocked. Lock to prevent collection changes.';
+    lockLabel.textContent = locked ? 'Locked' : 'Unlocked';
+    lockStatus.textContent = locked
+      ? 'Collection changes are locked on this page.'
+      : 'Collection changes are enabled on this page.';
+  }
+
+  if (lockToggle) {
+    let locked = true;
+    try {
+      // Lock by default; an explicit local opt-out is kept for this browser.
+      locked = localStorage.getItem(storageKey) !== 'false';
+    } catch {
+      // Private browsing or blocked storage should retain the safe default.
+    }
+
+    setCollectionLocked(locked);
+    lockToggle.addEventListener('click', () => {
+      locked = !locked;
+      try {
+        localStorage.setItem(storageKey, String(locked));
+      } catch {
+        // The toggle remains useful for this page even without persistent storage.
+      }
+      setCollectionLocked(locked);
+    });
+  }
+</script>

--- a/frontend/src/components/MediaCard.astro
+++ b/frontend/src/components/MediaCard.astro
@@ -6,9 +6,10 @@ import { episodeHref } from "../lib/episodeHref";
 
 interface Props {
   item: MediaItem;
+  collectionReadOnly?: boolean;
 }
 
-const { item } = Astro.props;
+const { item, collectionReadOnly = false } = Astro.props;
 const { user } = Astro.locals;
 
 const isPerson = item.type === "person";
@@ -134,6 +135,7 @@ const inLibrary = item.in_library ?? false;
       collectionPct={collectionPct}
       watchPct={watchPct}
       isSeries={isPercentageStyle}
+      collectionReadOnly={collectionReadOnly}
     />
   )}
 
@@ -177,4 +179,3 @@ const inLibrary = item.in_library ?? false;
     </div>
   )}
 </div>
-

--- a/frontend/src/pages/collection/movies.astro
+++ b/frontend/src/pages/collection/movies.astro
@@ -4,6 +4,7 @@ import MediaCard from "../../components/MediaCard.astro";
 import Pagination from "../../components/Pagination.astro";
 import FilterPanel from "../../components/FilterPanel.astro";
 import SortButton from "../../components/SortButton.astro";
+import CollectionViewLock from "../../components/CollectionViewLock.astro";
 import { api } from "../../lib/api";
 export const prerender = false;
 
@@ -45,6 +46,7 @@ const baseUrl = `/collection/movies?${baseParams.toString()}`;
   <div class="flex items-center gap-1 mb-6 bg-zinc-900 border border-zinc-800 rounded-xl p-1 w-fit">
     <a href="/movies" class="px-4 py-1.5 rounded-lg text-sm font-medium text-zinc-400 hover:text-zinc-100 transition-colors active:scale-95 active:opacity-70">Explore</a>
     <a href="/collection/movies" class="px-4 py-1.5 rounded-lg text-sm font-semibold bg-blue-600 text-white transition-colors active:scale-95 active:opacity-70">My Collection</a>
+    <CollectionViewLock />
   </div>
   <div class="flex flex-col md:flex-row md:items-center justify-between gap-4 mb-10">
     <div class="flex items-baseline gap-3">
@@ -92,7 +94,7 @@ const baseUrl = `/collection/movies?${baseParams.toString()}`;
   ) : (
     <>
       <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-6">
-        {data.results.map(item => <MediaCard item={{...item, in_library: true}} />)}
+        {data.results.map(item => <MediaCard item={{...item, in_library: true}} collectionReadOnly />)}
       </div>
 
       <Pagination

--- a/frontend/src/pages/collection/shows.astro
+++ b/frontend/src/pages/collection/shows.astro
@@ -4,6 +4,7 @@ import MediaCard from "../../components/MediaCard.astro";
 import Pagination from "../../components/Pagination.astro";
 import FilterPanel from "../../components/FilterPanel.astro";
 import SortButton from "../../components/SortButton.astro";
+import CollectionViewLock from "../../components/CollectionViewLock.astro";
 import { api } from "../../lib/api";
 export const prerender = false;
 
@@ -49,6 +50,7 @@ const baseUrl = `/collection/shows?${baseParams.toString()}`;
   <div class="flex items-center gap-1 mb-6 bg-zinc-900 border border-zinc-800 rounded-xl p-1 w-fit">
     <a href="/shows" class="px-4 py-1.5 rounded-lg text-sm font-medium text-zinc-400 hover:text-zinc-100 transition-colors active:scale-95 active:opacity-70">Explore</a>
     <a href="/collection/shows" class="px-4 py-1.5 rounded-lg text-sm font-semibold bg-blue-600 text-white transition-colors active:scale-95 active:opacity-70">My Collection</a>
+    <CollectionViewLock />
   </div>
   <div class="flex flex-col md:flex-row md:items-center justify-between gap-4 mb-10">
     <div class="flex items-baseline gap-3">
@@ -97,7 +99,7 @@ const baseUrl = `/collection/shows?${baseParams.toString()}`;
   ) : (
     <>
       <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-6">
-        {data.results.map(item => <MediaCard item={{...item, type: 'series', in_library: true}} />)}
+        {data.results.map(item => <MediaCard item={{...item, type: 'series', in_library: true}} collectionReadOnly />)}
       </div>
 
       <Pagination

--- a/frontend/test/collection-view-lock.test.mjs
+++ b/frontend/test/collection-view-lock.test.mjs
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+const root = new URL('..', import.meta.url);
+
+async function source(path) {
+  return readFile(new URL(path, root), 'utf8');
+}
+
+test('collection browsing starts locked and only marks collection action buttons as mutable', async () => {
+  const [lock, cardActions, movies, shows] = await Promise.all([
+    source('src/components/CollectionViewLock.astro'),
+    source('src/components/CardActionBar.astro'),
+    source('src/pages/collection/movies.astro'),
+    source('src/pages/collection/shows.astro'),
+  ]);
+
+  assert.match(lock, /localStorage\.getItem\(storageKey\) !== 'false'/);
+  assert.match(lock, /\[data-collection-mutation\]/);
+  assert.match(lock, /button\.disabled = locked/);
+  assert.match(lock, /aria-pressed/);
+  assert.match(lock, /data-collection-lock-closed-icon/);
+  assert.match(lock, /data-collection-lock-open-icon/);
+  assert.match(lock, /closedIcon\?\.classList\.toggle\('hidden', !locked\)/);
+  assert.match(lock, /openIcon\?\.classList\.toggle\('hidden', locked\)/);
+  assert.match(cardActions, /data-collection-mutation=\{collectionReadOnly/);
+  assert.match(cardActions, /disabled=\{collectionReadOnly\}/);
+  assert.match(movies, /<CollectionViewLock\s*\/>/);
+  assert.match(movies, /collectionReadOnly/);
+  assert.match(shows, /<CollectionViewLock\s*\/>/);
+  assert.match(shows, /collectionReadOnly/);
+});


### PR DESCRIPTION
## Summary

- add a visible padlock to Movies and Shows collection browse pages
- default the view to locked and disable only collection mutation buttons
- persist an explicit unlock locally per browser while failing safely when storage is unavailable
- expose lock state through accessible labels, live status, and disabled controls

Closes #44

## Verification

- npm test (1 test passed)
- npm run build
- git diff --check