### PR TITLE
feat(sonarr): select seasons when requesting shows

### DIFF
--- a/backend/core/sonarr.py
+++ b/backend/core/sonarr.py
@@ -11,6 +11,124 @@ _LIBRARY_TTL = 300.0
 _LIBRARY_FAILURE_TTL = 60.0
 
 
+class InvalidSeasonSelectionError(ValueError):
+    """Raised when a requested season selection no longer matches Sonarr."""
+
+
+async def lookup_series(url: str, token: str, tvdb_id: int) -> Dict[str, Any]:
+    """Fetch the current Sonarr lookup record without exposing its token."""
+    url = url.rstrip("/")
+    async with httpx.AsyncClient(timeout=10.0, follow_redirects=False) as client:
+        return await _lookup_series(client, url, token, tvdb_id)
+
+
+async def _lookup_series(
+    client: httpx.AsyncClient, url: str, token: str, tvdb_id: int
+) -> Dict[str, Any]:
+    lookup_res = await client.get(
+        f"{url}/api/v3/series/lookup",
+        headers={"X-Api-Key": token},
+        params={"term": f"tvdb:{tvdb_id}"},
+    )
+    lookup_res.raise_for_status()
+    lookup_data = lookup_res.json()
+    if not lookup_data:
+        raise Exception(f"Series with TVDB ID {tvdb_id} not found on Sonarr lookup")
+    return lookup_data[0]
+
+
+def _apply_season_monitoring(
+    series_data: Dict[str, Any], selected_seasons: Optional[List[int]]
+) -> List[Dict[str, Any]]:
+    """Build a deterministic Sonarr season-monitoring payload.
+
+    All mode intentionally means all *regular* seasons (number > 0); Sonarr's
+    own ``MonitorTypes.All`` has the same Specials-excluding meaning.  A
+    concrete selection may include season 0 and is checked against the fresh
+    lookup response to make stale browser state safe.
+    """
+    if selected_seasons is not None and any(
+        type(number) is not int or number < 0 for number in selected_seasons
+    ):
+        raise InvalidSeasonSelectionError("Selected seasons must be valid non-negative numbers")
+
+    available_seasons = series_data.get("seasons")
+    if not isinstance(available_seasons, list):
+        available_seasons = []
+
+    if selected_seasons is None:
+        return [
+            {
+                **season,
+                "monitored": season.get("seasonNumber", -1) > 0,
+            }
+            for season in available_seasons
+            if isinstance(season, dict)
+        ]
+
+    available_numbers = {
+        season.get("seasonNumber")
+        for season in available_seasons
+        if isinstance(season, dict) and isinstance(season.get("seasonNumber"), int)
+    }
+    requested_numbers = set(selected_seasons)
+    if not requested_numbers:
+        raise InvalidSeasonSelectionError("Select at least one season or choose all seasons")
+
+    invalid_numbers = sorted(requested_numbers - available_numbers)
+    if invalid_numbers:
+        values = ", ".join(str(number) for number in invalid_numbers)
+        raise InvalidSeasonSelectionError(f"The selected season(s) are no longer available: {values}")
+
+    return [
+        {
+            **season,
+            "monitored": season.get("seasonNumber") in requested_numbers,
+        }
+        for season in available_seasons
+    ]
+
+
+async def _queue_selected_season_searches(
+    client: httpx.AsyncClient,
+    url: str,
+    token: str,
+    series_id: int | None,
+    selected_seasons: List[int],
+) -> list[int]:
+    """Queue one explicit Sonarr SeasonSearch command per selected season.
+
+    A broad MissingEpisodeSearch has historically ignored per-season flags;
+    direct SeasonSearch commands are deliberately restricted to the requested
+    season, including season 0 (Specials).
+    """
+    if not series_id:
+        return list(selected_seasons)
+
+    failed_seasons: list[int] = []
+    for season_number in selected_seasons:
+        try:
+            response = await client.post(
+                f"{url}/api/v3/command",
+                headers={"X-Api-Key": token},
+                json={
+                    "name": "SeasonSearch",
+                    "seriesId": series_id,
+                    "seasonNumber": season_number,
+                },
+            )
+            response.raise_for_status()
+        except Exception as exc:
+            logger.error(
+                "Series %s was added but Sonarr SeasonSearch for season %s could not be queued: %s",
+                series_id,
+                season_number,
+                exc,
+            )
+            failed_seasons.append(season_number)
+    return failed_seasons
+
+
 async def get_all_series_ids(url: str, token: str) -> Optional[Tuple[Set[int], Set[int]]]:
     """(tmdb ids, tvdb ids) of every series in Sonarr, cached per server;
     None on failure. tmdbId only exists on Sonarr v4+."""
@@ -109,28 +227,34 @@ async def add_series(
     monitored: bool = True,
     search_for_missing_episodes: bool = True,
     season_folder: bool = True,
+    selected_seasons: Optional[List[int]] = None,
 ) -> Dict[str, Any]:
-    """Add a series to Sonarr."""
+    """Add a series to Sonarr, optionally monitoring only selected seasons."""
+    if selected_seasons is not None and any(
+        type(number) is not int or number < 0 for number in selected_seasons
+    ):
+        raise InvalidSeasonSelectionError("Selected seasons must be valid non-negative numbers")
     try:
         url = url.rstrip("/")
         async with httpx.AsyncClient(timeout=10.0, follow_redirects=False) as client:
-            # First, lookup series on Sonarr
-            lookup_res = await client.get(
-                f"{url}/api/v3/series/lookup",
-                headers={"X-Api-Key": token},
-                params={"term": f"tvdb:{tvdb_id}"},
-            )
-            lookup_res.raise_for_status()
-            lookup_data = lookup_res.json()
-            
-            if not lookup_data:
-                raise Exception(f"Series with TVDB ID {tvdb_id} not found on Sonarr lookup")
-            
-            series_data = lookup_data[0]
+            series_data = await _lookup_series(client, url, token, tvdb_id)
             
             # If series has an 'id', it's already in Sonarr
             if series_data.get("id"):
                 return {"status": "already_exists", "series": series_data}
+
+            # A selected list is validated against this fresh lookup, rather
+            # than trusting the seasons displayed in an earlier browser modal.
+            # ``skip`` makes Sonarr preserve these manual season flags; we
+            # then issue a SeasonSearch for each selected season below.
+            seasons = _apply_season_monitoring(series_data, selected_seasons)
+            add_options = {
+                "monitor": "skip" if selected_seasons is not None else "all",
+                "searchForMissingEpisodes": (
+                    search_for_missing_episodes if selected_seasons is None else False
+                ),
+                "searchForCutoffUnmetEpisodes": False,
+            }
 
             # Prepare payload
             payload = {
@@ -140,9 +264,8 @@ async def add_series(
                 "seasonFolder": season_folder,
                 "tags": tags or [],
                 "monitored": monitored,
-                "addOptions": {
-                    "searchForMissingEpisodes": search_for_missing_episodes
-                }
+                "addOptions": add_options,
+                "seasons": seasons,
             }
 
             response = await client.post(
@@ -151,8 +274,23 @@ async def add_series(
                 json=payload
             )
             response.raise_for_status()
-            return {"status": "added", "series": response.json()}
+            added_series = response.json()
+
+            if selected_seasons is not None:
+                failed_seasons = await _queue_selected_season_searches(
+                    client, url, token, added_series.get("id"), selected_seasons
+                )
+                if failed_seasons:
+                    return {
+                        "status": "added_search_failed",
+                        "series": added_series,
+                        "search_failed_seasons": failed_seasons,
+                    }
+
+            return {"status": "added", "series": added_series}
             
+    except InvalidSeasonSelectionError:
+        raise
     except Exception as e:
         logger.error(f"Failed to add series to Sonarr: {e}")
         raise Exception(str(e))

--- a/backend/routers/media.py
+++ b/backend/routers/media.py
@@ -7,7 +7,7 @@ import uuid
 from typing import Optional
 
 logger = logging.getLogger(__name__)
-from pydantic import BaseModel
+from pydantic import BaseModel, StrictInt
 from fastapi import APIRouter, Depends, Query, HTTPException, Request
 from fastapi.responses import StreamingResponse, Response
 from starlette.background import BackgroundTask
@@ -3654,6 +3654,7 @@ async def get_request_status(
 @router.get("/{type}/customize-options")
 async def get_customize_options(
     type: MediaType,
+    tmdb_id: int | None = Query(None, ge=1),
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(require_admin),
 ):
@@ -3698,6 +3699,29 @@ async def get_customize_options(
             sonarr.get_quality_profiles(sonarr_cfg.sonarr_url, sonarr_cfg.sonarr_token),
             sonarr.get_tags(sonarr_cfg.sonarr_url, sonarr_cfg.sonarr_token),
         )
+        # Keep this endpoint backwards compatible for clients that only need
+        # the existing add defaults.  The per-show UI supplies tmdb_id so its
+        # season picker can use a fresh Sonarr lookup.
+        seasons = []
+        if tmdb_id is not None:
+            tmdb_key = await get_user_tmdb_key(db, current_user.id)
+            external_ids = await tmdb.get_external_ids(tmdb_id, "tv", api_key=tmdb_key)
+            tvdb_id = external_ids.get("tvdb_id")
+            if not tvdb_id:
+                raise HTTPException(status_code=400, detail="Could not find TVDB ID for this show")
+
+            try:
+                series_data = await sonarr.lookup_series(
+                    sonarr_cfg.sonarr_url, sonarr_cfg.sonarr_token, tvdb_id
+                )
+            except Exception:
+                raise HTTPException(status_code=503, detail="Could not load seasons from Sonarr")
+
+            seasons = [
+                {"season_number": season["seasonNumber"]}
+                for season in series_data.get("seasons", [])
+                if isinstance(season, dict) and isinstance(season.get("seasonNumber"), int)
+            ]
         return {
             "root_folders": root_folders,
             "quality_profiles": quality_profiles,
@@ -3708,6 +3732,7 @@ async def get_customize_options(
                 "tags": sonarr_cfg.sonarr_tags or [],
                 "season_folder": sonarr_cfg.sonarr_season_folder if sonarr_cfg.sonarr_season_folder is not None else True,
             },
+            "seasons": seasons,
         }
 
     else:
@@ -3724,6 +3749,17 @@ class RequestOverrides(BaseModel):
     quality_profile: int | None = None
     tags: list[int] | None = None
     season_folder: bool | None = None
+    selected_seasons: list[StrictInt] | None = None
+
+    def model_post_init(self, __context) -> None:
+        if self.selected_seasons is None:
+            return
+        if not self.selected_seasons:
+            raise ValueError("Select at least one season or choose all seasons")
+        if len(set(self.selected_seasons)) != len(self.selected_seasons):
+            raise ValueError("Selected seasons must not contain duplicates")
+        if any(season < 0 for season in self.selected_seasons):
+            raise ValueError("Selected seasons must be valid non-negative numbers")
 
 
 def _resolve_add_overrides(overrides: RequestOverrides | None, is_admin: bool) -> RequestOverrides | None:
@@ -3847,8 +3883,11 @@ async def request_media(
                 quality_profile_id=(ov.quality_profile if ov and ov.quality_profile is not None else sonarr_cfg.sonarr_quality_profile),
                 tags=(ov.tags if ov and ov.tags is not None else sonarr_cfg.sonarr_tags),
                 season_folder=(ov.season_folder if ov and ov.season_folder is not None else default_season_folder),
+                selected_seasons=(ov.selected_seasons if ov else None),
             )
             return res
+        except sonarr.InvalidSeasonSelectionError as e:
+            raise HTTPException(status_code=400, detail=str(e))
         except Exception as e:
             if isinstance(e, HTTPException): raise e
             raise HTTPException(status_code=500, detail=f"Sonarr error: {e}")

--- a/backend/tests/test_media.py
+++ b/backend/tests/test_media.py
@@ -1,6 +1,8 @@
 import os
 import unittest
 
+from pydantic import ValidationError
+
 os.environ.setdefault("SECRET_KEY", "test-secret")
 os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://test:test@localhost/test")
 
@@ -141,6 +143,17 @@ class ResolveAddOverridesTests(unittest.TestCase):
 
     def test_no_overrides_sent_is_a_noop_for_a_non_admin(self) -> None:
         self.assertIsNone(_resolve_add_overrides(None, False))
+
+    def test_selected_seasons_are_admin_only_like_other_add_overrides(self) -> None:
+        overrides = RequestOverrides(selected_seasons=[0, 2])
+        self.assertEqual(_resolve_add_overrides(overrides, True).selected_seasons, [0, 2])
+        self.assertIsNone(_resolve_add_overrides(overrides, False))
+
+    def test_selected_seasons_reject_empty_duplicate_and_negative_values(self) -> None:
+        for seasons in ([], [1, 1], [-1], [True]):
+            with self.subTest(seasons=seasons):
+                with self.assertRaises(ValidationError):
+                    RequestOverrides(selected_seasons=seasons)
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_radarr_sonarr_credentials.py
+++ b/backend/tests/test_radarr_sonarr_credentials.py
@@ -1,5 +1,6 @@
 import os
 import unittest
+import json
 from unittest.mock import patch
 
 import httpx
@@ -94,6 +95,195 @@ class RadarrSonarrCredentialTests(unittest.IsolatedAsyncioTestCase):
             )
 
         self.assertEqual(result["status"], "already_exists")
+
+    async def test_sonarr_selected_seasons_only_monitor_and_search_the_selection(self) -> None:
+        requests: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            requests.append(request)
+            self.assertEqual(request.headers.get("x-api-key"), "sonarr-secret")
+            self.assertNotIn("apiKey", request.url.params)
+            if request.method == "GET":
+                return httpx.Response(200, json=[{
+                    "tvdbId": 12345,
+                    "title": "Example Show",
+                    "seasons": [
+                        {"seasonNumber": 0, "monitored": True},
+                        {"seasonNumber": 1, "monitored": True},
+                        {"seasonNumber": 2, "monitored": True},
+                    ],
+                }])
+            payload = json.loads(request.content)
+            if request.url.path == "/api/v3/series":
+                self.assertTrue(payload["monitored"])
+                self.assertEqual(
+                    {season["seasonNumber"] for season in payload["seasons"] if season["monitored"]},
+                    {0, 2},
+                )
+                self.assertEqual(payload["addOptions"], {
+                    "monitor": "skip",
+                    "searchForMissingEpisodes": False,
+                    "searchForCutoffUnmetEpisodes": False,
+                })
+                return httpx.Response(201, json={"id": 42, **payload})
+            self.assertEqual(request.url.path, "/api/v3/command")
+            self.assertEqual(payload["name"], "SeasonSearch")
+            self.assertEqual(payload["seriesId"], 42)
+            self.assertIn(payload["seasonNumber"], {0, 2})
+            self.assertNotEqual(payload["seasonNumber"], 1)
+            return httpx.Response(201, json={"id": 100 + payload["seasonNumber"]})
+
+        transport = httpx.MockTransport(handler)
+        with patch.object(
+            sonarr.httpx,
+            "AsyncClient",
+            side_effect=lambda **kwargs: _REAL_ASYNC_CLIENT(transport=transport, **kwargs),
+        ):
+            result = await sonarr.add_series(
+                "https://sonarr.example",
+                "sonarr-secret",
+                tvdb_id=12345,
+                root_folder="/tv",
+                quality_profile_id=1,
+                selected_seasons=[0, 2],
+            )
+
+        self.assertEqual(result["status"], "added")
+        self.assertEqual(
+            [(request.method, request.url.path) for request in requests],
+            [
+                ("GET", "/api/v3/series/lookup"),
+                ("POST", "/api/v3/series"),
+                ("POST", "/api/v3/command"),
+                ("POST", "/api/v3/command"),
+            ],
+        )
+        self.assertEqual(
+            [json.loads(request.content)["seasonNumber"] for request in requests[2:]],
+            [0, 2],
+        )
+
+    async def test_sonarr_all_mode_explicitly_searches_regular_seasons_not_specials(self) -> None:
+        requests: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            requests.append(request)
+            if request.method == "GET":
+                return httpx.Response(200, json=[{
+                    "tvdbId": 12345,
+                    "seasons": [
+                        {"seasonNumber": 0, "monitored": True},
+                        {"seasonNumber": 1, "monitored": False},
+                        {"seasonNumber": 2, "monitored": False},
+                    ],
+                }])
+            payload = json.loads(request.content)
+            self.assertEqual(
+                payload["seasons"],
+                [
+                    {"seasonNumber": 0, "monitored": False},
+                    {"seasonNumber": 1, "monitored": True},
+                    {"seasonNumber": 2, "monitored": True},
+                ],
+            )
+            self.assertEqual(payload["addOptions"], {
+                "monitor": "all",
+                "searchForMissingEpisodes": True,
+                "searchForCutoffUnmetEpisodes": False,
+            })
+            return httpx.Response(201, json={"id": 42, **payload})
+
+        transport = httpx.MockTransport(handler)
+        with patch.object(
+            sonarr.httpx,
+            "AsyncClient",
+            side_effect=lambda **kwargs: _REAL_ASYNC_CLIENT(transport=transport, **kwargs),
+        ):
+            result = await sonarr.add_series(
+                "https://sonarr.example",
+                "sonarr-secret",
+                tvdb_id=12345,
+                root_folder="/tv",
+                quality_profile_id=1,
+            )
+
+        self.assertEqual(result["status"], "added")
+        self.assertEqual(
+            [(request.method, request.url.path) for request in requests],
+            [("GET", "/api/v3/series/lookup"), ("POST", "/api/v3/series")],
+        )
+
+    async def test_sonarr_reports_a_search_queue_failure_without_disguising_the_add(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.method == "GET":
+                return httpx.Response(200, json=[{
+                    "tvdbId": 12345,
+                    "seasons": [{"seasonNumber": 1, "monitored": True}],
+                }])
+            if request.url.path == "/api/v3/series":
+                return httpx.Response(201, json={"id": 42})
+            self.assertEqual(json.loads(request.content), {
+                "name": "SeasonSearch", "seriesId": 42, "seasonNumber": 1,
+            })
+            return httpx.Response(500, json={"message": "queue unavailable"})
+
+        transport = httpx.MockTransport(handler)
+        with patch.object(
+            sonarr.httpx,
+            "AsyncClient",
+            side_effect=lambda **kwargs: _REAL_ASYNC_CLIENT(transport=transport, **kwargs),
+        ):
+            result = await sonarr.add_series(
+                "https://sonarr.example",
+                "sonarr-secret",
+                tvdb_id=12345,
+                root_folder="/tv",
+                quality_profile_id=1,
+                selected_seasons=[1],
+            )
+
+        self.assertEqual(result["status"], "added_search_failed")
+        self.assertEqual(result["series"], {"id": 42})
+        self.assertEqual(result["search_failed_seasons"], [1])
+
+    async def test_sonarr_rejects_stale_selected_seasons_before_posting(self) -> None:
+        requests: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            requests.append(request)
+            return httpx.Response(200, json=[{
+                "tvdbId": 12345,
+                "seasons": [{"seasonNumber": 1, "monitored": True}],
+            }])
+
+        transport = httpx.MockTransport(handler)
+        with patch.object(
+            sonarr.httpx,
+            "AsyncClient",
+            side_effect=lambda **kwargs: _REAL_ASYNC_CLIENT(transport=transport, **kwargs),
+        ):
+            with self.assertRaisesRegex(sonarr.InvalidSeasonSelectionError, "no longer available: 2"):
+                await sonarr.add_series(
+                    "https://sonarr.example",
+                    "sonarr-secret",
+                    tvdb_id=12345,
+                    root_folder="/tv",
+                    quality_profile_id=1,
+                    selected_seasons=[2],
+                )
+
+        self.assertEqual([request.method for request in requests], ["GET"])
+
+    async def test_sonarr_rejects_invalid_season_values_before_lookup(self) -> None:
+        with self.assertRaisesRegex(sonarr.InvalidSeasonSelectionError, "non-negative"):
+            await sonarr.add_series(
+                "https://sonarr.example",
+                "sonarr-secret",
+                tvdb_id=12345,
+                root_folder="/tv",
+                quality_profile_id=1,
+                selected_seasons=[True],
+            )
 
 
 if __name__ == "__main__":

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",
+    "test": "node --test test/*.test.mjs",
     "preview": "astro preview",
     "astro": "astro"
   },

--- a/frontend/src/layouts/Base.astro
+++ b/frontend/src/layouts/Base.astro
@@ -412,6 +412,19 @@ const bottomNavItem = (active: boolean) =>
           <input type="checkbox" id="customize-add-season-folder" class="sr-only peer" />
           <div class="relative w-10 h-5 bg-zinc-700 peer-checked:bg-blue-600 rounded-full transition-colors pointer-events-none shrink-0 after:content-[''] after:absolute after:top-0.5 after:left-0.5 after:w-4 after:h-4 after:bg-white after:rounded-full after:transition-transform peer-checked:after:translate-x-5"></div>
         </label>
+        <div id="customize-add-seasons-row" class="hidden space-y-2">
+          <span class="block text-sm font-medium text-zinc-400">Seasons</span>
+          <label class="flex items-center gap-2 text-sm text-zinc-300 cursor-pointer">
+            <input type="radio" name="customize-add-seasons" value="all" id="customize-add-seasons-all" checked class="accent-blue-500" />
+            Monitor all regular seasons
+          </label>
+          <p class="text-xs text-zinc-500 ml-6">Specials stay unmonitored unless you choose them below.</p>
+          <label class="flex items-center gap-2 text-sm text-zinc-300 cursor-pointer">
+            <input type="radio" name="customize-add-seasons" value="selected" id="customize-add-seasons-selected" class="accent-blue-500" />
+            Choose seasons
+          </label>
+          <div id="customize-add-seasons-list" class="hidden grid grid-cols-2 gap-2 p-3 bg-zinc-950 border border-zinc-800 rounded-lg"></div>
+        </div>
         <div id="customize-add-error" class="hidden text-sm text-red-400"></div>
       </div>
       <div id="customize-add-footer" class="hidden border-t border-zinc-800 px-5 py-4 flex gap-2">
@@ -494,6 +507,8 @@ const bottomNavItem = (active: boolean) =>
   </div>
 
   <script>
+    import { selectableSonarrSeasons, selectedSonarrSeasons } from "../lib/sonarrSeasons";
+
     // ── Theme toggle ───────────────────────────────────────────────────────────
     const themeToggle = document.getElementById('theme-toggle');
 
@@ -1163,13 +1178,35 @@ const bottomNavItem = (active: boolean) =>
       });
     }
 
-    async function openCustomizeAddPopover(mediaType: string, onConfirm: (overrides: Record<string, unknown>) => Promise<void>) {
+    function renderCustomizeAddSeasons(seasons: any[]) {
+      const all = document.getElementById('customize-add-seasons-all') as HTMLInputElement;
+      const selected = document.getElementById('customize-add-seasons-selected') as HTMLInputElement;
+      const list = document.getElementById('customize-add-seasons-list')!;
+      const validSeasons = selectableSonarrSeasons(seasons);
+
+      all.checked = true;
+      selected.checked = false;
+      selected.disabled = validSeasons.length === 0;
+      list.innerHTML = validSeasons.map((season: any) => {
+        const number = season.season_number as number;
+        const label = number === 0 ? 'Specials' : `Season ${number}`;
+        return `<label class="flex items-center gap-2 text-sm text-zinc-300 cursor-pointer"><input type="checkbox" value="${number}" class="customize-add-season-checkbox accent-blue-500" />${label}</label>`;
+      }).join('') || '<span class="col-span-2 text-xs text-zinc-500">No selectable seasons were returned by Sonarr.</span>';
+      list.classList.add('hidden');
+
+      const syncVisibility = () => list.classList.toggle('hidden', !selected.checked);
+      all.onchange = syncVisibility;
+      selected.onchange = syncVisibility;
+    }
+
+    async function openCustomizeAddPopover(mediaType: string, tmdbId: string, onConfirm: (overrides: Record<string, unknown>) => Promise<void>) {
       const popover = document.getElementById('customize-add-popover')!;
       const loading = document.getElementById('customize-add-loading')!;
       const body = document.getElementById('customize-add-body')!;
       const footer = document.getElementById('customize-add-footer')!;
       const errorEl = document.getElementById('customize-add-error')!;
       const seasonRow = document.getElementById('customize-add-season-folder-row')!;
+      const seasonsRow = document.getElementById('customize-add-seasons-row')!;
       const isSeries = mediaType === 'series';
 
       document.getElementById('customize-add-title')!.textContent = isSeries ? 'Add to Sonarr' : 'Add to Radarr';
@@ -1178,10 +1215,14 @@ const bottomNavItem = (active: boolean) =>
       footer.classList.add('hidden');
       errorEl.classList.add('hidden');
       seasonRow.classList.toggle('hidden', !isSeries);
+      seasonsRow.classList.toggle('hidden', !isSeries);
       popover.classList.remove('hidden');
 
       try {
-        const opts = await apiFetch(`/media/${mediaType}/customize-options`);
+        const optionsPath = isSeries
+          ? `/media/${mediaType}/customize-options?tmdb_id=${encodeURIComponent(tmdbId)}`
+          : `/media/${mediaType}/customize-options`;
+        const opts = await apiFetch(optionsPath);
 
         const rootSelect = document.getElementById('customize-add-root-folder') as HTMLSelectElement;
         rootSelect.innerHTML = opts.root_folders.map((f: any) =>
@@ -1198,6 +1239,7 @@ const bottomNavItem = (active: boolean) =>
 
         if (isSeries) {
           (document.getElementById('customize-add-season-folder') as HTMLInputElement).checked = opts.current.season_folder !== false;
+          renderCustomizeAddSeasons(opts.seasons);
         }
 
         loading.classList.add('hidden');
@@ -1219,6 +1261,18 @@ const bottomNavItem = (active: boolean) =>
         };
         if (isSeries) {
           overrides.season_folder = (document.getElementById('customize-add-season-folder') as HTMLInputElement).checked;
+          const selectedMode = (document.getElementById('customize-add-seasons-selected') as HTMLInputElement).checked;
+          if (selectedMode) {
+            const checkedSeasons = Array.from(document.querySelectorAll<HTMLInputElement>('.customize-add-season-checkbox:checked'))
+              .map(input => Number(input.value));
+            try {
+              overrides.selected_seasons = selectedSonarrSeasons(true, checkedSeasons);
+            } catch (error: any) {
+              errorEl.textContent = error.message;
+              errorEl.classList.remove('hidden');
+              return;
+            }
+          }
         }
         closeCustomizeAddPopover();
         await onConfirm(overrides);
@@ -1842,11 +1896,15 @@ const bottomNavItem = (active: boolean) =>
 
           try {
             const res = await apiFetch(`/media/${mediaType}/${tmdbId}/request`, 'POST', overrides);
-            if (res.status === 'added' || res.status === 'already_exists') {
-              btn.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" class="text-green-500"><polyline points="20 6 9 17 4 12"></polyline></svg><span class="text-[10px] font-bold uppercase tracking-wider leading-none text-green-500">' + (res.status === 'added' ? 'Added' : 'Exists') + '</span>';
+            if (res.status === 'added' || res.status === 'already_exists' || res.status === 'added_search_failed') {
+              btn.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" class="text-green-500"><polyline points="20 6 9 17 4 12"></polyline></svg><span class="text-[10px] font-bold uppercase tracking-wider leading-none text-green-500">' + (res.status === 'already_exists' ? 'Exists' : 'Added') + '</span>';
               btn.classList.remove('bg-zinc-800', 'text-zinc-500', 'hover:bg-orange-500/10', 'hover:text-orange-400');
               btn.classList.add('bg-green-500/10', 'text-green-500');
               (btn as HTMLButtonElement).disabled = true;
+              if (res.status === 'added_search_failed') {
+                const seasons = (res.search_failed_seasons || []).map((season: number) => season === 0 ? 'Specials' : `Season ${season}`).join(', ');
+                alert(`Added to Sonarr, but its search for ${seasons} could not be queued. Do not submit this request again; search those seasons manually in Sonarr.`);
+              }
             } else if (res.status === 'pending_approval') {
               btn.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" class="text-amber-400"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg><span class="text-[10px] font-bold uppercase tracking-wider leading-none text-amber-400">Pending</span>';
               btn.classList.remove('bg-zinc-800', 'text-zinc-500', 'hover:bg-orange-500/10', 'hover:text-orange-400');
@@ -1869,7 +1927,7 @@ const bottomNavItem = (active: boolean) =>
           (mediaType === 'series' && (window as any).__SONARR_CUSTOMIZE_ON_ADD__)
         );
         if (customizeOnAdd) {
-          openCustomizeAddPopover(mediaType, performRequestAdd);
+          openCustomizeAddPopover(mediaType, tmdbId, performRequestAdd);
         } else {
           await performRequestAdd();
         }

--- a/frontend/src/lib/sonarrSeasons.ts
+++ b/frontend/src/lib/sonarrSeasons.ts
@@ -1,0 +1,21 @@
+export function selectableSonarrSeasons(seasons: unknown): number[] {
+  if (!Array.isArray(seasons)) return [];
+
+  return [...new Set(
+    seasons
+      .map((season) => (typeof season === 'object' && season !== null ? (season as { season_number?: unknown }).season_number : undefined))
+      .filter((number): number is number => Number.isInteger(number) && number >= 0),
+  )].sort((a, b) => a - b);
+}
+
+export function selectedSonarrSeasons(selected: boolean, checkedSeasons: number[]): number[] | undefined {
+  if (!selected) return undefined;
+  const seasons = [...new Set(checkedSeasons)];
+  if (seasons.length === 0) {
+    throw new Error('Select at least one season or choose all seasons.');
+  }
+  if (seasons.some((season) => !Number.isInteger(season) || season < 0)) {
+    throw new Error('Selected seasons must be valid non-negative numbers.');
+  }
+  return seasons;
+}

--- a/frontend/test/request-season-selection.test.mjs
+++ b/frontend/test/request-season-selection.test.mjs
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+import { selectableSonarrSeasons, selectedSonarrSeasons } from '../src/lib/sonarrSeasons.ts';
+
+const base = await readFile(new URL('../src/layouts/Base.astro', import.meta.url), 'utf8');
+
+test('Sonarr request details expose an all-or-selected season choice', () => {
+  assert.match(base, /id="customize-add-seasons-all" checked/);
+  assert.match(base, /id="customize-add-seasons-selected"/);
+  assert.match(base, /Monitor all regular seasons/);
+  assert.match(base, /Specials stay unmonitored unless you choose them below/);
+  assert.match(base, /Choose seasons/);
+  assert.match(base, /customize-add-season-checkbox/);
+});
+
+test('only valid Sonarr seasons can be presented for selection', () => {
+  assert.deepEqual(
+    selectableSonarrSeasons([{ season_number: 2 }, { season_number: 0 }, { season_number: 2 }, { season_number: -1 }, {}]),
+    [0, 2],
+  );
+});
+
+test('all seasons keeps the existing Sonarr default and selected mode requires a choice', () => {
+  assert.equal(selectedSonarrSeasons(false, []), undefined);
+  assert.deepEqual(selectedSonarrSeasons(true, [2, 0, 2]), [2, 0]);
+  assert.throws(() => selectedSonarrSeasons(true, []), /Select at least one season/);
+  assert.throws(() => selectedSonarrSeasons(true, [-1]), /non-negative/);
+  assert.match(base, /overrides\.selected_seasons = selectedSonarrSeasons/);
+});
+
+test('Sonarr options are fetched for the title being requested', () => {
+  assert.match(base, /customize-options\?tmdb_id=\$\{encodeURIComponent\(tmdbId\)\}/);
+  assert.match(base, /openCustomizeAddPopover\(mediaType, tmdbId, performRequestAdd\)/);
+});
+
+test('a queued-search failure leaves the add succeeded and warns against retrying', () => {
+  assert.match(base, /res\.status === 'added_search_failed'/);
+  assert.match(base, /Do not submit this request again/);
+  assert.match(base, /search those seasons manually in Sonarr/);
+});


### PR DESCRIPTION
## Summary

- extend the existing admin Sonarr request-details flow with All regular seasons or selected-season choices
- load fresh title-specific seasons from Sonarr and validate the selection again at submission time
- monitor only selected seasons and queue one scoped SeasonSearch per choice, including Specials when explicitly selected
- keep broad missing-episode searches out of selected mode so unselected seasons are never searched
- treat a post-add command failure as partial success, mark the request Added, and give actionable manual-search guidance without inviting a duplicate add

This remains opt-in through the existing sonarr_customize_on_add setting; approval-queue requests keep their configured defaults.

Closes #149

## Verification

- full backend unittest suite (669 tests passed)
- focused media and Sonarr suites (23 tests passed)
- npm test (5 tests passed)
- ASTRO_TELEMETRY_DISABLED=1 npm run build
- git diff --check