### PR TITLE
feat(seasons): add episode ratings chart

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
     "dev": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
+    "test": "node --test test/*.test.mjs",
     "astro": "astro"
   },
   "dependencies": {

--- a/frontend/src/components/SeasonRatingChart.astro
+++ b/frontend/src/components/SeasonRatingChart.astro
@@ -1,0 +1,140 @@
+---
+import { buildSeasonRatingEntries, summarizeEpisodeRatings } from "../lib/season-ratings.mjs";
+
+interface Props {
+  episodes: Array<{
+    episode_number: number;
+    tmdb_rating?: number | null;
+    title?: string | null;
+    name?: string | null;
+  }>;
+  episodeBasePath: string;
+}
+
+const { episodes, episodeBasePath } = Astro.props;
+const chartId = "episode-rating-chart";
+const entries = buildSeasonRatingEntries(episodes);
+const { ratedEntries, highRating, lowRating, hasRange, highest, lowest } = summarizeEpisodeRatings(entries);
+const minWidth = Math.max(320, entries.length * 42);
+---
+
+<section class="mb-10 rounded-2xl border border-zinc-800 bg-zinc-900/50 p-4 sm:p-5" aria-labelledby={chartId}>
+  <div class="mb-4 flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+    <div>
+      <h2 id={chartId} class="text-lg font-black tracking-tight text-zinc-100">Episode ratings</h2>
+      <p class="text-xs text-zinc-500">Community ratings · select an episode bar to open its details</p>
+    </div>
+    {hasRange && highest && lowest && (
+      <p class="text-xs font-semibold text-zinc-400">
+        <span class="text-emerald-400">High E{highest.episodeNumber} · {highRating!.toFixed(1)}</span>
+        <span aria-hidden="true"> · </span>
+        <span class="text-amber-300">Low E{lowest.episodeNumber} · {lowRating!.toFixed(1)}</span>
+      </p>
+    )}
+  </div>
+
+  {ratedEntries.length === 0 ? (
+    <p class="rounded-xl border border-dashed border-zinc-700 px-4 py-5 text-sm text-zinc-400" role="status">
+      No episode ratings are available for this season yet.
+    </p>
+  ) : (
+    <div class="overflow-x-auto pb-2" tabindex="0" role="region" aria-label="Episode ratings chart; scroll horizontally to view every episode">
+      <div class="rating-chart" style={`min-width: ${minWidth}px`}>
+        <div class="rating-axis" aria-hidden="true"><span>10</span><span>5</span><span>0</span></div>
+        <div class="rating-bars">
+          {entries.map((episode) => {
+            const isRated = episode.rating !== null;
+            const isHighest = hasRange && episode.rating === highRating;
+            const isLowest = hasRange && episode.rating === lowRating;
+            const label = isRated
+              ? `Episode ${episode.episodeNumber}${episode.title ? `, ${episode.title}` : ""}: ${episode.rating!.toFixed(1)} out of 10${isHighest ? ", highest rated" : isLowest ? ", lowest rated" : ""}`
+              : `Episode ${episode.episodeNumber}${episode.title ? `, ${episode.title}` : ""}: rating unavailable`;
+            return (
+              <a
+                href={`${episodeBasePath}/${episode.episodeNumber}`}
+                class:list={["rating-bar", { "rating-bar--missing": !isRated, "rating-bar--highest": isHighest, "rating-bar--lowest": isLowest }]}
+                aria-label={label}
+              >
+                <span class="rating-bar__value" aria-hidden="true">{isRated ? episode.rating!.toFixed(1) : "—"}</span>
+                <span
+                  class="rating-bar__column"
+                  style={isRated ? `height: ${Math.max(8, episode.rating! * 10)}%` : undefined}
+                  aria-hidden="true"
+                ></span>
+                <span class="rating-bar__episode" aria-hidden="true">E{episode.episodeNumber}</span>
+              </a>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  )}
+</section>
+
+<style>
+  .rating-chart {
+    display: grid;
+    grid-template-columns: 1.6rem minmax(0, 1fr);
+    gap: 0.5rem;
+    height: 13rem;
+  }
+
+  .rating-axis {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    padding: 0.1rem 0 1.6rem;
+    color: rgb(113 113 122);
+    font-size: 0.625rem;
+    font-weight: 700;
+  }
+
+  .rating-bars {
+    display: grid;
+    grid-auto-columns: minmax(2rem, 1fr);
+    grid-auto-flow: column;
+    align-items: end;
+    gap: 0.35rem;
+    min-width: 0;
+    border-bottom: 1px solid rgb(63 63 70);
+    background-image: linear-gradient(to top, rgb(63 63 70 / 0.55) 1px, transparent 1px);
+    background-size: 100% 50%;
+  }
+
+  .rating-bar {
+    display: grid;
+    grid-template-rows: 1rem minmax(0, 1fr) 1.25rem;
+    min-width: 0;
+    height: 100%;
+    color: rgb(161 161 170);
+    text-align: center;
+    text-decoration: none;
+    outline-offset: 3px;
+  }
+
+  .rating-bar:focus-visible { outline: 2px solid rgb(96 165 250); }
+  .rating-bar:hover .rating-bar__column { filter: brightness(1.2); }
+
+  .rating-bar__value,
+  .rating-bar__episode { font-size: 0.625rem; font-weight: 700; line-height: 1rem; }
+  .rating-bar__episode { color: rgb(113 113 122); }
+
+  .rating-bar__column {
+    align-self: end;
+    min-height: 0.25rem;
+    border-radius: 0.35rem 0.35rem 0 0;
+    background: linear-gradient(to top, rgb(37 99 235), rgb(96 165 250));
+    transition: filter 150ms ease;
+  }
+
+  .rating-bar--highest .rating-bar__column { background: linear-gradient(to top, rgb(5 150 105), rgb(74 222 128)); }
+  .rating-bar--highest .rating-bar__value { color: rgb(74 222 128); }
+  .rating-bar--lowest .rating-bar__column { background: linear-gradient(to top, rgb(217 119 6), rgb(251 191 36)); }
+  .rating-bar--lowest .rating-bar__value { color: rgb(252 211 77); }
+
+  .rating-bar--missing .rating-bar__column {
+    height: 0.35rem;
+    border: 1px dashed rgb(82 82 91);
+    background: transparent;
+  }
+</style>

--- a/frontend/src/lib/season-ratings.mjs
+++ b/frontend/src/lib/season-ratings.mjs
@@ -1,0 +1,44 @@
+/**
+ * @typedef {{ episode_number: number, tmdb_rating?: number | null, title?: string | null, name?: string | null }} EpisodeRating
+ * @typedef {{ episodeNumber: number, title: string | null, rating: number | null }} SeasonRatingEntry
+ */
+
+/**
+ * Turn the episode data already supplied by a season endpoint into values that
+ * can be displayed on a 0–10 chart. Zero and invalid values mean unavailable.
+ *
+ * @param {EpisodeRating[]} episodes
+ * @returns {SeasonRatingEntry[]}
+ */
+export function buildSeasonRatingEntries(episodes) {
+  return episodes
+    .map((episode) => {
+      const value = Number(episode.tmdb_rating);
+      const rating = Number.isFinite(value) && value > 0 ? Math.min(value, 10) : null;
+      return {
+        episodeNumber: episode.episode_number,
+        title: episode.title ?? episode.name ?? null,
+        rating,
+      };
+    })
+    .filter((episode) => Number.isFinite(episode.episodeNumber))
+    .sort((a, b) => a.episodeNumber - b.episodeNumber);
+}
+
+/**
+ * @param {SeasonRatingEntry[]} entries
+ */
+export function summarizeEpisodeRatings(entries) {
+  const ratedEntries = entries.filter((episode) => episode.rating !== null);
+  const highRating = ratedEntries.length ? Math.max(...ratedEntries.map((episode) => episode.rating)) : null;
+  const lowRating = ratedEntries.length ? Math.min(...ratedEntries.map((episode) => episode.rating)) : null;
+
+  return {
+    ratedEntries,
+    highRating,
+    lowRating,
+    hasRange: highRating !== null && lowRating !== null && highRating !== lowRating,
+    highest: ratedEntries.find((episode) => episode.rating === highRating),
+    lowest: ratedEntries.find((episode) => episode.rating === lowRating),
+  };
+}

--- a/frontend/src/pages/show/[id]/season/[season_number].astro
+++ b/frontend/src/pages/show/[id]/season/[season_number].astro
@@ -2,6 +2,7 @@
 import Base from "../../../../layouts/Base.astro";
 import ActionBar from "../../../../components/ActionBar.astro";
 import CommentsSection from "../../../../components/CommentsSection.astro";
+import SeasonRatingChart from "../../../../components/SeasonRatingChart.astro";
 import { api, type Season } from "../../../../lib/api";
 export const prerender = false;
 
@@ -190,6 +191,11 @@ const show = season?.show;
           mediaType="series"
           tmdbId={Number(id)}
           seasonNumber={Number(season_number)}
+        />
+
+        <SeasonRatingChart
+          episodes={season.episodes ?? []}
+          episodeBasePath={`/show/${id}/season/${season_number}`}
         />
 
         <div class="space-y-4">

--- a/frontend/src/pages/show/tvdb/[id]/season/[season_number].astro
+++ b/frontend/src/pages/show/tvdb/[id]/season/[season_number].astro
@@ -2,6 +2,7 @@
 import Base from "../../../../../layouts/Base.astro";
 import ActionBar from "../../../../../components/ActionBar.astro";
 import CommentsSection from "../../../../../components/CommentsSection.astro";
+import SeasonRatingChart from "../../../../../components/SeasonRatingChart.astro";
 import { api, type TvdbSeason } from "../../../../../lib/api";
 import { formatSeasonTitle } from "../../../../../lib/media-format";
 export const prerender = false;
@@ -193,6 +194,11 @@ const seasonTitle = season
           mediaType="series"
           tmdbId={season.show.tmdb_id ?? Number(id)}
           seasonNumber={Number(season_number)}
+        />
+
+        <SeasonRatingChart
+          episodes={season.episodes ?? []}
+          episodeBasePath={`/show/tvdb/${id}/season/${season_number}`}
         />
 
         <div class="space-y-4">

--- a/frontend/test/season-rating-chart.test.mjs
+++ b/frontend/test/season-rating-chart.test.mjs
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import { buildSeasonRatingEntries, summarizeEpisodeRatings } from "../src/lib/season-ratings.mjs";
+
+const chart = await readFile(new URL("../src/components/SeasonRatingChart.astro", import.meta.url), "utf8");
+
+test("season rating chart normalizes ratings and represents missing values", () => {
+  assert.deepEqual(
+    buildSeasonRatingEntries([
+      { episode_number: 3, tmdb_rating: 12, title: "Finale" },
+      { episode_number: 1, tmdb_rating: 0, title: "Pilot" },
+      { episode_number: 2, tmdb_rating: "8.4", name: "Middle" },
+      { episode_number: 4, tmdb_rating: null },
+    ]),
+    [
+      { episodeNumber: 1, title: "Pilot", rating: null },
+      { episodeNumber: 2, title: "Middle", rating: 8.4 },
+      { episodeNumber: 3, title: "Finale", rating: 10 },
+      { episodeNumber: 4, title: null, rating: null },
+    ],
+  );
+  assert.match(chart, /rating-bar--missing/);
+  assert.match(chart, /No episode ratings are available for this season yet/);
+});
+
+test("season rating chart exposes high and low episodes accessibly", () => {
+  const entries = buildSeasonRatingEntries([
+    { episode_number: 1, tmdb_rating: 7.5 },
+    { episode_number: 2, tmdb_rating: 9.1 },
+    { episode_number: 3, tmdb_rating: 6.8 },
+  ]);
+  const summary = summarizeEpisodeRatings(entries);
+
+  assert.equal(summary.highRating, 9.1);
+  assert.equal(summary.lowRating, 6.8);
+  assert.equal(summary.highest?.episodeNumber, 2);
+  assert.equal(summary.lowest?.episodeNumber, 3);
+  assert.equal(summary.hasRange, true);
+  assert.match(chart, /rating-bar--highest/);
+  assert.match(chart, /rating-bar--lowest/);
+  assert.match(chart, /highest rated/);
+  assert.match(chart, /lowest rated/);
+  assert.match(chart, /aria-label=\{label\}/);
+  assert.match(chart, /role="region"/);
+  assert.match(chart, /tabindex="0"/);
+});
+
+test("both season route families use the shared chart with their own episode links", async () => {
+  const tmdb = await readFile(new URL("../src/pages/show/[id]/season/[season_number].astro", import.meta.url), "utf8");
+  const tvdb = await readFile(new URL("../src/pages/show/tvdb/[id]/season/[season_number].astro", import.meta.url), "utf8");
+
+  for (const source of [tmdb, tvdb]) {
+    assert.match(source, /import SeasonRatingChart/);
+    assert.match(source, /<SeasonRatingChart/);
+    assert.match(source, /episodes=\{season\.episodes \?\? \[\]\}/);
+  }
+  assert.match(tmdb, /episodeBasePath=\{`\/show\/\$\{id\}\/season\/\$\{season_number\}`\}/);
+  assert.match(tvdb, /episodeBasePath=\{`\/show\/tvdb\/\$\{id\}\/season\/\$\{season_number\}`\}/);
+});


### PR DESCRIPTION
## Summary

- add a dependency-free episode ratings graph to TMDB and TVDB season pages
- highlight and summarize the highest and lowest rated episodes
- link every keyboard-focusable bar to episode details with descriptive screen-reader labels
- handle missing ratings explicitly and keep long seasons usable with horizontal scrolling
- avoid presenting personal ratings as community ratings when TVDB has no provider-rating field

Closes #198

## Verification

- npm test (3 tests passed)
- ASTRO_TELEMETRY_DISABLED=1 npm run build
- git diff --check