### PR TITLE
feat(filters): add personal rating controls

### DIFF
--- a/backend/routers/media.py
+++ b/backend/routers/media.py
@@ -890,6 +890,7 @@ async def list_media(
     genre: list[str] = Query(default=[]),
     year: list[int] = Query(default=[]),
     watched: list[str] = Query(default=[]),
+    my_rating: list[int] = Query(default=[], ge=0, le=10),
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user_or_api_key),
 ):
@@ -912,6 +913,16 @@ async def list_media(
             .exists()
         )
         filters.append(watched_exists if "watched" in watched_states else ~watched_exists)
+    if my_rating:
+        # Personal ratings are user-scoped and do not include season ratings.
+        # An IN subquery avoids changing the collection join/cardinality used
+        # for the total count and the other collection filters.
+        rated_media_ids = select(Rating.media_id).where(
+            Rating.user_id == current_user.id,
+            Rating.season_number.is_(None),
+            Rating.rating.in_(my_rating),
+        )
+        filters.append(Media.id.in_(rated_media_ids))
 
     base_query = (
         select(Media)
@@ -945,6 +956,22 @@ async def list_media(
             base_query
             .outerjoin(last_watched_sq, last_watched_sq.c.media_id == Media.id)
             .order_by(last_watched_sq.c.last_watched_at.desc().nulls_last(), Media.id.desc())
+            .offset(offset).limit(page_size)
+        )
+    elif sort == "user_rating":
+        # Keep unrated items visible at the end, just like the TMDB rating
+        # sort, and always use Media.id as a stable pagination tie-breaker.
+        query = (
+            base_query
+            .outerjoin(
+                Rating,
+                and_(
+                    Rating.media_id == Media.id,
+                    Rating.user_id == current_user.id,
+                    Rating.season_number.is_(None),
+                ),
+            )
+            .order_by(Rating.rating.desc().nulls_last(), Media.id.desc())
             .offset(offset).limit(page_size)
         )
     else:
@@ -2058,10 +2085,12 @@ _ARR_CHECKS = {
 
 def _apply_local_filters(
     items: list[dict], collection: list[str], watch: list[str], arr: list[str], year: list[int] | None = None,
+    my_rating: list[int] | None = None,
 ) -> list[dict]:
     """Local-only filters get_tmdb_list applies after TMDB enrichment.
 
-    collection/watch/arr can't be expressed by TMDB's discover API at all.
+    collection/watch/arr/my_rating can't be expressed by TMDB's discover API
+    at all.
     year could (primary_release_year/first_air_date_year), but only as a
     single value - TMDB has no "year A OR year B" for discover, so a
     multi-year selection is applied locally here instead, same as the others.
@@ -2081,6 +2110,9 @@ def _apply_local_filters(
     if year:
         wanted = {str(y) for y in year}
         items = [i for i in items if (i.get("release_date") or "")[:4] in wanted]
+    if my_rating:
+        wanted_ratings = set(my_rating)
+        items = [i for i in items if i.get("user_rating") in wanted_ratings]
     return items
 
 
@@ -2116,6 +2148,7 @@ async def get_tmdb_list(
     collection: list[str] = Query(default=[]),
     watch: list[str] = Query(default=[]),
     arr: list[str] = Query(default=[]),
+    my_rating: list[int] = Query(default=[], ge=0, le=10),
     db: AsyncSession = Depends(get_db),
     current_user: User | None = Depends(get_optional_user_or_api_key),
 ):
@@ -2130,7 +2163,7 @@ async def get_tmdb_list(
             raise HTTPException(status_code=401, detail="Not authenticated")
         tmdb_key = gs.tmdb_api_key
         # No personal library/watch history to filter on without a user.
-        collection, watch, arr = [], [], []
+        collection, watch, arr, my_rating = [], [], [], []
     else:
         tmdb_key = await get_user_tmdb_key(db, current_user.id)
 
@@ -2237,7 +2270,7 @@ async def get_tmdb_list(
                 await enrich_with_state(db, current_user.id, enriched)
             return enriched
 
-        if not (collection or watch or arr or year):
+        if not (collection or watch or arr or year or my_rating):
             data = await _fetch_tmdb_page(page)
             enriched = await _build_enriched(data.get("results", []))
             return {
@@ -2276,7 +2309,7 @@ async def get_tmdb_list(
                         batch_results.append(res)
             if batch_results:
                 enriched = await _build_enriched(batch_results)
-                matched.extend(_apply_local_filters(enriched, collection, watch, arr, year))
+                matched.extend(_apply_local_filters(enriched, collection, watch, arr, year, my_rating))
             scan_page = batch_end + 1
             if total_tmdb_pages is not None and scan_page > total_tmdb_pages:
                 break

--- a/backend/routers/shows.py
+++ b/backend/routers/shows.py
@@ -209,6 +209,7 @@ async def list_shows(
     year: list[int] = Query(default=[]),
     status: list[str] = Query(default=[]),
     watched: list[str] = Query(default=[]),
+    my_rating: list[int] = Query(default=[], ge=0, le=10),
 ):
     offset = (page - 1) * page_size
 
@@ -281,6 +282,32 @@ async def list_shows(
         else:
             base_query = base_query.where(ShowModel.id.notin_(select(watched_show_ids)))
 
+    # Shows have their own metadata table, while a personal show rating is
+    # stored against its MediaType.series Media row. Match by TMDB ID so this
+    # also works for collections built from episode rows alone.
+    show_ratings_sq = (
+        select(
+            Media.tmdb_id.label("tmdb_id"),
+            func.max(Rating.rating).label("user_rating"),
+        )
+        .join(Rating, Rating.media_id == Media.id)
+        .where(
+            Media.media_type == MediaType.series,
+            Media.tmdb_id.isnot(None),
+            Rating.user_id == current_user.id,
+            Rating.season_number.is_(None),
+            Rating.rating.isnot(None),
+        )
+        .group_by(Media.tmdb_id)
+        .subquery()
+    )
+    if my_rating:
+        base_query = base_query.where(
+            ShowModel.tmdb_id.in_(
+                select(show_ratings_sq.c.tmdb_id).where(show_ratings_sq.c.user_rating.in_(my_rating))
+            )
+        )
+
     # Count total
     count_query = select(func.count()).select_from(base_query.subquery())
     total_result = await db.execute(count_query)
@@ -290,6 +317,12 @@ async def list_shows(
     # Sort and Paginate
     if sort == "rating":
         q = base_query.order_by(ShowModel.tmdb_rating.desc().nulls_last())
+    elif sort == "user_rating":
+        q = (
+            base_query
+            .outerjoin(show_ratings_sq, show_ratings_sq.c.tmdb_id == ShowModel.tmdb_id)
+            .order_by(show_ratings_sq.c.user_rating.desc().nulls_last(), ShowModel.id.desc())
+        )
     elif sort == "release_date":
         q = base_query.order_by(ShowModel.first_air_date.desc().nulls_last())
     elif sort == "created_at":

--- a/backend/tests/test_media_filters.py
+++ b/backend/tests/test_media_filters.py
@@ -7,7 +7,7 @@ os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://test:test@localhost/
 from routers.media import _apply_local_filters, _paginate_matches
 
 
-def _item(tmdb_id, in_library=False, watched=False, watch_started=False, is_monitored=False, release_date=None):
+def _item(tmdb_id, in_library=False, watched=False, watch_started=False, is_monitored=False, release_date=None, user_rating=None):
     return {
         "tmdb_id": tmdb_id,
         "in_library": in_library,
@@ -15,6 +15,7 @@ def _item(tmdb_id, in_library=False, watched=False, watch_started=False, is_moni
         "watch_started": watch_started,
         "is_monitored": is_monitored,
         "release_date": release_date,
+        "user_rating": user_rating,
     }
 
 
@@ -106,6 +107,24 @@ class ApplyLocalFiltersTests(unittest.TestCase):
     def test_unrecognized_value_alongside_a_real_one_is_ignored(self):
         items = [_item(1, watched=True), _item(2, watched=False)]
         result = _apply_local_filters(items, [], ["bogus", "watched"], [])
+        self.assertEqual([i["tmdb_id"] for i in result], [1])
+
+    def test_my_rating_matches_only_the_selected_personal_ratings(self):
+        items = [
+            _item(1, user_rating=10),
+            _item(2, user_rating=8),
+            _item(3, user_rating=None),
+        ]
+        result = _apply_local_filters(items, [], [], [], my_rating=[8, 10])
+        self.assertEqual([i["tmdb_id"] for i in result], [1, 2])
+
+    def test_my_rating_combines_with_the_existing_local_filters(self):
+        items = [
+            _item(1, in_library=True, user_rating=8),
+            _item(2, in_library=False, user_rating=8),
+            _item(3, in_library=True, user_rating=7),
+        ]
+        result = _apply_local_filters(items, ["in"], [], [], my_rating=[8])
         self.assertEqual([i["tmdb_id"] for i in result], [1])
 
 

--- a/backend/tests/test_my_rating_queries.py
+++ b/backend/tests/test_my_rating_queries.py
@@ -1,0 +1,109 @@
+import os
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+from sqlalchemy.dialects import postgresql
+
+os.environ.setdefault("SECRET_KEY", "test-secret")
+os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://test:test@localhost/test")
+
+from models.base import MediaType
+from models.media import Media
+from models.show import Show
+from routers.media import list_media
+from routers.shows import list_shows
+
+
+class _Result:
+    def __init__(self, *, count=None, items=None):
+        self.count = count
+        self.items = items or []
+
+    def scalar_one(self):
+        return self.count
+
+    def scalars(self):
+        return self
+
+    def all(self):
+        return self.items
+
+
+def _sql(statement) -> str:
+    return str(statement.compile(
+        dialect=postgresql.dialect(),
+        compile_kwargs={"literal_binds": True},
+    ))
+
+
+class MyRatingQueryTests(unittest.IsolatedAsyncioTestCase):
+    async def test_movie_filter_and_sort_are_scoped_to_the_current_users_top_level_rating(self):
+        movie = Media(
+            id=7, tmdb_id=550, media_type=MediaType.movie, title="Fight Club",
+            adult=False, tmdb_data={},
+        )
+        db = SimpleNamespace(execute=AsyncMock(side_effect=[
+            _Result(count=1), _Result(items=[movie]),
+        ]))
+        user = SimpleNamespace(id=42)
+
+        with (
+            patch("routers.media.enrich_with_state", AsyncMock()),
+            patch("routers.media.get_user_metadata_language", AsyncMock(return_value=None)),
+        ):
+            response = await list_media(
+                type=MediaType.movie,
+                sort="user_rating",
+                page=1,
+                page_size=30,
+                genre=[],
+                year=[],
+                watched=[],
+                my_rating=[8],
+                db=db,
+                current_user=user,
+            )
+
+        self.assertEqual(response["total_results"], 1)
+        query = _sql(db.execute.await_args_list[1].args[0])
+        self.assertIn("ratings.user_id = 42", query)
+        self.assertIn("ratings.season_number IS NULL", query)
+        self.assertIn("ratings.rating IN (8)", query)
+        self.assertIn("ORDER BY ratings.rating DESC NULLS LAST, media.id DESC", query)
+
+    async def test_show_filter_and_sort_join_rating_media_by_tmdb_id(self):
+        show = Show(id=3, tmdb_id=1396, title="Breaking Bad", tmdb_data={})
+        db = SimpleNamespace(execute=AsyncMock(side_effect=[
+            _Result(count=1), _Result(items=[show]),
+        ]))
+        user = SimpleNamespace(id=42)
+
+        with (
+            patch("routers.shows.enrich_with_state", AsyncMock()),
+            patch("routers.shows.get_user_metadata_language", AsyncMock(return_value=None)),
+        ):
+            response = await list_shows(
+                sort="user_rating",
+                page=1,
+                page_size=30,
+                genre=[],
+                year=[],
+                status=[],
+                watched=[],
+                my_rating=[9],
+                db=db,
+                current_user=user,
+            )
+
+        self.assertEqual(response["total_results"], 1)
+        query = _sql(db.execute.await_args_list[1].args[0])
+        self.assertIn("max(ratings.rating) AS user_rating", query)
+        self.assertIn("ratings.user_id = 42", query)
+        self.assertIn("ratings.season_number IS NULL", query)
+        self.assertIn("anon_1.user_rating IN (9)", query)
+        self.assertIn("ORDER BY anon_1.user_rating DESC NULLS LAST, shows.id DESC", query)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",
+    "test": "node --test test/*.test.mjs",
     "preview": "astro preview",
     "astro": "astro"
   },

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1108,7 +1108,7 @@ export const api = {
   },
 
   media: {
-    list: (params?: { type?: string; sort?: string; page?: number; genre?: string[]; year?: number[]; watched?: string[] }, token?: string) =>
+    list: (params?: { type?: string; sort?: string; page?: number; genre?: string[]; year?: number[]; watched?: string[]; my_rating?: number[] }, token?: string) =>
       get<{ page: number; page_size: number; total_pages: number; total_results: number; results: MediaItem[] }>("/media", params, token),
 
     years: (type: string, token?: string) =>
@@ -1137,7 +1137,7 @@ export const api = {
     getCollection: (collectionId: number, token?: string) =>
       get<CollectionDetail>(`/media/collection/${collectionId}`, undefined, token),
 
-    tmdbList: (params: { type: string; category?: string; page?: number; genre?: string[]; year?: number[]; min_rating?: number; status?: string; collection?: string[]; watch?: string[]; arr?: string[]; original_language?: string }, token?: string) =>
+    tmdbList: (params: { type: string; category?: string; page?: number; genre?: string[]; year?: number[]; min_rating?: number; status?: string; collection?: string[]; watch?: string[]; arr?: string[]; my_rating?: number[]; original_language?: string }, token?: string) =>
       get<{ results: MediaItem[]; page: number; total_pages: number; total_results: number }>("/media/tmdb/list", params, token),
 
     search: (q: string, type?: string, page: number = 1, year?: number, token?: string, inLibrary?: boolean) =>
@@ -1199,7 +1199,7 @@ export const api = {
   },
 
   shows: {
-    list: (params?: { sort?: string; page?: number; page_size?: number; genre?: string[]; year?: number[]; status?: string[]; watched?: string[] }, token?: string) =>
+    list: (params?: { sort?: string; page?: number; page_size?: number; genre?: string[]; year?: number[]; status?: string[]; watched?: string[]; my_rating?: number[] }, token?: string) =>
       get<{ page: number; page_size: number; total_results: number; total_pages: number; results: any[] }>("/shows", params, token),
 
     years: (token?: string) =>

--- a/frontend/src/pages/collection/movies.astro
+++ b/frontend/src/pages/collection/movies.astro
@@ -11,6 +11,7 @@ const sort = Astro.url.searchParams.get("sort") ?? "title";
 const genres = Astro.url.searchParams.getAll("genre");
 const years = Astro.url.searchParams.getAll("year").map(Number).filter((n) => !Number.isNaN(n));
 const watched = Astro.url.searchParams.getAll("watched");
+const myRating = Astro.url.searchParams.getAll("my_rating").map(Number).filter((n) => Number.isInteger(n) && n >= 0 && n <= 10);
 const page = Number(Astro.url.searchParams.get("page") ?? 1);
 const { token } = Astro.locals;
 Astro.response.headers.set("Cache-Control", "no-store");
@@ -22,6 +23,7 @@ const data = await api.media.list({
   genre: genres,
   year: years,
   watched,
+  my_rating: myRating,
 }, token);
 
 const MOVIE_GENRES = [
@@ -29,8 +31,11 @@ const MOVIE_GENRES = [
   "Drama", "Family", "Fantasy", "History", "Horror", "Music", "Mystery",
   "Romance", "Science Fiction", "Thriller", "War", "Western",
 ];
+const RATING_OPTIONS = Array.from({ length: 10 }, (_, index) => 10 - index).map((rating) => ({
+  value: String(rating), label: `${rating} / 10`,
+}));
 
-const hasFilters = genres.length > 0 || years.length > 0 || watched.length > 0;
+const hasFilters = genres.length > 0 || years.length > 0 || watched.length > 0 || myRating.length > 0;
 
 // Build base URL preserving active filters (without page)
 const baseParams = new URLSearchParams();
@@ -38,6 +43,7 @@ baseParams.set("sort", sort);
 genres.forEach((g) => baseParams.append("genre", g));
 years.forEach((y) => baseParams.append("year", String(y)));
 watched.forEach((w) => baseParams.append("watched", w));
+myRating.forEach((rating) => baseParams.append("my_rating", String(rating)));
 const baseUrl = `/collection/movies?${baseParams.toString()}`;
 ---
 
@@ -60,6 +66,7 @@ const baseUrl = `/collection/movies?${baseParams.toString()}`;
         options={[
           { value: "title", label: "A–Z" },
           { value: "rating", label: "Top" },
+          { value: "user_rating", label: "My Rating" },
           { value: "release_date", label: "Newest" },
           { value: "created_at", label: "Recently Added" },
           { value: "last_watched", label: "Recently Watched" },
@@ -73,6 +80,7 @@ const baseUrl = `/collection/movies?${baseParams.toString()}`;
           { key: "genre", label: "Genre", options: MOVIE_GENRES.map((g) => ({ value: g, label: g })), selected: genres },
           { key: "year", label: "Year", selected: years.map(String), dynamic: true, endpoint: "/api/proxy/media/years?type=movie" },
           { key: "watched", label: "Watched", options: [{ value: "watched", label: "Watched" }, { value: "unwatched", label: "Unwatched" }], selected: watched },
+          { key: "my_rating", label: "My Rating", options: RATING_OPTIONS, selected: myRating.map(String) },
         ]}
       />
     </div>

--- a/frontend/src/pages/collection/shows.astro
+++ b/frontend/src/pages/collection/shows.astro
@@ -12,6 +12,7 @@ const genres = Astro.url.searchParams.getAll("genre");
 const years = Astro.url.searchParams.getAll("year").map(Number).filter((n) => !Number.isNaN(n));
 const statuses = Astro.url.searchParams.getAll("status");
 const watched = Astro.url.searchParams.getAll("watched");
+const myRating = Astro.url.searchParams.getAll("my_rating").map(Number).filter((n) => Number.isInteger(n) && n >= 0 && n <= 10);
 const page = Number(Astro.url.searchParams.get("page") ?? 1);
 const { token } = Astro.locals;
 Astro.response.headers.set("Cache-Control", "no-store");
@@ -23,6 +24,7 @@ const data = await api.shows.list({
   year: years,
   status: statuses,
   watched,
+  my_rating: myRating,
 }, token);
 
 const TV_GENRES = [
@@ -32,8 +34,11 @@ const TV_GENRES = [
 ];
 
 const TV_STATUSES = ["Returning Series", "In Production", "Planned", "Ended", "Canceled"];
+const RATING_OPTIONS = Array.from({ length: 10 }, (_, index) => 10 - index).map((rating) => ({
+  value: String(rating), label: `${rating} / 10`,
+}));
 
-const hasFilters = genres.length > 0 || years.length > 0 || statuses.length > 0 || watched.length > 0;
+const hasFilters = genres.length > 0 || years.length > 0 || statuses.length > 0 || watched.length > 0 || myRating.length > 0;
 
 // Build base URL preserving active filters (without page)
 const baseParams = new URLSearchParams();
@@ -42,6 +47,7 @@ genres.forEach((g) => baseParams.append("genre", g));
 years.forEach((y) => baseParams.append("year", String(y)));
 statuses.forEach((s) => baseParams.append("status", s));
 watched.forEach((w) => baseParams.append("watched", w));
+myRating.forEach((rating) => baseParams.append("my_rating", String(rating)));
 const baseUrl = `/collection/shows?${baseParams.toString()}`;
 ---
 
@@ -64,6 +70,7 @@ const baseUrl = `/collection/shows?${baseParams.toString()}`;
         options={[
           { value: "title", label: "A–Z" },
           { value: "rating", label: "Top" },
+          { value: "user_rating", label: "My Rating" },
           { value: "release_date", label: "Newest" },
           { value: "created_at", label: "Recently Added" },
           { value: "last_watched", label: "Recently Watched" },
@@ -78,6 +85,7 @@ const baseUrl = `/collection/shows?${baseParams.toString()}`;
           { key: "year", label: "Year", selected: years.map(String), dynamic: true, endpoint: "/api/proxy/shows/years" },
           { key: "status", label: "Status", options: TV_STATUSES.map((s) => ({ value: s, label: s })), selected: statuses },
           { key: "watched", label: "Progress", options: [{ value: "watched", label: "Started" }, { value: "unwatched", label: "Not Started" }], selected: watched },
+          { key: "my_rating", label: "My Rating", options: RATING_OPTIONS, selected: myRating.map(String) },
         ]}
       />
     </div>

--- a/frontend/src/pages/movies.astro
+++ b/frontend/src/pages/movies.astro
@@ -14,6 +14,7 @@ const minRating = Astro.url.searchParams.get("min_rating") ? Number(Astro.url.se
 const collection = Astro.url.searchParams.getAll("collection");
 const watch = Astro.url.searchParams.getAll("watch");
 const arr = Astro.url.searchParams.getAll("arr");
+const myRating = Astro.url.searchParams.getAll("my_rating").map(Number).filter((n) => Number.isInteger(n) && n >= 0 && n <= 10);
 const langs = Astro.url.searchParams.getAll("lang");
 const page = Number(Astro.url.searchParams.get("page") ?? 1);
 const { token, user } = Astro.locals;
@@ -45,6 +46,7 @@ if (hasTmdbKey) {
       ...(collection.length ? { collection } : {}),
       ...(watch.length ? { watch } : {}),
       ...(hasRadarr && arr.length ? { arr } : {}),
+      ...(myRating.length ? { my_rating: myRating } : {}),
       ...(langs.length ? { original_language: langs.join("|") } : {}),
     }, token);
   } catch (e) {
@@ -81,6 +83,7 @@ if (minRating) baseParams.set("min_rating", String(minRating));
 collection.forEach((v) => baseParams.append("collection", v));
 watch.forEach((v) => baseParams.append("watch", v));
 if (hasRadarr) arr.forEach((v) => baseParams.append("arr", v));
+myRating.forEach((rating) => baseParams.append("my_rating", String(rating)));
 langs.forEach((l) => baseParams.append("lang", l));
 const baseUrl = `/movies?${baseParams.toString()}`;
 ---
@@ -123,6 +126,7 @@ const baseUrl = `/movies?${baseParams.toString()}`;
             ...(user ? [
               { key: "collection", label: "Collection", options: [{ value: "in", label: "In My Collection" }, { value: "out", label: "Not In My Collection" }], selected: collection },
               { key: "watch", label: "Watched", options: [{ value: "watched", label: "Watched" }, { value: "unwatched", label: "Unwatched" }], selected: watch },
+              { key: "my_rating", label: "My Rating", options: Array.from({ length: 10 }, (_, index) => 10 - index).map((rating) => ({ value: String(rating), label: `${rating} / 10` })), selected: myRating.map(String) },
             ] : []),
             ...(hasRadarr ? [{ key: "arr", label: "Radarr", options: [{ value: "added", label: "In Radarr" }, { value: "notadded", label: "Not In Radarr" }], selected: arr }] : []),
             { key: "lang", label: "Language", options: LANGUAGES, selected: langs },

--- a/frontend/src/pages/shows.astro
+++ b/frontend/src/pages/shows.astro
@@ -15,6 +15,7 @@ const status = Astro.url.searchParams.get("status") ?? "";
 const collection = Astro.url.searchParams.getAll("collection");
 const watch = Astro.url.searchParams.getAll("watch");
 const arr = Astro.url.searchParams.getAll("arr");
+const myRating = Astro.url.searchParams.getAll("my_rating").map(Number).filter((n) => Number.isInteger(n) && n >= 0 && n <= 10);
 const langs = Astro.url.searchParams.getAll("lang");
 const page = Number(Astro.url.searchParams.get("page") ?? 1);
 const { token, user } = Astro.locals;
@@ -47,6 +48,7 @@ if (hasTmdbKey) {
       ...(collection.length ? { collection } : {}),
       ...(watch.length ? { watch } : {}),
       ...(hasSonarr && arr.length ? { arr } : {}),
+      ...(myRating.length ? { my_rating: myRating } : {}),
       ...(langs.length ? { original_language: langs.join("|") } : {}),
     }, token);
   } catch (e) {
@@ -86,6 +88,7 @@ if (status) baseParams.set("status", status);
 collection.forEach((v) => baseParams.append("collection", v));
 watch.forEach((v) => baseParams.append("watch", v));
 if (hasSonarr) arr.forEach((v) => baseParams.append("arr", v));
+myRating.forEach((rating) => baseParams.append("my_rating", String(rating)));
 langs.forEach((l) => baseParams.append("lang", l));
 const baseUrl = `/shows?${baseParams.toString()}`;
 ---
@@ -129,6 +132,7 @@ const baseUrl = `/shows?${baseParams.toString()}`;
             ...(user ? [
               { key: "collection", label: "Collection", options: [{ value: "in", label: "In My Collection" }, { value: "out", label: "Not In My Collection" }], selected: collection },
               { key: "watch", label: "Watched", options: [{ value: "watched", label: "Watched" }, { value: "unwatched", label: "Unwatched" }, { value: "started", label: "In Progress" }], selected: watch },
+              { key: "my_rating", label: "My Rating", options: Array.from({ length: 10 }, (_, index) => 10 - index).map((rating) => ({ value: String(rating), label: `${rating} / 10` })), selected: myRating.map(String) },
             ] : []),
             ...(hasSonarr ? [{ key: "arr", label: "Sonarr", options: [{ value: "added", label: "In Sonarr" }, { value: "notadded", label: "Not In Sonarr" }], selected: arr }] : []),
             { key: "lang", label: "Language", options: LANGUAGES, selected: langs },

--- a/frontend/test/my-rating-filter-pages.test.mjs
+++ b/frontend/test/my-rating-filter-pages.test.mjs
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import test from "node:test";
+
+const frontendRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+async function pageSource(page) {
+  return readFile(path.join(frontendRoot, "src", "pages", page), "utf8");
+}
+
+for (const page of ["movies.astro", "shows.astro", "collection/movies.astro", "collection/shows.astro"]) {
+  test(`${page} keeps the My Rating filter in the page request and pagination URL`, async () => {
+    const source = await pageSource(page);
+
+    assert.match(source, /getAll\("my_rating"\).*Number\.isInteger/);
+    assert.match(source, /my_rating:\s*myRating/);
+    assert.match(source, /append\("my_rating", String\(rating\)\)/);
+    assert.match(source, /key:\s*"my_rating", label:\s*"My Rating"/);
+  });
+}
+
+for (const page of ["collection/movies.astro", "collection/shows.astro"]) {
+  test(`${page} offers descending My Rating as a collection sort`, async () => {
+    const source = await pageSource(page);
+    assert.match(source, /value:\s*"user_rating", label:\s*"My Rating"/);
+  });
+}
+
+test("the API client exposes My Rating to the movie, show, and explore requests", async () => {
+  const source = await readFile(path.join(frontendRoot, "src", "lib", "api.ts"), "utf8");
+  assert.equal((source.match(/my_rating\?: number\[\]/g) ?? []).length, 3);
+});


### PR DESCRIPTION
## Summary

- add exact 1–10 My Rating filters to Explore and collection Movies/Shows
- add descending My Rating sorting to collection Movies/Shows with unrated items last
- scope every query to the current user and exclude season ratings from show-level matches
- preserve active rating filters across pagination

Explore follows the existing bounded local-filter scan across TMDB pages; collection filtering and sorting use complete database queries.

Closes #136

## Verification

- python -m unittest tests.test_media_filters tests.test_my_rating_queries tests.test_media tests.test_shows (43 tests passed)
- npm test (7 tests passed)
- npm run build
- git diff --check