### PR TITLE
feat(sync): ignore unmatched source items

### DIFF
--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -45,6 +45,56 @@ class SyncCancelled(Exception):
     """Raised internally to unwind a background sync loop once its SyncJob has been cancelled."""
 
 
+class IgnoreUnmatchedItemsBody(BaseModel):
+    """Source IDs from one owned connection that the user has acknowledged."""
+
+    connection_id: int
+    source_ids: list[str]
+
+
+def _is_ignorable_unmatched_warning(warning: object) -> bool:
+    """Only source items with the normal unmatched warning may be ignored.
+
+    Enrichment/remap warnings deliberately stay actionable. Keeping this
+    predicate narrow also prevents the endpoint becoming a generic way to hide
+    arbitrary SyncJob messages.
+    """
+    return bool(
+        isinstance(warning, dict)
+        and warning.get("source_id")
+        and warning.get("title") is not None
+        and str(warning.get("reason") or "").startswith("Unmatched on source")
+        and not warning.get("matched")
+    )
+
+
+def _filter_ignored_warnings(warnings: list | None) -> list | None:
+    """Return displayable warnings without mutating persisted SyncJob JSON."""
+    if not warnings:
+        return warnings
+    visible = [
+        warning for warning in warnings
+        if not (
+            isinstance(warning, dict)
+            and _is_ignorable_unmatched_warning(warning)
+            and warning.get("ignored")
+        )
+    ]
+    return visible or None
+
+
+def _sync_job_response(job: SyncJob, warnings: list | None) -> dict:
+    """Serialize a job without assigning to its ORM warnings attribute.
+
+    Assigning filtered warnings to the model in a GET route risks accidentally
+    persisting the display-only filtering in a later flush.
+    """
+    return {
+        column.key: (warnings if column.key == "warnings" else getattr(job, column.key))
+        for column in SyncJob.__table__.columns
+    }
+
+
 async def _raise_if_cancelled(db: AsyncSession, job_id: int | None) -> None:
     """Re-read a job's status from the DB and raise SyncCancelled if the user cancelled it.
 
@@ -2546,6 +2596,7 @@ async def _run_jellyfin_sync(user_id: int, job_id: int, movie_limit: int, show_l
             # A pull only populates scrob's own data — it never automatically pushes to
             # other connections; users push explicitly per-service (the "Push" buttons).
             all_warnings = await _stamp_matched_show_warnings(db, user_id, all_warnings)
+            all_warnings = await _stamp_ignored_unmatched_warnings(db, user_id, conn.id, all_warnings)
             await db.execute(update(SyncJob).where(SyncJob.id == job_id).values(status=SyncStatus.completed, stats=stats, warnings=all_warnings or None, updated_at=func.now()))
             await db.commit()
             asyncio.create_task(pre_cache_all_collected_bg())
@@ -2755,6 +2806,7 @@ async def _run_emby_sync(user_id: int, job_id: int, movie_limit: int, show_limit
             # A pull only populates scrob's own data — it never automatically pushes to
             # other connections; users push explicitly per-service (the "Push" buttons).
             all_warnings = await _stamp_matched_show_warnings(db, user_id, all_warnings)
+            all_warnings = await _stamp_ignored_unmatched_warnings(db, user_id, conn.id, all_warnings)
             await db.execute(update(SyncJob).where(SyncJob.id == job_id).values(status=SyncStatus.completed, stats=stats, warnings=all_warnings or None, updated_at=func.now()))
             await db.commit()
             asyncio.create_task(pre_cache_all_collected_bg())
@@ -3666,6 +3718,7 @@ async def _run_plex_sync(user_id: int, job_id: int, movie_limit: int, show_limit
             # connection's own plex_push_watchlist flag in both jobs, so pull/push
             # scheduling order can't resurrect items removed on the other side.
             all_warnings = await _stamp_matched_show_warnings(db, user_id, all_warnings)
+            all_warnings = await _stamp_ignored_unmatched_warnings(db, user_id, conn.id, all_warnings)
             await db.execute(update(SyncJob).where(SyncJob.id == job_id).values(status=SyncStatus.completed, stats=stats, warnings=all_warnings or None, updated_at=func.now()))
             await db.commit()
             asyncio.create_task(pre_cache_all_collected_bg())
@@ -4274,6 +4327,7 @@ async def _run_nuvio_sync(
             # A pull only populates scrob's own data — it never automatically pushes to
             # other connections; users push explicitly per-service (the "Push" buttons).
             warnings = await _stamp_matched_show_warnings(db, user_id, warnings)
+            warnings = await _stamp_ignored_unmatched_warnings(db, user_id, conn.id, warnings)
             await db.execute(
                 update(SyncJob)
                 .where(SyncJob.id == job_id)
@@ -4775,6 +4829,7 @@ async def _run_stremio_sync(
             conn.stremio_pull_cursor_at = pull_started_at
             conn.stremio_full_sync_done = True
             warnings = await _stamp_matched_show_warnings(db, user_id, warnings)
+            warnings = await _stamp_ignored_unmatched_warnings(db, user_id, conn.id, warnings)
             await db.execute(
                 update(SyncJob)
                 .where(SyncJob.id == job_id)
@@ -6544,7 +6599,157 @@ async def get_sync_status(
     query = select(SyncJob).where(SyncJob.user_id == current_user.id).order_by(SyncJob.created_at.desc()).limit(20)
     result = await db.execute(query)
     jobs = result.scalars().all()
-    return jobs
+
+    # Ignoring only changes the Connections warning view.  SyncJob.warnings is
+    # intentionally retained as an audit trail and to make Unignore reversible.
+    return [
+        _sync_job_response(
+            job,
+            _filter_ignored_warnings(job.warnings),
+        )
+        for job in jobs
+    ]
+
+
+@router.get("/unmatched-ignores")
+async def list_ignored_unmatched_items(
+    connection_id: int | None = None,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user_or_api_key),
+):
+    """List acknowledgements separately so users can always recover them."""
+    if connection_id is not None:
+        await _get_connection_or_404(db, connection_id, current_user.id)
+
+    query = select(SyncJob).where(
+        SyncJob.user_id == current_user.id,
+        SyncJob.status == SyncStatus.completed,
+        SyncJob.warnings.isnot(None),
+    )
+    if connection_id is not None:
+        query = query.where(SyncJob.connection_id == connection_id)
+    result = await db.execute(query.order_by(SyncJob.created_at.desc()))
+
+    # The same item may be present in many completed sync jobs. Return its
+    # newest warning snapshot once, so the recovery UI stays concise.
+    ignored_items: dict[tuple[int, str], dict] = {}
+    for job in result.scalars().all():
+        if job.connection_id is None:
+            continue
+        for warning in job.warnings or []:
+            if not (_is_ignorable_unmatched_warning(warning) and warning.get("ignored")):
+                continue
+            source_id = str(warning["source_id"])
+            key = (job.connection_id, source_id)
+            ignored_items.setdefault(key, {
+                "connection_id": job.connection_id,
+                "source_id": source_id,
+                "title": warning.get("title"),
+                "series_name": warning.get("series_name"),
+                "media_type": warning.get("media_type"),
+                "reason": warning.get("reason"),
+                "ignored_at": job.updated_at,
+            })
+    return list(ignored_items.values())
+
+
+@router.post("/unmatched-ignores")
+async def ignore_unmatched_items(
+    body: IgnoreUnmatchedItemsBody,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Acknowledge source items from this user's connection, without touching media."""
+    await _get_connection_or_404(db, body.connection_id, current_user.id)
+    source_ids = list(dict.fromkeys(source_id.strip() for source_id in body.source_ids if source_id.strip()))
+    if not source_ids:
+        raise HTTPException(status_code=422, detail="At least one source item is required")
+    if len(source_ids) > 200:
+        raise HTTPException(status_code=422, detail="At most 200 source items can be ignored at once")
+
+    # Accept IDs only when they appear in an unmatched warning for this exact
+    # user+connection.  A caller cannot invent IDs, hide a different user's
+    # warning, or turn this into a library-wide exclusion.
+    jobs_result = await db.execute(
+        select(SyncJob).where(
+            SyncJob.user_id == current_user.id,
+            SyncJob.connection_id == body.connection_id,
+            SyncJob.status == SyncStatus.completed,
+            SyncJob.warnings.isnot(None),
+        ).order_by(SyncJob.created_at.desc())
+    )
+    warnings_by_source_id: dict[str, dict] = {}
+    matching_jobs: list[SyncJob] = []
+    requested_ids = set(source_ids)
+    for job in jobs_result.scalars().all():
+        matching_jobs.append(job)
+        for warning in job.warnings or []:
+            if not _is_ignorable_unmatched_warning(warning):
+                continue
+            source_id = str(warning["source_id"])
+            if source_id in requested_ids:
+                warnings_by_source_id.setdefault(source_id, warning)
+
+    missing_ids = requested_ids - warnings_by_source_id.keys()
+    if missing_ids:
+        raise HTTPException(status_code=404, detail="Unmatched source item not found for this connection")
+
+    for job in matching_jobs:
+        updated_warnings = []
+        changed = False
+        for warning in job.warnings or []:
+            if _is_ignorable_unmatched_warning(warning) and str(warning["source_id"]) in requested_ids:
+                updated_warnings.append({**warning, "ignored": True})
+                changed = changed or not warning.get("ignored")
+            else:
+                updated_warnings.append(warning)
+        if changed:
+            job.warnings = updated_warnings
+            flag_modified(job, "warnings")
+    await db.commit()
+    return {"status": "ok", "ignored": len(source_ids)}
+
+
+@router.delete("/unmatched-ignores")
+async def unignore_unmatched_items(
+    body: IgnoreUnmatchedItemsBody,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    await _get_connection_or_404(db, body.connection_id, current_user.id)
+    source_ids = list(dict.fromkeys(source_id.strip() for source_id in body.source_ids if source_id.strip()))
+    if not source_ids:
+        raise HTTPException(status_code=422, detail="At least one source item is required")
+    requested_ids = set(source_ids)
+    result = await db.execute(
+        select(SyncJob).where(
+            SyncJob.user_id == current_user.id,
+            SyncJob.connection_id == body.connection_id,
+            SyncJob.status == SyncStatus.completed,
+            SyncJob.warnings.isnot(None),
+        )
+    )
+    jobs = result.scalars().all()
+    found_ids: set[str] = set()
+    for job in jobs:
+        updated_warnings = []
+        changed = False
+        for warning in job.warnings or []:
+            source_id = str(warning.get("source_id") or "")
+            if _is_ignorable_unmatched_warning(warning) and warning.get("ignored") and source_id in requested_ids:
+                updated = {key: value for key, value in warning.items() if key != "ignored"}
+                updated_warnings.append(updated)
+                found_ids.add(source_id)
+                changed = True
+            else:
+                updated_warnings.append(warning)
+        if changed:
+            job.warnings = updated_warnings
+            flag_modified(job, "warnings")
+    if found_ids != requested_ids:
+        raise HTTPException(status_code=404, detail="Ignored item not found")
+    await db.commit()
+    return {"status": "ok"}
 
 
 @router.post("/heal")
@@ -6794,6 +6999,46 @@ async def _stamp_matched_show_warnings(db: AsyncSession, user_id: int, warnings:
         else:
             stamped.append(w)
     return stamped
+
+
+async def _stamp_ignored_unmatched_warnings(
+    db: AsyncSession,
+    user_id: int,
+    connection_id: int | None,
+    warnings: list[dict],
+) -> list[dict]:
+    """Carry per-source acknowledgements into a newly generated sync result.
+
+    The acknowledgement is deliberately stored on existing SyncJob warning JSON
+    rather than a new table. This keeps it auditable and reversible while
+    avoiding a schema migration for a single UI state. Sync jobs are never
+    pruned here; old completed warnings provide the durable source-ID record.
+    """
+    if connection_id is None or not warnings:
+        return warnings
+    previous_result = await db.execute(
+        select(SyncJob.warnings).where(
+            SyncJob.user_id == user_id,
+            SyncJob.connection_id == connection_id,
+            SyncJob.status == SyncStatus.completed,
+            SyncJob.warnings.isnot(None),
+        )
+    )
+    ignored_source_ids = {
+        str(warning["source_id"])
+        for (job_warnings,) in previous_result.all()
+        for warning in (job_warnings or [])
+        if _is_ignorable_unmatched_warning(warning) and warning.get("ignored")
+    }
+    if not ignored_source_ids:
+        return warnings
+    return [
+        {**warning, "ignored": True}
+        if _is_ignorable_unmatched_warning(warning)
+        and str(warning["source_id"]) in ignored_source_ids
+        else warning
+        for warning in warnings
+    ]
 
 
 # ── Season override endpoints ─────────────────────────────────────────────────

--- a/backend/tests/test_sync.py
+++ b/backend/tests/test_sync.py
@@ -8,8 +8,10 @@ os.environ.setdefault("SECRET_KEY", "test-secret")
 os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://test:test@localhost/test")
 
 from fastapi import HTTPException
+from fastapi import FastAPI
 
 from models.connections import MediaServerConnection
+from models.base import CollectionSource
 from routers import sync
 
 
@@ -84,6 +86,181 @@ class PushUpstreamValidationTests(unittest.IsolatedAsyncioTestCase):
         )
         self.assertEqual(response["status"], "started")
 
+
+class _RowsResult:
+    def __init__(self, rows):
+        self.rows = rows
+
+    def scalars(self):
+        return self
+
+    def all(self):
+        return self.rows
+
+
+class _IgnoredItemDB:
+    """Small ordered-result double for the acknowledgement API routes."""
+
+    def __init__(self, results):
+        self.results = list(results)
+        self.statements = []
+        self.commit = AsyncMock()
+
+    async def execute(self, statement):
+        self.statements.append(statement)
+        return self.results.pop(0) if self.results else _RowsResult([])
+
+
+class IgnoreUnmatchedItemsTests(unittest.IsolatedAsyncioTestCase):
+    _warning = {
+        "title": "Family Vacation 2024",
+        "media_type": "movie",
+        "source_id": "jellyfin-home-video-1",
+        "reason": "Unmatched on source — no TMDB ID available",
+    }
+
+    @classmethod
+    def _job(cls, warnings):
+        return sync.SyncJob(
+            user_id=1,
+            source=CollectionSource.jellyfin,
+            status=sync.SyncStatus.completed,
+            connection_id=9,
+            job_type="pull",
+            warnings=warnings,
+        )
+
+    def test_only_normal_unmatched_source_warnings_are_hidden(self):
+        warnings = [
+            self._warning,
+            {"tmdb_id": 1, "season": 2, "show": "Needs remap"},
+            {**self._warning, "source_id": "matched-item", "matched": True},
+        ]
+
+        warnings[0] = {**warnings[0], "ignored": True}
+        visible = sync._filter_ignored_warnings(warnings)
+
+        self.assertEqual(visible, [warnings[1], warnings[2]])
+        self.assertEqual(warnings[0]["source_id"], "jellyfin-home-video-1")  # no persisted JSON mutation
+
+    def test_only_source_backed_unmatched_warnings_can_be_ignored(self):
+        self.assertTrue(sync._is_ignorable_unmatched_warning(self._warning))
+        self.assertFalse(sync._is_ignorable_unmatched_warning({"tmdb_id": 1, "season": 2}))
+        self.assertFalse(sync._is_ignorable_unmatched_warning({**self._warning, "matched": True}))
+
+    async def test_ignore_accepts_only_a_warning_from_the_owned_connection(self):
+        connection = SimpleNamespace(id=9, user_id=1, type="jellyfin")
+        job = self._job([self._warning])
+        db = _IgnoredItemDB([
+            _Result(connection),  # _get_connection_or_404
+            _RowsResult([job]),   # completed warnings for that exact connection
+        ])
+
+        response = await sync.ignore_unmatched_items(
+            sync.IgnoreUnmatchedItemsBody(connection_id=9, source_ids=["jellyfin-home-video-1"]),
+            db=db,
+            current_user=SimpleNamespace(id=1),
+        )
+
+        self.assertEqual(response, {"status": "ok", "ignored": 1})
+        self.assertEqual(db.commit.await_count, 1)
+        self.assertTrue(job.warnings[0]["ignored"])
+        self.assertEqual(job.warnings[0]["source_id"], "jellyfin-home-video-1")
+        validation_sql = str(db.statements[1])
+        self.assertIn("sync_jobs.connection_id", validation_sql)
+        self.assertIn("sync_jobs.user_id", validation_sql)
+
+    async def test_ignore_rejects_source_ids_not_in_that_connections_warning_history(self):
+        connection = SimpleNamespace(id=9, user_id=1, type="jellyfin")
+        db = _IgnoredItemDB([
+            _Result(connection),
+            _RowsResult([self._job([self._warning])]),
+        ])
+
+        with self.assertRaises(HTTPException) as ctx:
+            await sync.ignore_unmatched_items(
+                sync.IgnoreUnmatchedItemsBody(connection_id=9, source_ids=["another-connection-item"]),
+                db=db,
+                current_user=SimpleNamespace(id=1),
+            )
+
+        self.assertEqual(ctx.exception.status_code, 404)
+        db.commit.assert_not_awaited()
+
+    async def test_unignore_deletes_only_the_current_users_acknowledgement(self):
+        connection = SimpleNamespace(id=9, user_id=1, type="jellyfin")
+        older_job = self._job([{**self._warning, "ignored": True}])
+        newer_job = self._job([{**self._warning, "ignored": True}])
+        db = _IgnoredItemDB([_Result(connection), _RowsResult([older_job, newer_job])])
+        response = await sync.unignore_unmatched_items(
+            sync.IgnoreUnmatchedItemsBody(connection_id=9, source_ids=["jellyfin-home-video-1"]),
+            db=db,
+            current_user=SimpleNamespace(id=1),
+        )
+
+        self.assertEqual(response, {"status": "ok"})
+        self.assertEqual(db.commit.await_count, 1)
+        self.assertNotIn("ignored", older_job.warnings[0])
+        self.assertNotIn("ignored", newer_job.warnings[0])
+
+    async def test_status_hides_an_ignored_item_without_overwriting_job_warnings(self):
+        job = sync.SyncJob(
+            id=1,
+            user_id=1,
+            source=CollectionSource.jellyfin,
+            status=sync.SyncStatus.completed,
+            connection_id=9,
+            job_type="pull",
+            warnings=[{**self._warning, "ignored": True}],
+        )
+        db = _IgnoredItemDB([
+            _RowsResult([job]),
+        ])
+
+        response = await sync.get_sync_status(db=db, current_user=SimpleNamespace(id=1))
+
+        self.assertIsNone(response[0]["warnings"])
+        self.assertEqual(job.warnings, [{**self._warning, "ignored": True}])
+
+    async def test_later_sync_reuses_the_same_connections_ignored_source_ids(self):
+        historical = [{**self._warning, "ignored": True}]
+        incoming = [{**self._warning}, {"title": "Different", "source_id": "other", "reason": "Unmatched on source — no TMDB ID available"}]
+        db = _IgnoredItemDB([_RowsResult([(historical,)])])
+
+        stamped = await sync._stamp_ignored_unmatched_warnings(
+            db, user_id=1, connection_id=9, warnings=incoming
+        )
+
+        self.assertTrue(stamped[0]["ignored"])
+        self.assertNotIn("ignored", stamped[1])
+        self.assertNotIn("ignored", incoming[0])
+        self.assertIn("sync_jobs.connection_id", str(db.statements[0]))
+
+    async def test_ignored_view_deduplicates_source_items_across_sync_history(self):
+        older = self._job([{**self._warning, "ignored": True}])
+        newer = self._job([{**self._warning, "ignored": True}])
+        db = _IgnoredItemDB([_RowsResult([newer, older])])
+
+        response = await sync.list_ignored_unmatched_items(
+            connection_id=None, db=db, current_user=SimpleNamespace(id=1)
+        )
+
+        self.assertEqual(len(response), 1)
+        self.assertEqual(response[0]["connection_id"], 9)
+        self.assertEqual(response[0]["source_id"], "jellyfin-home-video-1")
+
+
+class IgnoreUnmatchedItemsApiContractTests(unittest.TestCase):
+    def test_reversible_ignore_endpoints_are_exposed_with_a_body(self):
+        app = FastAPI()
+        app.include_router(sync.router, prefix="/sync")
+        openapi = app.openapi()
+
+        self.assertIn("get", openapi["paths"]["/sync/unmatched-ignores"])
+        self.assertIn("post", openapi["paths"]["/sync/unmatched-ignores"])
+        self.assertIn("requestBody", openapi["paths"]["/sync/unmatched-ignores"]["post"])
+        self.assertIn("delete", openapi["paths"]["/sync/unmatched-ignores"])
+        self.assertIn("requestBody", openapi["paths"]["/sync/unmatched-ignores"]["delete"])
 
 class PlexSyncNeedsLibraryScanTests(unittest.TestCase):
     """Regression test: a Plex pull with only "Watchlist" selected still

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",
+    "test": "node --test test/*.test.mjs",
     "preview": "astro preview",
     "astro": "astro"
   },

--- a/frontend/src/pages/connections.astro
+++ b/frontend/src/pages/connections.astro
@@ -4972,15 +4972,25 @@ const sonarrConfigured   = !!(settings.sonarr_url && settings.sonarr_token);
         if (!el.classList.contains('hidden')) expandedDetails.add(el.id);
       });
 
-      const [statusRes, overridesRes, matchedRes] = await Promise.all([
+      const [statusRes, overridesRes, matchedRes, ignoredRes] = await Promise.all([
         fetch('/api/proxy/sync/status', { headers: { 'Authorization': `Bearer ${token}` } }),
         fetch('/api/proxy/sync/season-overrides', { headers: { 'Authorization': `Bearer ${token}` } }),
         fetch('/api/proxy/sync/matched-shows', { headers: { 'Authorization': `Bearer ${token}` } }),
+        fetch('/api/proxy/sync/unmatched-ignores', { headers: { 'Authorization': `Bearer ${token}` } }),
       ]);
       if (!statusRes.ok) return;
       const jobs: any[] = await statusRes.json();
       const overrides: any[] = overridesRes.ok ? await overridesRes.json() : [];
       const matchedShows: any[] = matchedRes.ok ? await matchedRes.json() : [];
+      const ignoredItems: any[] = ignoredRes.ok ? await ignoredRes.json() : [];
+
+      const ignoredByConnection = new Map<string, any[]>();
+      for (const item of ignoredItems) {
+        const key = String(item.connection_id);
+        const items = ignoredByConnection.get(key) ?? [];
+        items.push(item);
+        ignoredByConnection.set(key, items);
+      }
 
       // Build a lookup: lowercase show_title → matched show info
       // Used to overlay matched state onto SyncJob warnings that lack matched:true stamps
@@ -4998,11 +5008,17 @@ const sonarrConfigured   = !!(settings.sonarr_url && settings.sonarr_token);
       const containers = document.querySelectorAll<HTMLElement>('[id^="conn-warnings-"]');
       containers.forEach(container => {
         const connId = container.id.replace('conn-warnings-', '');
-        const job = jobs.find(j => String(j.connection_id) === connId && j.status === 'completed' && j.warnings?.length > 0);
-        if (!job) { container.classList.add('hidden'); container.innerHTML = ''; return; }
+        // Only the latest completed run describes this connection's current
+        // warning state.  Do not fall back to an older warning after the
+        // latest one was fully acknowledged or fixed.
+        const latestCompletedJob = jobs.find(j => String(j.connection_id) === connId && j.status === 'completed');
+        const job = latestCompletedJob?.warnings?.length ? latestCompletedJob : undefined;
+        const ignoredForConnection = ignoredByConnection.get(connId) ?? [];
+        if (!job && !ignoredForConnection.length) { container.classList.add('hidden'); container.innerHTML = ''; return; }
 
-        const warnings: any[] = job.warnings;
-        const _updatedAt = job.updated_at.endsWith('Z') || job.updated_at.includes('+') ? job.updated_at : job.updated_at + 'Z';
+        const warnings: any[] = job?.warnings ?? [];
+        const rawUpdatedAt = job?.updated_at ?? new Date().toISOString();
+        const _updatedAt = rawUpdatedAt.endsWith('Z') || rawUpdatedAt.includes('+') ? rawUpdatedAt : `${rawUpdatedAt}Z`;
         const date = new Date(_updatedAt).toLocaleString(undefined, { dateStyle: 'short', timeStyle: 'short' });
         const detailsId = `conn-warnings-details-${connId}`;
 
@@ -5036,7 +5052,7 @@ const sonarrConfigured   = !!(settings.sonarr_url && settings.sonarr_token);
         // Series-level warnings for the same show are merged in (to carry their GUIDs) rather
         // than rendered as a separate row. Matched state is read directly from warning entries,
         // with a fallback to matchedShowMap for warnings created before auto-stamping existed.
-        type GroupEntry = {count: number, reason: string, plex_guids: string[], matched: boolean, matched_tvdb_id?: number, matched_show_id?: number, matched_show_title?: string};
+        type GroupEntry = {count: number, reason: string, plex_guids: string[], sourceIds: string[], matched: boolean, matched_tvdb_id?: number, matched_show_id?: number, matched_show_title?: string};
         const groupedEpisodeWarnings: Map<string, GroupEntry> = new Map();
         const standaloneUnmatched: any[] = [];
         for (const w of unmatchedWarnings) {
@@ -5047,6 +5063,7 @@ const sonarrConfigured   = !!(settings.sonarr_url && settings.sonarr_token);
             const existing = groupedEpisodeWarnings.get(w.series_name);
             if (existing) {
               existing.count++;
+              if (w.source_id) existing.sourceIds.push(String(w.source_id));
               if (isMatched) {
                 existing.matched = true;
                 // Prefer tvdb_id: DB > stamp (stamps from old `already_linked` runs may have null tvdb_id)
@@ -5059,6 +5076,7 @@ const sonarrConfigured   = !!(settings.sonarr_url && settings.sonarr_token);
                 count: 1,
                 reason: w.reason ?? 'unknown reason',
                 plex_guids: w.plex_guids ?? [],
+                sourceIds: w.source_id ? [String(w.source_id)] : [],
                 matched: isMatched,
                 matched_tvdb_id: dbMatch?.tvdb_id ?? w.matched_tvdb_id,
                 matched_show_id: dbMatch?.show_id ?? w.matched_show_id,
@@ -5079,6 +5097,7 @@ const sonarrConfigured   = !!(settings.sonarr_url && settings.sonarr_token);
             if (w.plex_guids?.length && !grouped.plex_guids.length) {
               grouped.plex_guids = w.plex_guids;
             }
+            if (w.source_id) grouped.sourceIds.push(String(w.source_id));
             return false; // suppress — already shown in grouped section
           }
           // Apply matchedShowMap overlay for series-type standalone warnings
@@ -5099,7 +5118,7 @@ const sonarrConfigured   = !!(settings.sonarr_url && settings.sonarr_token);
         const renderUnmatched = hasUnmatched ? `
           <div class="space-y-1 ${enrichmentWarnings.length > 0 ? 'mt-4 pt-4 border-t border-zinc-800/60' : ''}">
             <p class="text-xs text-zinc-500 mb-2">Items that couldn't be matched to TMDB:</p>
-            ${[...groupedEpisodeWarnings.entries()].map(([seriesName, {count, reason, plex_guids, matched, matched_tvdb_id, matched_show_id, matched_show_title}]) => {
+            ${[...groupedEpisodeWarnings.entries()].map(([seriesName, {count, reason, plex_guids, sourceIds, matched, matched_tvdb_id, matched_show_id, matched_show_title}]) => {
               const isMatched = matched;
               const matchedTitle = matched_show_title ?? '';
               const matchHref = matched_tvdb_id ? `/show/tvdb/${matched_tvdb_id}` : (matched_show_id ? `/show/${matched_show_id}` : '');
@@ -5122,6 +5141,8 @@ const sonarrConfigured   = !!(settings.sonarr_url && settings.sonarr_token);
                     : `<button type="button" class="match-show-btn text-xs px-2.5 py-1 rounded-lg border bg-amber-500/15 border-amber-500/40 text-amber-500 hover:bg-amber-500/25 hover:border-amber-500/60 cursor-pointer transition-colors"
                         data-series-name="${escapeHtml(seriesName)}">Match</button>`
                   }
+                  ${!isMatched && sourceIds.length ? `<button type="button" class="ignore-unmatched-btn text-xs px-2.5 py-1 rounded-lg border border-zinc-700 text-zinc-400 hover:bg-zinc-800 cursor-pointer transition-colors"
+                    data-source-ids="${escapeHtml(JSON.stringify([...new Set(sourceIds)]))}">Ignore</button>` : ''}
                 </div>
               </div>`;
             }).join('')}
@@ -5150,14 +5171,32 @@ const sonarrConfigured   = !!(settings.sonarr_url && settings.sonarr_token);
                     : `<button type="button" class="match-show-btn text-xs px-2.5 py-1 rounded-lg border bg-amber-500/15 border-amber-500/40 text-amber-500 hover:bg-amber-500/25 hover:border-amber-500/60 cursor-pointer transition-colors shrink-0"
                         data-series-name="${escapeHtml(w.title)}" data-media-type="${escapeHtml(w.media_type ?? '')}">Match</button>`
                   }
+                  ${!wMatched && w.source_id ? `<button type="button" class="ignore-unmatched-btn text-xs px-2.5 py-1 rounded-lg border border-zinc-700 text-zinc-400 hover:bg-zinc-800 cursor-pointer transition-colors shrink-0"
+                    data-source-ids="${escapeHtml(JSON.stringify([String(w.source_id)]))}">Ignore</button>` : ''}
                 </div>
               </div>`;
             }).join('')}
           </div>
         ` : '';
 
+        const renderIgnored = ignoredForConnection.length ? `
+          <div class="space-y-1 ${displayCount > 0 ? 'mt-4 pt-4 border-t border-zinc-800/60' : ''}">
+            <p class="text-xs text-zinc-500 mb-2">Ignored unmatched items — kept out of sync warnings, never removed from your media server:</p>
+            ${ignoredForConnection.map((item: any) => `
+              <div class="flex items-center gap-3 py-1.5 border-b border-zinc-800/60 last:border-0">
+                <div class="flex-1 min-w-0">
+                  <span class="text-sm text-zinc-300 font-medium">${escapeHtml(item.series_name || item.title || 'Untitled item')}</span>
+                  ${item.series_name && item.title && item.series_name !== item.title ? `<span class="ml-2 text-xs text-zinc-600">${escapeHtml(item.title)}</span>` : ''}
+                  ${item.media_type ? `<span class="ml-2 text-xs text-zinc-600">${escapeHtml(item.media_type)}</span>` : ''}
+                </div>
+                <button type="button" class="unignore-unmatched-btn text-xs px-2.5 py-1 rounded-lg border border-zinc-700 text-zinc-300 hover:bg-zinc-800 cursor-pointer transition-colors shrink-0"
+                  data-source-id="${escapeHtml(String(item.source_id))}">Unignore</button>
+              </div>`).join('')}
+          </div>
+        ` : '';
+
         container.classList.remove('hidden');
-        container.innerHTML = `
+        container.innerHTML = job ? `
           <div class="rounded-xl border border-amber-500/20 bg-amber-500/5 overflow-hidden">
             <button
               type="button"
@@ -5176,7 +5215,12 @@ const sonarrConfigured   = !!(settings.sonarr_url && settings.sonarr_token);
             <div id="${detailsId}" class="hidden border-t border-amber-500/15 px-4 py-3">
               ${renderEnrichment}
               ${renderUnmatched}
+              ${renderIgnored}
             </div>
+          </div>
+        ` : `
+          <div class="rounded-xl border border-zinc-700/60 bg-zinc-900/40 px-4 py-3">
+            ${renderIgnored}
           </div>
         `;
 
@@ -5230,6 +5274,57 @@ const sonarrConfigured   = !!(settings.sonarr_url && settings.sonarr_token);
               el.disabled = false;
               el.textContent = 'Unmatch';
               alert(`Failed to unmatch: ${e.message ?? 'Unknown error'}`);
+            }
+          });
+        });
+
+        container.querySelectorAll('.ignore-unmatched-btn').forEach((btn) => {
+          btn.addEventListener('click', async () => {
+            const el = btn as HTMLButtonElement;
+            let sourceIds: string[];
+            try {
+              sourceIds = JSON.parse(el.dataset.sourceIds ?? '[]');
+            } catch {
+              return;
+            }
+            if (!sourceIds.length || !confirm('Ignore these unmatched item(s)? They will remain in your media server and can be restored here later.')) return;
+            el.disabled = true;
+            el.textContent = 'Ignoring…';
+            try {
+              const res = await fetch('/api/proxy/sync/unmatched-ignores', {
+                method: 'POST',
+                headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' },
+                body: JSON.stringify({ connection_id: Number(connId), source_ids: sourceIds }),
+              });
+              if (!res.ok) throw new Error(await res.text());
+              loadSyncWarnings();
+            } catch (e: any) {
+              el.disabled = false;
+              el.textContent = 'Ignore';
+              alert(`Failed to ignore item: ${e.message ?? 'Unknown error'}`);
+            }
+          });
+        });
+
+        container.querySelectorAll('.unignore-unmatched-btn').forEach((btn) => {
+          btn.addEventListener('click', async () => {
+            const el = btn as HTMLButtonElement;
+            const sourceId = el.dataset.sourceId;
+            if (!sourceId) return;
+            el.disabled = true;
+            el.textContent = 'Restoring…';
+            try {
+              const res = await fetch('/api/proxy/sync/unmatched-ignores', {
+                method: 'DELETE',
+                headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' },
+                body: JSON.stringify({ connection_id: Number(connId), source_ids: [sourceId] }),
+              });
+              if (!res.ok) throw new Error(await res.text());
+              loadSyncWarnings();
+            } catch (e: any) {
+              el.disabled = false;
+              el.textContent = 'Unignore';
+              alert(`Failed to restore item: ${e.message ?? 'Unknown error'}`);
             }
           });
         });

--- a/frontend/test/unmatched-ignore.test.mjs
+++ b/frontend/test/unmatched-ignore.test.mjs
@@ -1,0 +1,18 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+const page = await readFile(new URL('../src/pages/connections.astro', import.meta.url), 'utf8');
+
+test('Connections warnings expose reversible per-item ignore controls', () => {
+  assert.match(page, /\/api\/proxy\/sync\/unmatched-ignores/);
+  assert.match(page, /class="ignore-unmatched-btn/);
+  assert.match(page, /data-source-ids=/);
+  assert.match(page, /class="unignore-unmatched-btn/);
+  assert.match(page, /Ignored unmatched items/);
+});
+
+test('Connections uses the latest sync result instead of resurrecting old ignored warnings', () => {
+  assert.match(page, /const latestCompletedJob = jobs\.find/);
+  assert.match(page, /const job = latestCompletedJob\?\.warnings\?\.length \? latestCompletedJob : undefined/);
+});


### PR DESCRIPTION
## Summary

- add reversible per-item Ignore controls for source-backed unmatched warnings
- scope acknowledgements to the current user, owned connection, and source ID
- hide acknowledged items from active warning counts while retaining a deduplicated Ignored items recovery view
- carry ignore state into later Jellyfin, Emby, Plex, Nuvio, and Stremio sync results
- persist state in existing SyncJob warning JSON, avoiding a new migration and preserving the warning audit trail

Ignoring never deletes or changes media on the source server; these items remain recoverable through Unignore.

Closes #252

## Verification

- uv run python -m unittest tests.test_sync (62 tests passed)
- npm test (2 tests passed)
- npm run build
- alembic heads (single upstream head)
- Python compileall
- git diff --check