### PR TITLE
feat(next-up): add episode status badges

### DIFF
--- a/backend/routers/history.py
+++ b/backend/routers/history.py
@@ -645,6 +645,33 @@ def _has_confirmed_air_date(release_date: str | None, today: date) -> bool:
     return bool(release_date) and release_date <= today.isoformat()
 
 
+def _next_up_status(media: Media, today: date) -> str:
+    """Return the single, highest-priority badge for a Next Up episode.
+
+    Precedence is finale, premiere, new today, then the universal next-episode
+    label. A finale is emitted only when the show's existing TMDB season
+    metadata explicitly names this episode as its final numbered episode. A
+    "new" label is emitted only for an exact ISO release-date match, never from
+    a guess based on watch history or a missing date.
+    """
+    season = media.season_number
+    episode = media.episode_number
+    if media.show and season is not None and episode is not None:
+        seasons = (media.show.tmdb_data or {}).get("seasons") or []
+        for season_data in seasons:
+            if season_data.get("season_number") != season:
+                continue
+            episode_count = season_data.get("episode_count")
+            if isinstance(episode_count, int) and episode_count > 0 and episode == episode_count:
+                return "season_finale"
+            break
+    if season is not None and season > 0 and episode == 1:
+        return "season_premiere"
+    if media.release_date == today.isoformat():
+        return "new_today"
+    return "next_episode"
+
+
 class _NextUpEpisodeNotOnTmdb(Exception):
     """Internal signal to roll back a speculative next-up episode row when TMDB
     doesn't actually have it — not a real error, never raised past get_next_up."""
@@ -1001,8 +1028,10 @@ async def get_next_up(
     )
 
     items = [_format_media_item(m) for m in next_up]
+    status_by_media_id = {media.id: _next_up_status(media, today) for media in next_up}
     for item in items:
         item["next_up_hidden"] = item.get("show_id") in hidden_set
+        item["next_up_status"] = status_by_media_id.get(item.get("id"), "next_episode")
         show_stats = remaining_stats.get(item.get("show_id"))
         if show_stats:
             item["episodes_left"] = show_stats["episodes_left"]

--- a/backend/tests/test_next_up.py
+++ b/backend/tests/test_next_up.py
@@ -5,7 +5,9 @@ from datetime import date, datetime, timezone
 os.environ.setdefault("SECRET_KEY", "test-secret")
 os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://test:test@localhost/test")
 
-from routers.history import _compute_next_episode, _group_last_watched, _has_aired, _has_confirmed_air_date, _remaining_episode_stats
+from routers.history import _compute_next_episode, _group_last_watched, _has_aired, _has_confirmed_air_date, _next_up_status, _remaining_episode_stats
+from models.media import Media
+from models.show import Show
 
 
 class ComputeNextEpisodeTests(unittest.TestCase):
@@ -127,6 +129,55 @@ class HasConfirmedAirDateTests(unittest.TestCase):
         # date is missing rather than in the future.
         self.assertFalse(_has_confirmed_air_date(None, date(2026, 1, 1)))
         self.assertFalse(_has_confirmed_air_date("", date(2026, 1, 1)))
+
+
+class NextUpStatusTests(unittest.TestCase):
+    """Feature #195: precise, mutually-exclusive labels for Next Up cards."""
+
+    def _episode(self, *, season=1, episode=2, release_date="2026-01-01", episode_count=None):
+        media = Media(season_number=season, episode_number=episode, release_date=release_date)
+        if episode_count is not None:
+            media.show = Show(tmdb_data={"seasons": [{"season_number": season, "episode_count": episode_count}]})
+        return media
+
+    def test_finale_takes_precedence_over_new_today(self):
+        self.assertEqual(
+            _next_up_status(self._episode(episode=8, episode_count=8), date(2026, 1, 1)),
+            "season_finale",
+        )
+
+    def test_premiere_takes_precedence_over_new_today(self):
+        self.assertEqual(
+            _next_up_status(self._episode(episode=1), date(2026, 1, 1)),
+            "season_premiere",
+        )
+
+    def test_specials_do_not_receive_a_season_premiere_badge(self):
+        self.assertEqual(
+            _next_up_status(self._episode(season=0, episode=1, release_date="2025-12-31"), date(2026, 1, 1)),
+            "next_episode",
+        )
+
+    def test_new_today_requires_an_exact_release_date_match(self):
+        self.assertEqual(_next_up_status(self._episode(), date(2026, 1, 1)), "new_today")
+        self.assertEqual(
+            _next_up_status(self._episode(release_date=None), date(2026, 1, 1)),
+            "next_episode",
+        )
+        self.assertEqual(
+            _next_up_status(self._episode(release_date="2025-12-31"), date(2026, 1, 1)),
+            "next_episode",
+        )
+
+    def test_finale_requires_explicit_matching_season_metadata(self):
+        self.assertEqual(
+            _next_up_status(self._episode(episode=8, episode_count=9), date(2026, 1, 1)),
+            "new_today",
+        )
+        self.assertEqual(
+            _next_up_status(self._episode(episode=8), date(2026, 1, 1)),
+            "new_today",
+        )
 
 
 if __name__ == "__main__":

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",
+    "test": "node --test test/*.test.mjs",
     "preview": "astro preview",
     "astro": "astro"
   },

--- a/frontend/src/components/EpisodeCard.astro
+++ b/frontend/src/components/EpisodeCard.astro
@@ -3,12 +3,15 @@ import type { MediaItem } from "../lib/api";
 import { tmdbImageUrl } from "../lib/api";
 import CardActionBar from "./CardActionBar.astro";
 import { episodeHref } from "../lib/episodeHref";
+import NextUpBadge from "./NextUpBadge.astro";
+import type { NextUpStatus } from "../lib/next-up-status";
 
 interface Props {
   item: MediaItem;
+  nextUpStatus?: NextUpStatus | null;
 }
 
-const { item } = Astro.props;
+const { item, nextUpStatus } = Astro.props;
 
 const sxe =
   item.season_number != null && item.episode_number != null
@@ -67,6 +70,8 @@ const collectionPct = item.collection_pct ?? (inLibrary ? 100 : 0);
 
         <div class="absolute inset-0 bg-gradient-to-t from-black/80 via-black/20 to-transparent"></div>
 
+        <NextUpBadge status={nextUpStatus} />
+
         {sxe && (
           <div class="absolute top-2 left-2 bg-blue-600/90 backdrop-blur-md text-white text-xs font-bold px-2 py-0.5 rounded-full shadow-lg border border-blue-500/30">
             {sxe}
@@ -74,7 +79,7 @@ const collectionPct = item.collection_pct ?? (inLibrary ? 100 : 0);
         )}
 
         {item.library?.resolution && (
-          <div class="absolute top-2 right-2 bg-black/70 backdrop-blur-md text-white text-[11px] font-bold px-2 py-0.5 rounded-md border border-white/10 shadow-lg tracking-tighter">
+          <div class:list={["absolute right-2 bg-black/70 backdrop-blur-md text-white text-[11px] font-bold px-2 py-0.5 rounded-md border border-white/10 shadow-lg tracking-tighter", nextUpStatus ? "top-10" : "top-2"]}>
             {item.library.resolution}
           </div>
         )}
@@ -101,6 +106,8 @@ const collectionPct = item.collection_pct ?? (inLibrary ? 100 : 0);
 
         <div class="absolute inset-0 bg-gradient-to-t from-black/80 via-black/20 to-transparent"></div>
 
+        <NextUpBadge status={nextUpStatus} />
+
         {sxe && (
           <div class="absolute top-2 left-2 bg-blue-600/90 backdrop-blur-md text-white text-xs font-bold px-2 py-0.5 rounded-full shadow-lg border border-blue-500/30">
             {sxe}
@@ -108,7 +115,7 @@ const collectionPct = item.collection_pct ?? (inLibrary ? 100 : 0);
         )}
 
         {item.library?.resolution && (
-          <div class="absolute top-2 right-2 bg-black/70 backdrop-blur-md text-white text-[11px] font-bold px-2 py-0.5 rounded-md border border-white/10 shadow-lg tracking-tighter">
+          <div class:list={["absolute right-2 bg-black/70 backdrop-blur-md text-white text-[11px] font-bold px-2 py-0.5 rounded-md border border-white/10 shadow-lg tracking-tighter", nextUpStatus ? "top-10" : "top-2"]}>
             {item.library.resolution}
           </div>
         )}

--- a/frontend/src/components/MediaCard.astro
+++ b/frontend/src/components/MediaCard.astro
@@ -3,12 +3,15 @@ import type { MediaItem } from "../lib/api";
 import { tmdbImageUrl } from "../lib/api";
 import CardActionBar from "./CardActionBar.astro";
 import { episodeHref } from "../lib/episodeHref";
+import NextUpBadge from "./NextUpBadge.astro";
+import type { NextUpStatus } from "../lib/next-up-status";
 
 interface Props {
   item: MediaItem;
+  nextUpStatus?: NextUpStatus | null;
 }
 
-const { item } = Astro.props;
+const { item, nextUpStatus } = Astro.props;
 const { user } = Astro.locals;
 
 const isPerson = item.type === "person";
@@ -86,6 +89,8 @@ const inLibrary = item.in_library ?? false;
 
         <div class="absolute inset-0 bg-gradient-to-t from-black/80 via-transparent to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
 
+        <NextUpBadge status={nextUpStatus} />
+
         {rating && (
           <div class="absolute top-2 left-2 bg-black/80 backdrop-blur-md text-yellow-400 text-xs font-bold px-2 py-0.5 rounded-full shadow-lg border border-zinc-800 flex items-center gap-1">
             <span class="text-xs leading-none">★</span> {rating}
@@ -121,6 +126,7 @@ const inLibrary = item.in_library ?? false;
             <span class="text-xs leading-none">★</span> {rating}
           </div>
         )}
+        <NextUpBadge status={nextUpStatus} />
       </div>
     </div>
   )}
@@ -177,4 +183,3 @@ const inLibrary = item.in_library ?? false;
     </div>
   )}
 </div>
-

--- a/frontend/src/components/NextUpBadge.astro
+++ b/frontend/src/components/NextUpBadge.astro
@@ -1,0 +1,24 @@
+---
+import type { NextUpStatus } from "../lib/next-up-status";
+import { nextUpBadge } from "../lib/next-up-status";
+
+interface Props {
+  status?: NextUpStatus | null;
+  variant?: "overlay" | "inline";
+}
+
+const { status, variant = "overlay" } = Astro.props;
+const badge = status ? nextUpBadge(status) : null;
+---
+
+{badge && (
+  <span
+    class:list={[
+      "inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-black uppercase tracking-wider shadow-lg backdrop-blur-md",
+      badge.className,
+      variant === "overlay" ? "absolute top-2 right-2 z-10" : "mb-3",
+    ]}
+  >
+    {badge.label}
+  </span>
+)}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -583,6 +583,9 @@ export interface MediaItem {
   tvdb_season_number?: number | null;
   tvdb_episode_number?: number | null;
   next_up_hidden?: boolean;
+  // Backend-derived status for a Next Up episode. The server only emits
+  // "New Today" with an exact release-date match; see #195.
+  next_up_status?: "season_finale" | "season_premiere" | "new_today" | "next_episode";
   // Next Up remaining-content estimate (#170) — released unwatched episodes
   // for the show and their estimated total runtime in minutes.
   episodes_left?: number | null;

--- a/frontend/src/lib/next-up-status.ts
+++ b/frontend/src/lib/next-up-status.ts
@@ -1,0 +1,23 @@
+/** Statuses returned only by the personal Next Up endpoint. The server decides
+ * the meaning from episode metadata so every Next Up surface stays consistent. */
+export const NEXT_UP_STATUSES = [
+  "season_finale",
+  "season_premiere",
+  "new_today",
+  "next_episode",
+] as const;
+
+export type NextUpStatus = (typeof NEXT_UP_STATUSES)[number];
+
+export function nextUpBadge(status: NextUpStatus) {
+  switch (status) {
+    case "season_finale":
+      return { label: "Season Finale", className: "border-amber-400/30 bg-amber-500/90 text-amber-950" };
+    case "season_premiere":
+      return { label: "Season Premiere", className: "border-violet-300/30 bg-violet-600/90 text-white" };
+    case "new_today":
+      return { label: "New Today", className: "border-emerald-300/30 bg-emerald-600/90 text-white" };
+    case "next_episode":
+      return { label: "Next Episode", className: "border-blue-300/30 bg-blue-600/90 text-white" };
+  }
+}

--- a/frontend/src/pages/index.astro
+++ b/frontend/src/pages/index.astro
@@ -7,6 +7,7 @@ import ContinueWatchingCard from "../components/ContinueWatchingCard.astro";
 import { api, type ContinueWatchingItem, type MediaItem, tmdbImageUrl } from "../lib/api";
 import { formatEpisodesLeft } from "../lib/media-format";
 import { episodeHref } from "../lib/episodeHref";
+import NextUpBadge from "../components/NextUpBadge.astro";
 
 const { token, user } = Astro.locals;
 Astro.response.headers.set("Cache-Control", "no-store");
@@ -178,7 +179,7 @@ const discoverBackdropUrl = discoverPick?.backdrop_path
       </div>
       <div class="flex gap-3 overflow-x-auto pb-3 scrollbar-none -mx-6 px-6 md:mx-0 md:px-0">
         {nextUp.map((item) => (
-          <div class="flex-shrink-0 w-56"><EpisodeCard item={item} /></div>
+          <div class="flex-shrink-0 w-56"><EpisodeCard item={item} nextUpStatus={item.next_up_status} /></div>
         ))}
       </div>
     </section>
@@ -222,11 +223,14 @@ const discoverBackdropUrl = discoverPick?.backdrop_path
 
           <div class="flex-1 flex items-end pb-6 sm:pb-8">
             <a href={heroHref} class="block max-w-2xl group">
-              {episodeLabel && (
-                <span class="inline-block text-xs font-bold uppercase tracking-widest text-blue-400 bg-blue-500/10 border border-blue-500/20 px-3 py-1 rounded-full mb-3">
-                  {episodeLabel}
-                </span>
-              )}
+              <div class="flex flex-wrap items-center gap-2 mb-3">
+                <NextUpBadge status={hero.next_up_status} variant="inline" />
+                {episodeLabel && (
+                  <span class="inline-block text-xs font-bold uppercase tracking-widest text-blue-400 bg-blue-500/10 border border-blue-500/20 px-3 py-1 rounded-full">
+                    {episodeLabel}
+                  </span>
+                )}
+              </div>
               <h3 class="text-2xl sm:text-4xl font-black text-zinc-100 leading-tight mb-1 drop-shadow-lg group-hover:text-blue-200 transition-colors">
                 {hero.show_title ?? hero.title}
               </h3>
@@ -244,7 +248,7 @@ const discoverBackdropUrl = discoverPick?.backdrop_path
 
         {rest.length > 0 && (
           <div class="relative flex gap-3 overflow-x-auto pb-3 scrollbar-none pt-6 -mx-6 px-6 md:mx-0 md:px-0">
-            {rest.map((item) => <div class="flex-shrink-0 w-40"><MediaCard item={item} /></div>)}
+            {rest.map((item) => <div class="flex-shrink-0 w-40"><MediaCard item={item} nextUpStatus={item.next_up_status} /></div>)}
           </div>
         )}
       </section>

--- a/frontend/src/pages/next-up.astro
+++ b/frontend/src/pages/next-up.astro
@@ -79,6 +79,15 @@ Astro.response.headers.set("Cache-Control", "no-store");
   const EYE_SLASH = `<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M9.88 9.88a3 3 0 1 0 4.24 4.24"/><path d="M10.73 5.08A10.43 10.43 0 0 1 12 5c7 0 10 7 10 7a13.16 13.16 0 0 1-1.67 2.68"/><path d="M6.61 6.61A13.526 13.526 0 0 0 2 12s3 7 10 7a9.74 9.74 0 0 0 5.39-1.61"/><line x1="2" x2="22" y1="2" y2="22"/></svg>`;
   const EYE    = `<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z"/><circle cx="12" cy="12" r="3"/></svg>`;
   const SPIN   = `<svg class="animate-spin" xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><circle cx="12" cy="12" r="10" stroke-opacity="0.25"/><path d="M12 2a10 10 0 0 1 10 10"/></svg>`;
+  // Local copy of lib/next-up-status's presentation mapping. This page
+  // renders cards after a client fetch, so define:vars scripts cannot import
+  // the shared module; the backend remains the single source of status facts.
+  const NEXT_UP_BADGES = {
+    season_finale: { label: 'Season Finale', className: 'border-amber-400/30 bg-amber-500/90 text-amber-950' },
+    season_premiere: { label: 'Season Premiere', className: 'border-violet-300/30 bg-violet-600/90 text-white' },
+    new_today: { label: 'New Today', className: 'border-emerald-300/30 bg-emerald-600/90 text-white' },
+    next_episode: { label: 'Next Episode', className: 'border-blue-300/30 bg-blue-600/90 text-white' },
+  };
 
   let showingHidden = false;
   let allItems = [];
@@ -115,6 +124,11 @@ Astro.response.headers.set("Cache-Control", "no-store");
     return label;
   }
 
+  function nextUpBadge(item) {
+    const badge = NEXT_UP_BADGES[item.next_up_status] ?? NEXT_UP_BADGES.next_episode;
+    return `<span class="absolute top-2 left-2 z-10 inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-black uppercase tracking-wider shadow-lg backdrop-blur-md ${badge.className}">${esc(badge.label)}</span>`;
+  }
+
   function buildCard(item) {
     const isHidden = item.next_up_hidden === true;
     // Local copy of lib/episodeHref's episode branch - this define:vars
@@ -135,7 +149,6 @@ Astro.response.headers.set("Cache-Control", "no-store");
 
     const posterSrc = tmdbImageUrl(item.show_poster_path || item.poster_path, 'w500');
 
-    const rating = item.tmdb_rating ? Number(item.tmdb_rating).toFixed(1) : null;
     const sxe = item.season_number != null && item.episode_number != null
       ? `S${String(item.season_number).padStart(2, '0')}E${String(item.episode_number).padStart(2, '0')}`
       : null;
@@ -162,7 +175,7 @@ Astro.response.headers.set("Cache-Control", "no-store");
                 : `<div class="w-full h-full flex flex-col items-center justify-center text-zinc-700 bg-zinc-900 p-4 text-center"><span class="text-3xl mb-2 opacity-30">📺</span><span class="text-xs font-bold uppercase tracking-widest">${esc(item.show_title ?? item.title)}</span></div>`
               }
               <div class="absolute inset-0 bg-gradient-to-t from-black/80 via-transparent to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
-              ${rating ? `<div class="absolute top-2 left-2 bg-black/80 backdrop-blur-md text-yellow-400 text-[10px] font-black px-2 py-0.5 rounded-full shadow-lg border border-zinc-800 flex items-center gap-1"><span class="text-xs leading-none">★</span> ${esc(rating)}</div>` : ''}
+              ${nextUpBadge(item)}
             </div>
           </a>
           ${hideBtn}

--- a/frontend/test/next-up-badge.test.mjs
+++ b/frontend/test/next-up-badge.test.mjs
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFile } from "node:fs/promises";
+
+const root = new URL("..", import.meta.url);
+const read = (path) => readFile(new URL(path, root), "utf8");
+
+test("Next Up badges have one accessible label and distinct status colours", async () => {
+  const component = await read("src/components/NextUpBadge.astro");
+  const statuses = await read("src/lib/next-up-status.ts");
+
+  for (const label of ["Season Finale", "Season Premiere", "New Today", "Next Episode"]) {
+    assert.match(statuses, new RegExp(`label: \\"${label}\\"`));
+  }
+  assert.match(component, /uppercase tracking-wider/);
+  assert.match(component, /variant === "overlay" \? "absolute top-2 right-2 z-10"/);
+});
+
+test("all Next Up surfaces pass the backend-derived status to the shared badge", async () => {
+  const index = await read("src/pages/index.astro");
+  const episodeCard = await read("src/components/EpisodeCard.astro");
+  const mediaCard = await read("src/components/MediaCard.astro");
+  const fullNextUp = await read("src/pages/next-up.astro");
+
+  assert.match(index, /EpisodeCard item=\{item\} nextUpStatus=\{item\.next_up_status\}/);
+  assert.match(index, /NextUpBadge status=\{hero\.next_up_status\} variant="inline"/);
+  assert.match(index, /MediaCard item=\{item\} nextUpStatus=\{item\.next_up_status\}/);
+  assert.match(episodeCard, /NextUpBadge status=\{nextUpStatus\}/);
+  const cardStart = mediaCard.indexOf("{href ? (");
+  const noHrefStart = mediaCard.indexOf("\n  ) : (", cardStart);
+  const actionBarStart = mediaCard.indexOf("<!-- Action bar", noHrefStart);
+  const badgeCount = (branch) => (branch.match(/<NextUpBadge status=\{nextUpStatus\} \/>/g) ?? []).length;
+  assert.equal(badgeCount(mediaCard.slice(cardStart, noHrefStart)), 1);
+  assert.equal(badgeCount(mediaCard.slice(noHrefStart, actionBarStart)), 1);
+  assert.match(fullNextUp, /next_up_status/);
+});


### PR DESCRIPTION
## Summary

- derive one reliable Next Up status per episode with explicit precedence
- show Season Finale only from matching TMDB episode-count metadata
- label season-one openings as Season Premiere and exact-date releases as New Today
- render shared coloured badges across homepage hero/cards and the full Next Up view
- keep specials and missing dates from receiving misleading labels

Closes #195

## Verification

- uv run python -m unittest tests.test_next_up (29 tests passed)
- npm test (2 tests passed)
- npm run build
- Python compileall
- git diff --check