### PR TITLE
fix(frontend): honor runtime backend configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,11 @@ POSTGRES_DB=scrob
 POSTGRES_HOST=localhost
 POSTGRES_PORT=5432
 
+# Astro's server-side proxy reaches the backend over this URL. On one host,
+# leave BACKEND_URL unset and optionally change BACKEND_PORT instead.
+#BACKEND_URL=http://127.0.0.1:7331
+#BACKEND_PORT=7331
+
 # Generate with: openssl rand -hex 32
 SECRET_KEY=changethisinproduction
 
@@ -14,6 +19,8 @@ REGISTRATION_MAX_ALLOWED_USERS=5
 # Uncomment to enable, and fill in the SMTP settings below to send emails
 # If SMTP settings are provided, it will also enable the reset password link on the login page
 #REQUIRE_EMAIL_VALIDATION=true
+# Public URL of the Astro frontend. Required for email links/OIDC redirects and
+# is the only browser origin FastAPI permits for direct API requests.
 #SERVER_URL=https://scrob.example.com
 #SMTP_ADDRESS=smtp.gmail.com
 #SMTP_PORT=587

--- a/README.md
+++ b/README.md
@@ -294,7 +294,9 @@ Database migrations run automatically on startup - no manual steps required.
 | `TZ` | `UTC` | Container timezone (e.g. `Europe/Lisbon`). |
 | `PUID` | `1000` | User ID to run the process as. |
 | `PGID` | `1000` | Group ID to run the process as. |
-| `BACKEND_PORT` | `7331` | Internal port the backend binds to. Override only if `7331` conflicts on bare metal. |
+| `BACKEND_URL` | `http://127.0.0.1:7331` | Runtime URL Astro uses to reach FastAPI. Set this when frontend and backend are on different hosts or the backend has a non-loopback address. Must be an `http://` or `https://` origin with no path or credentials. |
+| `BACKEND_PORT` | `7331` | Backwards-compatible loopback-port override when `BACKEND_URL` is unset. Must be between `1` and `65535`. |
+| `SERVER_URL` | `http://localhost:7330` | Public URL of the Astro frontend. Set it on public deployments; FastAPI uses it for email/OIDC links and its direct-API CORS allowlist. |
 | `OIDC_ENABLED` | `false` | Enable OIDC login. |
 | `OIDC_DISABLE_PASSWORD_LOGIN` | `false` | Enforce OIDC-only login (disables username/password). |
 
@@ -310,6 +312,34 @@ scrob.yourdomain.com {
     reverse_proxy localhost:7330
 }
 ```
+
+### Bare-metal installation
+
+The supported bare-metal topology keeps FastAPI private and lets Astro proxy
+all browser API requests, so no browser credentials or CORS relaxation is
+needed. Install Node.js 22+ and [uv](https://docs.astral.sh/uv/), provision
+PostgreSQL, then copy `.env.example` to `.env` and set `DATABASE_URL`,
+`SECRET_KEY`, and the public `SERVER_URL`.
+
+```bash
+# terminal 1 — FastAPI stays on loopback
+cd backend
+uv sync --frozen
+uv run alembic upgrade head
+uv run uvicorn main:app --host 127.0.0.1 --port 7331
+
+# terminal 2 — Astro reads BACKEND_URL/BACKEND_PORT at process start
+cd frontend
+npm ci
+npm run build
+HOST=127.0.0.1 PORT=7330 BACKEND_URL=http://127.0.0.1:7331 node dist/server/entry.mjs
+```
+
+Put Caddy, Nginx, or another HTTPS reverse proxy in front of port `7330`.
+If FastAPI is on another host, set `BACKEND_URL=https://backend.internal.example`
+for the Astro process and protect that backend network path independently.
+Do not expose FastAPI just to make the frontend work; browser traffic should
+continue through `/api/proxy/`.
 
 ### External PostgreSQL
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",
+    "test": "node --test test/*.test.mjs",
     "preview": "astro preview",
     "astro": "astro"
   },

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,5 +1,4 @@
-const BACKEND_PORT = (import.meta.env.BACKEND_PORT as string | undefined) ?? "7331";
-const BASE = `http://localhost:${BACKEND_PORT}`;
+import { backendUrl as BASE } from "./backend-url.mjs";
 
 type ParamValue = string | number | boolean | undefined;
 

--- a/frontend/src/lib/backend-proxy.ts
+++ b/frontend/src/lib/backend-proxy.ts
@@ -1,5 +1,4 @@
-const BACKEND_PORT = (import.meta.env.BACKEND_PORT as string | undefined) ?? "7331";
-const BACKEND = `http://localhost:${BACKEND_PORT}`;
+import { backendPath } from "./backend-url.mjs";
 
 // Passes a backend path straight through byte-for-byte. Used for FastAPI's
 // built-in docs (/docs, /redoc, /openapi.json) — their generated HTML embeds
@@ -13,7 +12,7 @@ const BACKEND = `http://localhost:${BACKEND_PORT}`;
 export async function proxyBackendPath(path: string, token?: string): Promise<Response> {
   const headers = new Headers();
   if (token) headers.set("Authorization", `Bearer ${token}`);
-  const res = await fetch(`${BACKEND}${path}`, { headers });
+  const res = await fetch(backendPath(path), { headers });
   const responseHeaders = new Headers();
   const contentType = res.headers.get("Content-Type");
   if (contentType) responseHeaders.set("Content-Type", contentType);

--- a/frontend/src/lib/backend-url.mjs
+++ b/frontend/src/lib/backend-url.mjs
@@ -1,0 +1,53 @@
+const DEFAULT_BACKEND_PORT = 7331;
+
+/**
+ * Resolve the server-to-server URL used by Astro's SSR/API proxy.
+ *
+ * `BACKEND_URL` is the preferred runtime setting. `BACKEND_PORT` remains a
+ * backwards-compatible shortcut for a backend listening on this host's
+ * loopback interface. Keeping the default on loopback means the backend does
+ * not become publicly reachable merely because the frontend is deployed.
+ */
+export function resolveBackendUrl(environment = process.env) {
+  const configuredUrl = environment.BACKEND_URL?.trim();
+  if (configuredUrl) {
+    let parsed;
+    try {
+      parsed = new URL(configuredUrl);
+    } catch {
+      throw new Error("BACKEND_URL must be an absolute http:// or https:// URL");
+    }
+
+    if (
+      !["http:", "https:"].includes(parsed.protocol) ||
+      !parsed.hostname ||
+      parsed.username ||
+      parsed.password ||
+      (parsed.pathname !== "/" && parsed.pathname !== "") ||
+      parsed.search ||
+      parsed.hash
+    ) {
+      throw new Error(
+        "BACKEND_URL must be an http:// or https:// origin without credentials, a path, query, or fragment"
+      );
+    }
+    return parsed.origin;
+  }
+
+  const configuredPort = environment.BACKEND_PORT?.trim();
+  const port = configuredPort === undefined || configuredPort === "" ? DEFAULT_BACKEND_PORT : Number(configuredPort);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new Error("BACKEND_PORT must be an integer between 1 and 65535");
+  }
+  return `http://127.0.0.1:${port}`;
+}
+
+// Astro/Vite supplies .env values through import.meta.env in development and
+// at build time. In a standalone production build, process.env is the runtime
+// source of truth so an image/service can be configured without rebuilding.
+const buildEnvironment = typeof import.meta.env === "object" ? import.meta.env : {};
+export const backendUrl = resolveBackendUrl({ ...buildEnvironment, ...process.env });
+
+export function backendPath(path) {
+  return `${backendUrl}${path.startsWith("/") ? path : `/${path}`}`;
+}

--- a/frontend/src/pages/api/proxy/[...path].ts
+++ b/frontend/src/pages/api/proxy/[...path].ts
@@ -1,7 +1,5 @@
 import type { APIRoute } from "astro";
-
-const BACKEND_PORT = (import.meta.env.BACKEND_PORT as string | undefined) ?? "7331";
-const BACKEND = `http://localhost:${BACKEND_PORT}`;
+import { backendPath } from "../../../lib/backend-url.mjs";
 
 // This proxy is a generic catch-all for every backend path, so a redirect
 // passed straight through to the browser must be pinned to hosts we actually
@@ -13,7 +11,7 @@ const ALLOWED_REDIRECT_HOSTS = new Set(["image.tmdb.org"]);
 async function handle({ params, request }: Parameters<APIRoute>[0]): Promise<Response> {
   const path = params.path ?? "";
   const search = new URL(request.url).search;
-  const backendUrl = `${BACKEND}/${path}${search}`;
+  const backendUrl = backendPath(`/${path}${search}`);
 
   const forwardHeaders = new Headers();
 

--- a/frontend/src/pages/recently-watched-movies/[id].astro
+++ b/frontend/src/pages/recently-watched-movies/[id].astro
@@ -2,6 +2,7 @@
 import Base from "../../layouts/Base.astro";
 import Pagination from "../../components/Pagination.astro";
 import { api, type ProfileWatchedItem, tmdbImageUrl } from "../../lib/api";
+import { backendPath } from "../../lib/backend-url.mjs";
 
 export const prerender = false;
 
@@ -17,7 +18,7 @@ let accessError = "";
 
 try {
   const res = await fetch(
-    `http://localhost:${import.meta.env.BACKEND_PORT ?? "7331"}/profile/${id}`,
+    backendPath(`/profile/${id}`),
     token ? { headers: { Authorization: `Bearer ${token}` } } : {}
   );
   if (res.status === 404) accessError = "User not found.";

--- a/frontend/src/pages/recently-watched-shows/[id].astro
+++ b/frontend/src/pages/recently-watched-shows/[id].astro
@@ -2,6 +2,7 @@
 import Base from "../../layouts/Base.astro";
 import Pagination from "../../components/Pagination.astro";
 import { api, type ProfileWatchedItem, tmdbImageUrl } from "../../lib/api";
+import { backendPath } from "../../lib/backend-url.mjs";
 
 export const prerender = false;
 
@@ -17,7 +18,7 @@ let accessError = "";
 
 try {
   const res = await fetch(
-    `http://localhost:${import.meta.env.BACKEND_PORT ?? "7331"}/profile/${id}`,
+    backendPath(`/profile/${id}`),
     token ? { headers: { Authorization: `Bearer ${token}` } } : {}
   );
   if (res.status === 404) accessError = "User not found.";

--- a/frontend/src/pages/stats/[id].astro
+++ b/frontend/src/pages/stats/[id].astro
@@ -1,5 +1,6 @@
 ---
 import Base from "../../layouts/Base.astro";
+import { backendPath } from "../../lib/backend-url.mjs";
 export const prerender = false;
 
 const { id } = Astro.params;
@@ -11,7 +12,7 @@ let accessError = "";
 
 try {
   const res = await fetch(
-    `http://localhost:${import.meta.env.BACKEND_PORT ?? "7331"}/profile/${id}`,
+    backendPath(`/profile/${id}`),
     token ? { headers: { Authorization: `Bearer ${token}` } } : {}
   );
   if (res.status === 404) accessError = "User not found.";

--- a/frontend/src/pages/top-rated-movies/[id].astro
+++ b/frontend/src/pages/top-rated-movies/[id].astro
@@ -2,6 +2,7 @@
 import Base from "../../layouts/Base.astro";
 import Pagination from "../../components/Pagination.astro";
 import { api, type ProfileRatedItem, tmdbImageUrl } from "../../lib/api";
+import { backendPath } from "../../lib/backend-url.mjs";
 
 export const prerender = false;
 
@@ -17,7 +18,7 @@ let accessError = "";
 
 try {
   const res = await fetch(
-    `http://localhost:${import.meta.env.BACKEND_PORT ?? "7331"}/profile/${id}`,
+    backendPath(`/profile/${id}`),
     token ? { headers: { Authorization: `Bearer ${token}` } } : {}
   );
   if (res.status === 404) accessError = "User not found.";

--- a/frontend/src/pages/top-rated-shows/[id].astro
+++ b/frontend/src/pages/top-rated-shows/[id].astro
@@ -2,6 +2,7 @@
 import Base from "../../layouts/Base.astro";
 import Pagination from "../../components/Pagination.astro";
 import { api, type ProfileRatedItem, tmdbImageUrl } from "../../lib/api";
+import { backendPath } from "../../lib/backend-url.mjs";
 
 export const prerender = false;
 
@@ -17,7 +18,7 @@ let accessError = "";
 
 try {
   const res = await fetch(
-    `http://localhost:${import.meta.env.BACKEND_PORT ?? "7331"}/profile/${id}`,
+    backendPath(`/profile/${id}`),
     token ? { headers: { Authorization: `Bearer ${token}` } } : {}
   );
   if (res.status === 404) accessError = "User not found.";

--- a/frontend/test/backend-url.test.mjs
+++ b/frontend/test/backend-url.test.mjs
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { resolveBackendUrl } from "../src/lib/backend-url.mjs";
+
+test("uses the loopback default when no backend environment is configured", () => {
+  assert.equal(resolveBackendUrl({}), "http://127.0.0.1:7331");
+});
+
+test("uses BACKEND_PORT at runtime for a loopback backend", () => {
+  assert.equal(resolveBackendUrl({ BACKEND_PORT: "8123" }), "http://127.0.0.1:8123");
+});
+
+test("BACKEND_URL overrides BACKEND_PORT for a separately hosted backend", () => {
+  assert.equal(
+    resolveBackendUrl({ BACKEND_URL: "https://api.scrob.example", BACKEND_PORT: "8123" }),
+    "https://api.scrob.example"
+  );
+});
+
+for (const environment of [
+  { BACKEND_PORT: "0" },
+  { BACKEND_PORT: "7331.5" },
+  { BACKEND_PORT: "not-a-port" },
+  { BACKEND_URL: "api.scrob.example" },
+  { BACKEND_URL: "ftp://api.scrob.example" },
+  { BACKEND_URL: "https://api.scrob.example/v1" },
+  { BACKEND_URL: "https://user:secret@api.scrob.example" },
+]) {
+  test(`rejects invalid backend configuration ${JSON.stringify(environment)}`, () => {
+    assert.throws(() => resolveBackendUrl(environment));
+  });
+}


### PR DESCRIPTION
## Summary

- centralize every Astro SSR/proxy backend target in one validated runtime resolver
- prefer BACKEND_URL for split-host installs while retaining BACKEND_PORT as a loopback shortcut
- read production process environment at server startup instead of baking the default port into the frontend build
- preserve the private 127.0.0.1:7331 default and existing Docker behavior
- document a secure bare-metal startup path and the distinct roles of BACKEND_URL, BACKEND_PORT, and SERVER_URL

This deliberately does not duplicate PR #260 or expose FastAPI publicly; browser traffic continues through the Astro proxy.

Closes #109
Related to #260

## Verification

- npm test (10 tests passed)
- ASTRO_TELEMETRY_DISABLED=1 npm run build
- imported the built server chunk with BACKEND_PORT=8123 and BACKEND_URL=https://backend.internal.example; both runtime values resolved correctly
- git diff --check