### PR TITLE
feat(media): add compact browse view

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
     "dev": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
+    "test": "node --test test/*.test.mjs",
     "astro": "astro"
   },
   "dependencies": {

--- a/frontend/src/components/MediaCard.astro
+++ b/frontend/src/components/MediaCard.astro
@@ -127,14 +127,16 @@ const inLibrary = item.in_library ?? false;
 
   <!-- Action bar (below poster, above info) -->
   {showActionBar && (
-    <CardActionBar
-      watched={watched}
-      inLists={inLists}
-      inLibrary={inLibrary}
-      collectionPct={collectionPct}
-      watchPct={watchPct}
-      isSeries={isPercentageStyle}
-    />
+    <div data-card-actions>
+      <CardActionBar
+        watched={watched}
+        inLists={inLists}
+        inLibrary={inLibrary}
+        collectionPct={collectionPct}
+        watchPct={watchPct}
+        isSeries={isPercentageStyle}
+      />
+    </div>
   )}
 
   <slot />
@@ -177,4 +179,3 @@ const inLibrary = item.in_library ?? false;
     </div>
   )}
 </div>
-

--- a/frontend/src/components/MediaViewToggle.astro
+++ b/frontend/src/components/MediaViewToggle.astro
@@ -1,0 +1,139 @@
+---
+interface Props {
+  targetId: string;
+}
+
+const { targetId } = Astro.props;
+---
+
+<div class="inline-flex items-center gap-1 rounded-lg border border-zinc-800 bg-zinc-900 p-1" data-media-view-toggle data-target-id={targetId} role="group" aria-label="Media layout">
+  <button
+    type="button"
+    class="rounded-md p-1.5 text-zinc-300 transition hover:bg-zinc-800 hover:text-white focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+    data-view="grid"
+    aria-label="Use grid view"
+    aria-pressed="true"
+  >
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.8" stroke="currentColor" class="h-4 w-4" aria-hidden="true">
+      <rect x="3" y="3" width="7" height="7" rx="1" /><rect x="14" y="3" width="7" height="7" rx="1" /><rect x="3" y="14" width="7" height="7" rx="1" /><rect x="14" y="14" width="7" height="7" rx="1" />
+    </svg>
+  </button>
+  <button
+    type="button"
+    class="rounded-md p-1.5 text-zinc-400 transition hover:bg-zinc-800 hover:text-white focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+    data-view="list"
+    aria-label="Use compact list view"
+    aria-pressed="false"
+  >
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.8" stroke="currentColor" class="h-4 w-4" aria-hidden="true">
+      <path stroke-linecap="round" d="M9 6h11M9 12h11M9 18h11" /><path fill="currentColor" stroke="none" d="M4 5h2v2H4zM4 11h2v2H4zM4 17h2v2H4z" />
+    </svg>
+  </button>
+</div>
+
+<script>
+  const STORAGE_KEY = "scrob-media-view";
+  type MediaView = "grid" | "list";
+
+  function storedView(): MediaView {
+    try {
+      return localStorage.getItem(STORAGE_KEY) === "list" ? "list" : "grid";
+    } catch {
+      return "grid";
+    }
+  }
+
+  function initMediaViewToggle(toggle: HTMLElement) {
+    if (toggle.dataset.initialized) return;
+    toggle.dataset.initialized = "true";
+
+    const targetId = toggle.dataset.targetId;
+    const target = targetId ? document.getElementById(targetId) : null;
+    if (!target) return;
+
+    const buttons = Array.from(toggle.querySelectorAll<HTMLButtonElement>("[data-view]"));
+    const applyView = (view: MediaView, persist = false) => {
+      target.dataset.mediaView = view;
+      buttons.forEach((button) => {
+        const selected = button.dataset.view === view;
+        button.setAttribute("aria-pressed", String(selected));
+        button.classList.toggle("bg-zinc-700", selected);
+        button.classList.toggle("text-white", selected);
+        button.classList.toggle("text-zinc-400", !selected);
+      });
+      if (persist) {
+        try {
+          localStorage.setItem(STORAGE_KEY, view);
+        } catch {
+          // Storage can be disabled; the selected layout remains usable for this page.
+        }
+      }
+    };
+
+    applyView(storedView());
+    buttons.forEach((button) => button.addEventListener("click", () => {
+      applyView(button.dataset.view === "list" ? "list" : "grid", true);
+    }));
+  }
+
+  document.querySelectorAll<HTMLElement>("[data-media-view-toggle]").forEach(initMediaViewToggle);
+</script>
+
+<style>
+  :global([data-media-view-container][data-media-view="list"]) {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  :global([data-media-view-container][data-media-view="list"] > [data-card]) {
+    min-height: 5.75rem;
+    flex-direction: row;
+    align-items: stretch;
+    border-radius: 0.75rem;
+    transform: none;
+  }
+
+  :global([data-media-view-container][data-media-view="list"] > [data-card]:hover) {
+    transform: none;
+  }
+
+  :global([data-media-view-container][data-media-view="list"] > [data-card] > a:first-child),
+  :global([data-media-view-container][data-media-view="list"] > [data-card] > div:first-child) {
+    width: 4rem;
+    flex: 0 0 4rem;
+  }
+
+  :global([data-media-view-container][data-media-view="list"] > [data-card] > a:first-child > div),
+  :global([data-media-view-container][data-media-view="list"] > [data-card] > div:first-child > div) {
+    height: 100%;
+    min-height: 5.75rem;
+    aspect-ratio: 2 / 3;
+  }
+
+  :global([data-media-view-container][data-media-view="list"] > [data-card] > [data-card-actions]) {
+    width: 8.25rem;
+    flex: 0 0 auto;
+    align-self: stretch;
+  }
+
+  :global([data-media-view-container][data-media-view="list"] > [data-card] > [data-card-actions] > div) {
+    height: 100%;
+  }
+
+  :global([data-media-view-container][data-media-view="list"] > [data-card] > a:last-child),
+  :global([data-media-view-container][data-media-view="list"] > [data-card] > div:last-child) {
+    display: flex;
+    min-width: 0;
+    align-items: center;
+    padding: 0.65rem 0.8rem;
+  }
+
+  @media (max-width: 420px) {
+    :global([data-media-view-container][data-media-view="list"] > [data-card] > a:first-child),
+    :global([data-media-view-container][data-media-view="list"] > [data-card] > div:first-child) {
+      width: 3.25rem;
+      flex-basis: 3.25rem;
+    }
+  }
+</style>

--- a/frontend/src/pages/collection/movies.astro
+++ b/frontend/src/pages/collection/movies.astro
@@ -4,6 +4,7 @@ import MediaCard from "../../components/MediaCard.astro";
 import Pagination from "../../components/Pagination.astro";
 import FilterPanel from "../../components/FilterPanel.astro";
 import SortButton from "../../components/SortButton.astro";
+import MediaViewToggle from "../../components/MediaViewToggle.astro";
 import { api } from "../../lib/api";
 export const prerender = false;
 
@@ -53,7 +54,7 @@ const baseUrl = `/collection/movies?${baseParams.toString()}`;
     </div>
 
     <!-- Sort & filter controls -->
-    <div class="flex items-center gap-3">
+    <div class="flex flex-wrap items-center gap-3">
       <SortButton
         id="movie-sort"
         current={sort}
@@ -75,6 +76,7 @@ const baseUrl = `/collection/movies?${baseParams.toString()}`;
           { key: "watched", label: "Watched", options: [{ value: "watched", label: "Watched" }, { value: "unwatched", label: "Unwatched" }], selected: watched },
         ]}
       />
+      <MediaViewToggle targetId="collection-movie-results" />
     </div>
   </div>
 
@@ -91,7 +93,7 @@ const baseUrl = `/collection/movies?${baseParams.toString()}`;
     </div>
   ) : (
     <>
-      <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-6">
+      <div id="collection-movie-results" data-media-view-container data-media-view="grid" class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-6">
         {data.results.map(item => <MediaCard item={{...item, in_library: true}} />)}
       </div>
 

--- a/frontend/src/pages/collection/shows.astro
+++ b/frontend/src/pages/collection/shows.astro
@@ -4,6 +4,7 @@ import MediaCard from "../../components/MediaCard.astro";
 import Pagination from "../../components/Pagination.astro";
 import FilterPanel from "../../components/FilterPanel.astro";
 import SortButton from "../../components/SortButton.astro";
+import MediaViewToggle from "../../components/MediaViewToggle.astro";
 import { api } from "../../lib/api";
 export const prerender = false;
 
@@ -57,7 +58,7 @@ const baseUrl = `/collection/shows?${baseParams.toString()}`;
     </div>
 
     <!-- Sort & filter controls -->
-    <div class="flex items-center gap-3">
+    <div class="flex flex-wrap items-center gap-3">
       <SortButton
         id="show-sort"
         current={sort}
@@ -80,6 +81,7 @@ const baseUrl = `/collection/shows?${baseParams.toString()}`;
           { key: "watched", label: "Progress", options: [{ value: "watched", label: "Started" }, { value: "unwatched", label: "Not Started" }], selected: watched },
         ]}
       />
+      <MediaViewToggle targetId="collection-show-results" />
     </div>
   </div>
 
@@ -96,7 +98,7 @@ const baseUrl = `/collection/shows?${baseParams.toString()}`;
     </div>
   ) : (
     <>
-      <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-6">
+      <div id="collection-show-results" data-media-view-container data-media-view="grid" class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-6">
         {data.results.map(item => <MediaCard item={{...item, type: 'series', in_library: true}} />)}
       </div>
 

--- a/frontend/src/pages/movies.astro
+++ b/frontend/src/pages/movies.astro
@@ -4,6 +4,7 @@ import MediaCard from "../components/MediaCard.astro";
 import Pagination from "../components/Pagination.astro";
 import FilterPanel from "../components/FilterPanel.astro";
 import SortButton from "../components/SortButton.astro";
+import MediaViewToggle from "../components/MediaViewToggle.astro";
 import { api, type MediaItem } from "../lib/api";
 export const prerender = false;
 
@@ -96,7 +97,7 @@ const baseUrl = `/movies?${baseParams.toString()}`;
     <h1 class="page-title">Explore Movies</h1>
 
     {hasTmdbKey && (
-      <div class="flex items-center gap-3">
+      <div class="flex flex-wrap items-center gap-3">
         <SortButton
           id="explore-movie-category"
           current={category}
@@ -128,6 +129,7 @@ const baseUrl = `/movies?${baseParams.toString()}`;
             { key: "lang", label: "Language", options: LANGUAGES, selected: langs },
           ]}
         />
+        <MediaViewToggle targetId="movie-results" />
       </div>
     )}
   </div>
@@ -143,7 +145,7 @@ const baseUrl = `/movies?${baseParams.toString()}`;
     </div>
   ) : (
     <>
-      <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-6">
+      <div id="movie-results" data-media-view-container data-media-view="grid" class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-6">
         {data.results.map(item => <MediaCard item={item} />)}
       </div>
 

--- a/frontend/src/pages/shows.astro
+++ b/frontend/src/pages/shows.astro
@@ -4,6 +4,7 @@ import MediaCard from "../components/MediaCard.astro";
 import Pagination from "../components/Pagination.astro";
 import FilterPanel from "../components/FilterPanel.astro";
 import SortButton from "../components/SortButton.astro";
+import MediaViewToggle from "../components/MediaViewToggle.astro";
 import { api, type MediaItem } from "../lib/api";
 export const prerender = false;
 
@@ -101,7 +102,7 @@ const baseUrl = `/shows?${baseParams.toString()}`;
     <h1 class="page-title">Explore Shows</h1>
 
     {hasTmdbKey && (
-      <div class="flex items-center gap-3">
+      <div class="flex flex-wrap items-center gap-3">
         <SortButton
           id="explore-show-category"
           current={category}
@@ -134,6 +135,7 @@ const baseUrl = `/shows?${baseParams.toString()}`;
             { key: "lang", label: "Language", options: LANGUAGES, selected: langs },
           ]}
         />
+        <MediaViewToggle targetId="show-results" />
       </div>
     )}
   </div>
@@ -149,7 +151,7 @@ const baseUrl = `/shows?${baseParams.toString()}`;
     </div>
   ) : (
     <>
-      <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-6">
+      <div id="show-results" data-media-view-container data-media-view="grid" class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-6">
         {data.results.map(item => <MediaCard item={item} />)}
       </div>
 

--- a/frontend/test/media-view-toggle.test.mjs
+++ b/frontend/test/media-view-toggle.test.mjs
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const component = await readFile(new URL("../src/components/MediaViewToggle.astro", import.meta.url), "utf8");
+const mediaCard = await readFile(new URL("../src/components/MediaCard.astro", import.meta.url), "utf8");
+
+test("compact media view is accessible, persistent, and defaults to grid", () => {
+  assert.match(component, /aria-label="Use grid view"/);
+  assert.match(component, /aria-label="Use compact list view"/);
+  assert.match(component, /aria-pressed="true"/);
+  assert.match(component, /const STORAGE_KEY = "scrob-media-view"/);
+  assert.match(component, /localStorage\.getItem\(STORAGE_KEY\) === "list" \? "list" : "grid"/);
+  assert.match(component, /localStorage\.setItem\(STORAGE_KEY, view\)/);
+  assert.match(component, /target\.dataset\.mediaView = view/);
+});
+
+test("compact mode reflows existing cards instead of dropping card actions", () => {
+  assert.match(component, /\[data-media-view-container\]\[data-media-view="list"\]/);
+  assert.match(component, /\[data-card-actions\]/);
+  assert.match(mediaCard, /<div data-card-actions>/);
+  assert.match(mediaCard, /<CardActionBar/);
+});
+
+test("all Movies and Shows browse surfaces use the shared control and target", async () => {
+  const pages = [
+    ["../src/pages/movies.astro", "movie-results"],
+    ["../src/pages/shows.astro", "show-results"],
+    ["../src/pages/collection/movies.astro", "collection-movie-results"],
+    ["../src/pages/collection/shows.astro", "collection-show-results"],
+  ];
+
+  for (const [file, targetId] of pages) {
+    const source = await readFile(new URL(file, import.meta.url), "utf8");
+    assert.match(source, /import MediaViewToggle/);
+    assert.match(source, new RegExp(`<MediaViewToggle targetId="${targetId}"`));
+    assert.match(source, new RegExp(`id="${targetId}" data-media-view-container data-media-view="grid"`));
+  }
+});


### PR DESCRIPTION
## Summary

- add an accessible Grid/List toggle to Movies and Shows Explore and Collection pages
- preserve Grid as the default and persist the selected layout per browser
- reflow existing cards into denser rows without dropping actions, badges, links, filters, or pagination
- keep the controls and compact rows responsive on narrow screens

Closes #120

## Verification

- npm test (3 tests passed)
- ASTRO_TELEMETRY_DISABLED=1 npm run build
- git diff --check