### PR TITLE
feat(tmdb): support an optional outbound proxy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,10 @@ POSTGRES_PORT=5432
 # Generate with: openssl rand -hex 32
 SECRET_KEY=changethisinproduction
 
+# Optional: route only TMDB metadata and image traffic through an HTTP or
+# SOCKS5 proxy (for example, a Cloudflare WARP container on the Docker network).
+# TMDB_PROXY_URL=socks5://warp:1080
+
 ENABLE_REGISTRATIONS=false
 REGISTRATION_MAX_ALLOWED_USERS=5
 

--- a/README.md
+++ b/README.md
@@ -295,10 +295,27 @@ Database migrations run automatically on startup - no manual steps required.
 | `PUID` | `1000` | User ID to run the process as. |
 | `PGID` | `1000` | Group ID to run the process as. |
 | `BACKEND_PORT` | `7331` | Internal port the backend binds to. Override only if `7331` conflicts on bare metal. |
+| `TMDB_PROXY_URL` | - | Optional HTTP or SOCKS5 proxy for TMDB metadata and image requests only. |
 | `OIDC_ENABLED` | `false` | Enable OIDC login. |
 | `OIDC_DISABLE_PASSWORD_LOGIN` | `false` | Enforce OIDC-only login (disables username/password). |
 
 See `docker-compose.yaml` for the full list of OIDC variables and other variables.
+
+### TMDB-only proxy
+
+On networks where TMDB is blocked, route Scrob's TMDB traffic through a proxy
+without affecting Plex, Jellyfin, Trakt, or any other provider. Set
+`TMDB_PROXY_URL` to an HTTP or SOCKS5 proxy reachable from the Scrob container:
+
+```yaml
+environment:
+  TMDB_PROXY_URL: socks5://warp:1080
+```
+
+For example, `warp` can be a Cloudflare WARP container on the same Docker
+network. The setting is deployment-wide and is not exposed in user settings.
+TMDB image requests served through Scrob's `/media/image/...` endpoint also use
+the proxy, including when Scrob's optional disk image cache is disabled.
 
 ### Reverse proxy
 

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -16,6 +16,12 @@ class Settings(BaseSettings):
 
     server_url: str = "http://localhost:7330"
 
+    # Optional outbound proxy used exclusively by TMDB metadata and image
+    # requests. This is intentionally an environment-only deployment setting,
+    # rather than a per-user preference, so users cannot select an arbitrary
+    # proxy for server-side requests.
+    tmdb_proxy_url: Optional[str] = None
+
     # Already set to UTC in the Dockerfiles (ENV TZ=UTC) for the container's own
     # system clock; reused here as the server-side "today" for pages that have
     # no per-request browser timezone to go on (e.g. /airing-today's plain SSR
@@ -82,3 +88,13 @@ class Settings(BaseSettings):
 
 
 settings = Settings()
+
+
+def tmdb_httpx_kwargs() -> dict[str, str]:
+    """Return the explicit proxy option for TMDB-only httpx clients.
+
+    httpx 0.28 uses the singular ``proxy`` keyword. Keeping this helper next
+    to the environment setting makes it harder to accidentally apply the
+    proxy to another provider's client.
+    """
+    return {"proxy": settings.tmdb_proxy_url} if settings.tmdb_proxy_url else {}

--- a/backend/core/image_cache.py
+++ b/backend/core/image_cache.py
@@ -9,7 +9,7 @@ from sqlalchemy import select, func, delete as sa_delete
 from sqlalchemy.exc import IntegrityError
 
 from db import AsyncSessionLocal
-from core.config import settings
+from core.config import settings, tmdb_httpx_kwargs
 from models.image_cache import ImageCache
 from models.media import Media
 from models.show import Show as ShowModel
@@ -65,41 +65,55 @@ async def download_and_cache_image(db, size: str, path: str, image_type: str = "
             await db.delete(cached)
             await db.commit()
 
-    # Fetch from TMDB
-    url = f"https://image.tmdb.org/t/p/{size}{path}"
+    # Fetch from TMDB.  This is deliberately the only non-metadata request
+    # that receives TMDB_PROXY_URL, so image caching works on networks that
+    # block image.tmdb.org without proxying any other provider.
     try:
-        async with httpx.AsyncClient(timeout=15.0) as client:
-            r = await client.get(url)
-            if r.status_code == 200:
-                local_path.parent.mkdir(parents=True, exist_ok=True)
-                local_path.write_bytes(r.content)
+        image = await fetch_tmdb_image(size, path)
+        if image:
+            content, _content_type = image
+            local_path.parent.mkdir(parents=True, exist_ok=True)
+            local_path.write_bytes(content)
 
-                cache_entry = ImageCache(
-                    path=path,
-                    size=size,
-                    image_type=image_type,
-                    file_size=len(r.content),
-                    last_accessed=datetime.now(timezone.utc),
-                    created_at=datetime.now(timezone.utc),
+            cache_entry = ImageCache(
+                path=path,
+                size=size,
+                image_type=image_type,
+                file_size=len(content),
+                last_accessed=datetime.now(timezone.utc),
+                created_at=datetime.now(timezone.utc),
+            )
+            try:
+                db.add(cache_entry)
+                await db.commit()
+            except IntegrityError:
+                # Concurrent request already inserted this entry; update last_accessed instead
+                await db.rollback()
+                result = await db.execute(
+                    select(ImageCache).where(ImageCache.path == path, ImageCache.size == size)
                 )
-                try:
-                    db.add(cache_entry)
+                existing = result.scalar_one_or_none()
+                if existing:
+                    existing.last_accessed = datetime.now(timezone.utc)
                     await db.commit()
-                except IntegrityError:
-                    # Concurrent request already inserted this entry; update last_accessed instead
-                    await db.rollback()
-                    result = await db.execute(
-                        select(ImageCache).where(ImageCache.path == path, ImageCache.size == size)
-                    )
-                    existing = result.scalar_one_or_none()
-                    if existing:
-                        existing.last_accessed = datetime.now(timezone.utc)
-                        await db.commit()
-                return str(local_path)
+            return str(local_path)
     except Exception as e:
-        logger.error(f"Error downloading TMDB image {url}: {e}")
+        logger.error("Error downloading TMDB image: %s", e)
 
     return None
+
+
+async def fetch_tmdb_image(size: str, path: str) -> tuple[bytes, Optional[str]] | None:
+    """Fetch one validated TMDB image, using the optional TMDB-only proxy."""
+    if size not in ALLOWED_SIZES or ".." in path or not path.startswith("/"):
+        return None
+
+    url = f"https://image.tmdb.org/t/p/{size}{path}"
+    async with httpx.AsyncClient(timeout=15.0, **tmdb_httpx_kwargs()) as client:
+        response = await client.get(url)
+        if response.status_code != 200:
+            return None
+        return response.content, response.headers.get("content-type")
 
 
 async def _prune_type(db, image_type: str, total_size: int, limit_bytes: int) -> int:

--- a/backend/core/tmdb.py
+++ b/backend/core/tmdb.py
@@ -1,7 +1,7 @@
 import asyncio
 import time
 import httpx
-from core.config import settings
+from core.config import settings, tmdb_httpx_kwargs
 
 TMDB_BASE = "https://api.themoviedb.org/3"
 TMDB_IMAGE_BASE = "https://image.tmdb.org/t/p"
@@ -78,7 +78,9 @@ async def _get(
     last_exc: Exception = None
     for attempt in range(max_retries + 1):
         try:
-            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0)) as client:
+            async with httpx.AsyncClient(
+                timeout=httpx.Timeout(30.0), **tmdb_httpx_kwargs()
+            ) as client:
                 r = await client.get(url, headers=headers or {}, params=params)
                 if r.status_code == 429:
                     wait = int(r.headers.get("Retry-After", 2 ** (attempt + 1)))

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "h11==0.16.0",
     "httpcore==1.0.9",
     "httptools==0.7.1",
-    "httpx==0.28.1",
+    "httpx[socks]==0.28.1",
     "idna==3.11",
     "mako==1.3.10",
     "markupsafe==3.0.3",

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -10,7 +10,7 @@ greenlet==3.3.2
 h11==0.16.0
 httpcore==1.0.9
 httptools==0.7.1
-httpx==0.28.1
+httpx[socks]==0.28.1
 idna==3.11
 Mako==1.3.10
 MarkupSafe==3.0.3

--- a/backend/routers/media.py
+++ b/backend/routers/media.py
@@ -5687,6 +5687,27 @@ async def serve_image(
     settings_stmt = select(GlobalSettings).where(GlobalSettings.id == 1)
     gs = (await db.execute(settings_stmt)).scalar_one_or_none()
 
+    # With a TMDB-only proxy configured, stream through the backend when the
+    # optional disk cache is disabled. Redirecting would make the browser
+    # contact image.tmdb.org directly and bypass the deployment proxy. When
+    # the disk cache is enabled, the normal cache path below still uses the
+    # same proxy for its TMDB fetches.
+    if settings.tmdb_proxy_url and (not gs or not gs.image_cache_enabled):
+        from core.image_cache import ALLOWED_SIZES, fetch_tmdb_image
+        if size not in ALLOWED_SIZES:
+            raise HTTPException(status_code=400, detail="Invalid image size")
+        if ".." in path:
+            raise HTTPException(status_code=400, detail="Invalid image path")
+        image = await fetch_tmdb_image(size, path)
+        if not image:
+            raise HTTPException(status_code=502, detail="Unable to fetch TMDB image through configured proxy")
+        content, content_type = image
+        return Response(
+            content=content,
+            media_type=content_type or "application/octet-stream",
+            headers={"Cache-Control": "public, max-age=86400"},
+        )
+
     if not gs or not gs.image_cache_enabled:
         return RedirectResponse(f"https://image.tmdb.org/t/p/{size}{path}")
 
@@ -5698,6 +5719,8 @@ async def serve_image(
 
     local_path_str = await download_and_cache_image(db, size, path)
     if not local_path_str:
+        if settings.tmdb_proxy_url:
+            raise HTTPException(status_code=502, detail="Unable to fetch TMDB image through configured proxy")
         return RedirectResponse(f"https://image.tmdb.org/t/p/{size}{path}")
 
     # Eviction pruning check in background

--- a/backend/tests/test_tmdb_proxy.py
+++ b/backend/tests/test_tmdb_proxy.py
@@ -1,0 +1,102 @@
+import os
+import unittest
+from unittest.mock import AsyncMock, patch
+
+import httpx
+
+os.environ.setdefault("SECRET_KEY", "test-secret")
+os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://test:test@localhost/test")
+
+from core import image_cache, tmdb
+from routers import media
+
+
+class _RecordingAsyncClient:
+    def __init__(self, captured: list[dict], **kwargs):
+        captured.append(kwargs)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return False
+
+    async def get(self, url, **_kwargs):
+        content = b'{"id": 1}' if "/3/" in str(url) else b"image-data"
+        return httpx.Response(
+            200,
+            content=content,
+            headers={"content-type": "image/jpeg"},
+            request=httpx.Request("GET", url),
+        )
+
+
+class _ScalarResult:
+    def scalar_one_or_none(self):
+        return None
+
+
+class _NoSettingsDb:
+    async def execute(self, _statement):
+        return _ScalarResult()
+
+
+class TmdbProxyTests(unittest.IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        tmdb._cache._store.clear()
+
+    async def test_tmdb_metadata_client_uses_configured_proxy(self) -> None:
+        captured: list[dict] = []
+        with (
+            patch.object(tmdb.settings, "tmdb_proxy_url", "socks5://warp:1080"),
+            patch.object(tmdb.httpx, "AsyncClient", side_effect=lambda **kw: _RecordingAsyncClient(captured, **kw)),
+        ):
+            await tmdb.get_show(1399, api_key="tmdb-token", cache_ttl=None)
+
+        self.assertEqual(captured[0]["proxy"], "socks5://warp:1080")
+
+    async def test_tmdb_metadata_client_is_direct_when_proxy_is_unset(self) -> None:
+        captured: list[dict] = []
+        with (
+            patch.object(tmdb.settings, "tmdb_proxy_url", None),
+            patch.object(tmdb.httpx, "AsyncClient", side_effect=lambda **kw: _RecordingAsyncClient(captured, **kw)),
+        ):
+            await tmdb.get_show(1399, api_key="tmdb-token", cache_ttl=None)
+
+        self.assertNotIn("proxy", captured[0])
+
+    async def test_tmdb_image_client_uses_only_the_configured_tmdb_proxy(self) -> None:
+        captured: list[dict] = []
+        with (
+            patch.object(image_cache.settings, "tmdb_proxy_url", "http://warp:3128"),
+            patch.object(image_cache.httpx, "AsyncClient", side_effect=lambda **kw: _RecordingAsyncClient(captured, **kw)),
+        ):
+            image = await image_cache.fetch_tmdb_image("w500", "/poster.jpg")
+
+        self.assertEqual(image, (b"image-data", "image/jpeg"))
+        self.assertEqual(captured[0]["proxy"], "http://warp:3128")
+
+    async def test_tmdb_image_client_is_direct_when_proxy_is_unset(self) -> None:
+        captured: list[dict] = []
+        with (
+            patch.object(image_cache.settings, "tmdb_proxy_url", None),
+            patch.object(image_cache.httpx, "AsyncClient", side_effect=lambda **kw: _RecordingAsyncClient(captured, **kw)),
+        ):
+            await image_cache.fetch_tmdb_image("w500", "/poster.jpg")
+
+        self.assertNotIn("proxy", captured[0])
+
+    async def test_image_endpoint_streams_through_proxy_instead_of_redirecting(self) -> None:
+        with (
+            patch.object(media.settings, "tmdb_proxy_url", "socks5://warp:1080"),
+            patch("core.image_cache.fetch_tmdb_image", new=AsyncMock(return_value=(b"image-data", "image/jpeg"))),
+        ):
+            response = await media.serve_image("w500", "poster.jpg", _NoSettingsDb(), 1)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.body, b"image-data")
+        self.assertEqual(response.headers["content-type"], "image/jpeg")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -14,7 +14,7 @@ dependencies = [
     { name = "mako" },
     { name = "sqlalchemy" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/94/13/8b084e0f2efb0275a1d534838844926f798bd766566b1375174e2448cd31/alembic-1.18.4.tar.gz", hash = "sha256:cb6e1fd84b6174ab8dbb2329f86d631ba9559dd78df550b57804d607672cedbc", size = 2056725, upload-time = "2026-02-10T16:00:47.195Z" }
 wheels = [
@@ -188,7 +188,7 @@ dependencies = [
     { name = "h11" },
     { name = "httpcore" },
     { name = "httptools" },
-    { name = "httpx" },
+    { name = "httpx", extra = ["socks"] },
     { name = "idna" },
     { name = "mako" },
     { name = "markupsafe" },
@@ -230,7 +230,7 @@ requires-dist = [
     { name = "h11", specifier = "==0.16.0" },
     { name = "httpcore", specifier = "==1.0.9" },
     { name = "httptools", specifier = "==0.7.1" },
-    { name = "httpx", specifier = "==0.28.1" },
+    { name = "httpx", extras = ["socks"], specifier = "==0.28.1" },
     { name = "idna", specifier = "==3.11" },
     { name = "mako", specifier = "==1.3.10" },
     { name = "markupsafe", specifier = "==3.0.3" },
@@ -549,7 +549,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -710,6 +710,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[package.optional-dependencies]
+socks = [
+    { name = "socksio" },
 ]
 
 [[package]]
@@ -1173,6 +1178,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a0/99/adfc7f94ca024736f061257d39118e1542bade7a52e86415a4c4ae92d8ff/slowapi-0.1.9.tar.gz", hash = "sha256:639192d0f1ca01b1c6d95bf6c71d794c3a9ee189855337b4821f7f457dddad77", size = 14028, upload-time = "2024-02-05T12:11:52.13Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2b/bb/f71c4b7d7e7eb3fc1e8c0458a8979b912f40b58002b9fbf37729b8cb464b/slowapi-0.1.9-py3-none-any.whl", hash = "sha256:cfad116cfb84ad9d763ee155c1e5c5cbf00b0d47399a769b227865f5df576e36", size = 14670, upload-time = "2024-02-05T12:11:50.898Z" },
+]
+
+[[package]]
+name = "socksio"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/5c/48a7d9495be3d1c651198fd99dbb6ce190e2274d0f28b9051307bdec6b85/socksio-1.0.0.tar.gz", hash = "sha256:f88beb3da5b5c38b9890469de67d0cb0f9d494b78b106ca1845f96c10b91c4ac", size = 19055, upload-time = "2020-04-17T15:50:34.664Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/c3/6eeb6034408dac0fa653d126c9204ade96b819c936e136c5e8a6897eee9c/socksio-1.0.0-py3-none-any.whl", hash = "sha256:95dc1f15f9b34e8d7b16f06d74b8ccf48f609af32ab33c608d08761c5dcbb1f3", size = 12763, upload-time = "2020-04-17T15:50:31.878Z" },
 ]
 
 [[package]]

--- a/docker-compose.omnibus.yml
+++ b/docker-compose.omnibus.yml
@@ -24,6 +24,11 @@ services:
       # to use the official key.
       # ARVIO_APP_ANON_KEY: ""
 
+      # ── TMDB-only proxy (optional) ─────────────────────────────────────────
+      # Route only TMDB metadata and image traffic through an HTTP or SOCKS5
+      # proxy such as a Cloudflare WARP container on this Docker network.
+      # TMDB_PROXY_URL: socks5://warp:1080
+
       # ── OIDC (optional) ─────────────────────────────────────────────────────
       # OIDC_ENABLED: "false"
       # OIDC_PROVIDER_NAME: SSO

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -46,6 +46,11 @@ services:
       # to use the official key.
       # ARVIO_APP_ANON_KEY: ""
 
+      # ── TMDB-only proxy (optional) ─────────────────────────────────────────
+      # Route only TMDB metadata and image traffic through an HTTP or SOCKS5
+      # proxy such as a Cloudflare WARP container on this Docker network.
+      # TMDB_PROXY_URL: socks5://warp:1080
+
       # ── OIDC (optional) ─────────────────────────────────────────────────────
       # OIDC_ENABLED: "false"
       # OIDC_PROVIDER_NAME: SSO


### PR DESCRIPTION
## Summary

- add an environment-only TMDB_PROXY_URL for HTTP and SOCKS5 proxies
- apply it exclusively to shared TMDB metadata clients and backend TMDB image downloads
- stream the authenticated media-image endpoint through the proxy when disk caching is disabled
- avoid redirecting around a configured proxy when an image fetch fails
- document bare-metal and Compose configuration and include SOCKS transport support

Legacy absolute image URLs rendered directly by a browser remain outside this server-side proxy; Scrob media images served through /media/image are covered.

Closes #152

## Verification

- python -m unittest tests.test_tmdb tests.test_tmdb_proxy tests.test_media (32 tests passed)
- uv lock --check
- Python compileall
- Compose YAML parse
- git diff --check