### PR TITLE
fix(history): close tracking modal after success

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",
+    "test": "node --test test/*.test.mjs",
     "preview": "astro preview",
     "astro": "astro"
   },

--- a/frontend/src/layouts/Base.astro
+++ b/frontend/src/layouts/Base.astro
@@ -1490,6 +1490,12 @@ const bottomNavItem = (active: boolean) =>
       }
     }
 
+    function updateWatchHistoryItemUI(watched: boolean) {
+      document.querySelectorAll<HTMLElement>(
+        `[data-card][data-tmdb-id="${_watchHistoryTmdbId}"][data-media-type="${_watchHistoryMediaType}"] [data-action="watched"]`
+      ).forEach(btn => updateWatchedButtonUI(btn, watched));
+    }
+
     async function loadWatchHistoryEvents() {
       const eventsEl = document.getElementById('watch-history-modal-events')!;
       eventsEl.innerHTML = '<div class="px-4 py-3 text-xs text-zinc-500">Loading…</div>';
@@ -1524,9 +1530,7 @@ const bottomNavItem = (active: boolean) =>
         const hasEvents = events.length > 0;
         unwatchBtn.classList.toggle('hidden', !hasEvents);
         document.getElementById('watch-history-log-btn')!.textContent = hasEvents ? 'Log a rewatch' : 'Mark as watched';
-        document.querySelectorAll<HTMLElement>(
-          `[data-card][data-tmdb-id="${_watchHistoryTmdbId}"][data-media-type="${_watchHistoryMediaType}"] [data-action="watched"]`
-        ).forEach(b => updateWatchedButtonUI(b, watched));
+        updateWatchHistoryItemUI(watched);
       } catch {
         eventsEl.innerHTML = '<div class="px-4 py-2 text-xs text-red-400">Failed to load</div>';
       }
@@ -1663,17 +1667,26 @@ const bottomNavItem = (active: boolean) =>
             if (_watchHistoryEpisodeNumber) watchBody.episode_number = Number(_watchHistoryEpisodeNumber);
           }
           await apiFetch('/history', 'POST', watchBody);
-          await loadWatchHistoryEvents();
-          syncSeasonWatchPctFromDOM(_watchHistoryShowTmdbId, _watchHistorySeasonNumber);
-          // Reset to "Just now" after logging
-          _watchHistoryDateMode = 'now';
-          (document.getElementById('watch-history-now-btn') as HTMLElement).className = activeClass;
-          (document.getElementById('watch-history-custom-btn') as HTMLElement).className = inactiveClass;
-          (document.getElementById('watch-history-unknown-btn') as HTMLElement).className = inactiveClass;
-          input.classList.add('hidden');
         } catch (err) {
           logBtn.textContent = idleLabel;
           alertFromError(err, 'Failed to mark as watched');
+          logBtn.disabled = false;
+          return;
+        }
+
+        // The write is now durable. Reflect that locally before attempting
+        // the non-critical history reload, so a failed follow-up GET cannot
+        // be presented as a failed write or invite a duplicate submission.
+        updateWatchHistoryItemUI(true);
+        try {
+          await loadWatchHistoryEvents();
+          syncSeasonWatchPctFromDOM(_watchHistoryShowTmdbId, _watchHistorySeasonNumber);
+        } catch {
+          // The POST succeeded; the next modal opening retries the history
+          // fetch. Keep the local watched state instead of reporting a write
+          // failure after the fact.
+        } finally {
+          closeWatchHistoryModal();
         }
         logBtn.disabled = false;
       });

--- a/frontend/test/watch-history-modal.test.mjs
+++ b/frontend/test/watch-history-modal.test.mjs
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const source = readFileSync(new URL('../src/layouts/Base.astro', import.meta.url), 'utf8');
+const logHandler = source.slice(
+  source.indexOf("document.getElementById('watch-history-log-btn')!.addEventListener('click'"),
+  source.indexOf('// ── Main event delegation')
+);
+
+test('manual watch treats the POST as the failure boundary and closes after a best-effort refresh', () => {
+  const post = logHandler.indexOf("await apiFetch('/history', 'POST', watchBody);");
+  const postFailure = logHandler.indexOf('} catch (err) {', post);
+  const localUpdate = logHandler.indexOf('updateWatchHistoryItemUI(true);', postFailure);
+  const refreshTry = logHandler.indexOf('try {', localUpdate);
+  const refresh = logHandler.indexOf('await loadWatchHistoryEvents();', refreshTry);
+  const refreshFailure = logHandler.indexOf('} catch {', refresh);
+  const close = logHandler.indexOf('closeWatchHistoryModal();', refreshFailure);
+
+  assert.ok(post >= 0, 'manual watch submits history');
+  assert.ok(postFailure > post, 'only POST failures enter the visible error path');
+  assert.match(logHandler.slice(postFailure, localUpdate), /alertFromError\(err, 'Failed to mark as watched'\)/);
+  assert.ok(localUpdate > postFailure, 'a successful POST updates card state before refresh');
+  assert.ok(refresh > localUpdate, 'history refresh follows the durable write');
+  assert.ok(refreshFailure > refresh, 'refresh errors are handled separately from POST errors');
+  assert.ok(close > refreshFailure, 'the modal closes even when the follow-up refresh fails');
+});
+
+test('bulk season and show watches retain the same success-only close behavior', () => {
+  const bulkPath = logHandler.slice(
+    logHandler.indexOf('if (_watchHistoryBulkMode)'),
+    logHandler.indexOf('\n        try {', logHandler.indexOf('if (_watchHistoryBulkMode)'))
+  );
+  const close = bulkPath.indexOf('closeWatchHistoryModal();');
+  const failurePath = bulkPath.slice(bulkPath.indexOf('} catch (err)'));
+
+  assert.ok(close >= 0, 'bulk submissions close after their API request and UI cascade');
+  assert.equal(failurePath.includes('closeWatchHistoryModal();'), false, 'failed bulk submissions remain open');
+});
+
+test('every watch-history entry point resets the date picker to Just now', () => {
+  const singleOpen = source.slice(source.indexOf('async function openWatchHistoryModal'), source.indexOf('function openBulkWatchModal'));
+  const bulkOpen = source.slice(source.indexOf('function openBulkWatchModal'), source.indexOf('function cascadeWatchedUI'));
+
+  assert.match(singleOpen, /resetWatchHistoryDateUI\(\)/);
+  assert.match(bulkOpen, /resetWatchHistoryDateUI\(\)/);
+  assert.match(source, /function resetWatchHistoryDateUI\(\)\s*\{[\s\S]*?_watchHistoryDateMode = 'now'/);
+});


### PR DESCRIPTION
## Summary

- close the manual watch/rewatch modal after a successful history write
- update the visible watched state before attempting the non-critical history refresh
- keep the modal, selected timestamp, and error path intact when the write itself fails
- preserve the existing success-only close behavior for season/show bulk actions
- verify every manual entry point already resets to Just now by default

Closes #248

## Verification

- npm test (3 tests passed)
- ASTRO_TELEMETRY_DISABLED=1 npm run build
- git diff --check