### PR TITLE
feat(ui): add configurable spoiler controls

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",
+    "test": "node --test test/*.test.mjs",
     "preview": "astro preview",
     "astro": "astro"
   },

--- a/frontend/src/components/ActionBar.astro
+++ b/frontend/src/components/ActionBar.astro
@@ -190,6 +190,7 @@ const requestTitle = isMonitored
     {!listOnly && (
       <button
         data-action="rate"
+        data-spoiler="ratings"
         data-user-rating={userRating != null ? String(userRating) : ""}
         data-state={userRating != null ? "active" : "inactive"}
         title={userRating != null ? `Your rating: ${ratingLabel}/10` : "Rate this"}

--- a/frontend/src/components/CommentsSection.astro
+++ b/frontend/src/components/CommentsSection.astro
@@ -151,6 +151,7 @@ try {
                 </div>
                 <!-- Spoiler wrapper: always present, overlay toggled via JS -->
                 <div class="comment-body relative">
+                  <!-- Comments have an explicit author-selected spoiler flag; global media controls do not hide unflagged discussion. -->
                   <p class={`comment-text text-zinc-300 leading-relaxed font-medium whitespace-pre-wrap break-words${comment.is_spoiler ? ' blur-sm select-none pointer-events-none' : ''}`}>{comment.content}</p>
                   <div class={`spoiler-overlay absolute inset-0 flex items-center justify-center rounded-lg cursor-pointer bg-zinc-950/70 backdrop-blur-sm${comment.is_spoiler ? '' : ' hidden'}`}>
                     <span class="text-amber-400 font-bold text-sm">Click to reveal</span>

--- a/frontend/src/components/EpisodeCard.astro
+++ b/frontend/src/components/EpisodeCard.astro
@@ -6,9 +6,10 @@ import { episodeHref } from "../lib/episodeHref";
 
 interface Props {
   item: MediaItem;
+  spoilerNext?: boolean;
 }
 
-const { item } = Astro.props;
+const { item, spoilerNext = false } = Astro.props;
 
 const sxe =
   item.season_number != null && item.episode_number != null
@@ -49,7 +50,7 @@ const collectionPct = item.collection_pct ?? (inLibrary ? 100 : 0);
   {href ? (
     <a href={href} class="block">
       <!-- Backdrop container: 3:2 (no title info here — info is below action bar) -->
-      <div class="aspect-[3/2] bg-zinc-950 relative overflow-hidden ring-1 ring-white/5 group-hover:ring-blue-500/30 transition-all duration-300">
+      <div data-spoiler={spoilerNext ? "next" : undefined} class="aspect-[3/2] bg-zinc-950 relative overflow-hidden ring-1 ring-white/5 group-hover:ring-blue-500/30 transition-all duration-300">
         {imageUrl ? (
           <img
             src={imageUrl}
@@ -83,7 +84,7 @@ const collectionPct = item.collection_pct ?? (inLibrary ? 100 : 0);
   ) : (
     <div class="block">
       <!-- Backdrop container: no link when metadata is incomplete -->
-      <div class="aspect-[3/2] bg-zinc-950 relative overflow-hidden ring-1 ring-white/5">
+      <div data-spoiler={spoilerNext ? "next" : undefined} class="aspect-[3/2] bg-zinc-950 relative overflow-hidden ring-1 ring-white/5">
         {imageUrl ? (
           <img
             src={imageUrl}
@@ -136,7 +137,7 @@ const collectionPct = item.collection_pct ?? (inLibrary ? 100 : 0);
       {item.show_title && (
         <p class="text-xs font-medium text-zinc-400 truncate mb-0.5">{item.show_title}</p>
       )}
-      <h3 class="text-sm font-bold text-zinc-100 truncate group-hover:text-blue-300 transition-colors leading-tight">
+      <h3 data-spoiler={spoilerNext ? "next" : undefined} class="text-sm font-bold text-zinc-100 truncate group-hover:text-blue-300 transition-colors leading-tight">
         {item.title}
       </h3>
       {sxe && <span class="text-[11px] font-bold text-blue-400 tracking-wide mt-0.5 block">{sxe}</span>}
@@ -146,7 +147,7 @@ const collectionPct = item.collection_pct ?? (inLibrary ? 100 : 0);
       {item.show_title && (
         <p class="text-xs font-medium text-zinc-400 truncate mb-0.5">{item.show_title}</p>
       )}
-      <h3 class="text-sm font-bold text-zinc-500 truncate leading-tight">
+      <h3 data-spoiler={spoilerNext ? "next" : undefined} class="text-sm font-bold text-zinc-500 truncate leading-tight">
         {item.title}
       </h3>
       {sxe && <span class="text-[11px] font-bold text-zinc-400 tracking-wide mt-0.5 block">{sxe}</span>}

--- a/frontend/src/components/HistoryCard.astro
+++ b/frontend/src/components/HistoryCard.astro
@@ -57,7 +57,7 @@ const href = isEpisode ? episodeHref(media) : `/media/movie/${media.tmdb_id}`;
           {timeString}
         </span>
         {media.user_rating != null && (
-          <span class="flex items-center gap-0.5 text-xs font-bold text-amber-400">
+          <span data-spoiler="ratings" class="flex items-center gap-0.5 text-xs font-bold text-amber-400">
             <svg xmlns="http://www.w3.org/2000/svg" width="11" height="11" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
             {media.user_rating % 1 === 0 ? media.user_rating : media.user_rating.toFixed(1)}
           </span>

--- a/frontend/src/components/MediaCard.astro
+++ b/frontend/src/components/MediaCard.astro
@@ -6,9 +6,10 @@ import { episodeHref } from "../lib/episodeHref";
 
 interface Props {
   item: MediaItem;
+  spoilerNext?: boolean;
 }
 
-const { item } = Astro.props;
+const { item, spoilerNext = false } = Astro.props;
 const { user } = Astro.locals;
 
 const isPerson = item.type === "person";
@@ -61,7 +62,7 @@ const inLibrary = item.in_library ?? false;
   <!-- Clickable poster -->
   {href ? (
     <a href={href} class="block">
-      <div class="aspect-[2/3] bg-zinc-950 relative overflow-hidden ring-1 ring-white/5 group-hover:ring-blue-500/30 transition-all duration-300" data-adult={item.adult ? "true" : undefined}>
+      <div class="aspect-[2/3] bg-zinc-950 relative overflow-hidden ring-1 ring-white/5 group-hover:ring-blue-500/30 transition-all duration-300" data-adult={item.adult ? "true" : undefined} data-spoiler={spoilerNext && isEpisode ? "next" : undefined}>
         {posterPath ? (
           <>
             <img
@@ -87,7 +88,7 @@ const inLibrary = item.in_library ?? false;
         <div class="absolute inset-0 bg-gradient-to-t from-black/80 via-transparent to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
 
         {rating && (
-          <div class="absolute top-2 left-2 bg-black/80 backdrop-blur-md text-yellow-400 text-xs font-bold px-2 py-0.5 rounded-full shadow-lg border border-zinc-800 flex items-center gap-1">
+          <div data-spoiler="ratings" class="absolute top-2 left-2 bg-black/80 backdrop-blur-md text-yellow-400 text-xs font-bold px-2 py-0.5 rounded-full shadow-lg border border-zinc-800 flex items-center gap-1">
             <span class="text-xs leading-none">★</span> {rating}
           </div>
         )}
@@ -101,7 +102,7 @@ const inLibrary = item.in_library ?? false;
     </a>
   ) : (
     <div class="block">
-      <div class="aspect-[2/3] bg-zinc-950 relative overflow-hidden ring-1 ring-white/5" data-adult={item.adult ? "true" : undefined}>
+      <div class="aspect-[2/3] bg-zinc-950 relative overflow-hidden ring-1 ring-white/5" data-adult={item.adult ? "true" : undefined} data-spoiler={spoilerNext && isEpisode ? "next" : undefined}>
         {posterPath ? (
           <img
             src={posterPath}
@@ -117,7 +118,7 @@ const inLibrary = item.in_library ?? false;
           </div>
         )}
         {rating && (
-          <div class="absolute top-2 left-2 bg-black/80 backdrop-blur-md text-yellow-400 text-xs font-bold px-2 py-0.5 rounded-full shadow-lg border border-zinc-800 flex items-center gap-1">
+          <div data-spoiler="ratings" class="absolute top-2 left-2 bg-black/80 backdrop-blur-md text-yellow-400 text-xs font-bold px-2 py-0.5 rounded-full shadow-lg border border-zinc-800 flex items-center gap-1">
             <span class="text-xs leading-none">★</span> {rating}
           </div>
         )}
@@ -145,7 +146,7 @@ const inLibrary = item.in_library ?? false;
       {(isEpisode || isSeason) && item.show_title ? (
         <h3 class="text-xs font-medium text-zinc-400 truncate mb-0.5">{item.show_title}</h3>
       ) : null}
-      <h3 class="text-sm font-bold text-zinc-100 truncate group-hover:text-blue-400 transition-colors leading-tight mb-1">{cardTitle}</h3>
+      <h3 data-spoiler={spoilerNext && isEpisode ? "next" : undefined} class="text-sm font-bold text-zinc-100 truncate group-hover:text-blue-400 transition-colors leading-tight mb-1">{cardTitle}</h3>
       <div class="flex items-center justify-between">
         <div class="flex items-center gap-2">
           {sxe && <span class="text-[11px] font-bold text-blue-400 tracking-wide">{sxe}</span>}
@@ -164,7 +165,7 @@ const inLibrary = item.in_library ?? false;
       {(isEpisode || isSeason) && item.show_title ? (
         <h3 class="text-xs font-medium text-zinc-400 truncate mb-0.5">{item.show_title}</h3>
       ) : null}
-      <h3 class="text-sm font-bold text-zinc-500 truncate leading-tight mb-1">{cardTitle}</h3>
+      <h3 data-spoiler={spoilerNext && isEpisode ? "next" : undefined} class="text-sm font-bold text-zinc-500 truncate leading-tight mb-1">{cardTitle}</h3>
       <div class="flex items-center justify-between">
         <div class="flex items-center gap-2">
           {sxe && <span class="text-[11px] font-bold text-zinc-400 tracking-wide">{sxe}</span>}
@@ -177,4 +178,3 @@ const inLibrary = item.in_library ?? false;
     </div>
   )}
 </div>
-

--- a/frontend/src/layouts/Base.astro
+++ b/frontend/src/layouts/Base.astro
@@ -531,7 +531,22 @@ const bottomNavItem = (active: boolean) =>
       if (active.length) document.documentElement.setAttribute('data-spoilers', active.join(' ')); else document.documentElement.removeAttribute('data-spoilers');
       if (reset) document.querySelectorAll('[data-spoiler-revealed]').forEach(node => node.removeAttribute('data-spoiler-revealed'));
       spoilerToggles.forEach(toggle => { toggle.checked = spoilerControls[toggle.dataset.spoilerToggle || ''] === true; });
-      document.querySelectorAll<HTMLElement>('[data-spoiler]').forEach(node => { const enabled = spoilerControls[node.dataset.spoiler || '']; node.tabIndex = enabled ? 0 : -1; if (enabled) { node.setAttribute('role', 'button'); node.setAttribute('aria-label', `Reveal hidden ${node.dataset.spoiler}`); } else { node.removeAttribute('role'); node.removeAttribute('aria-label'); } });
+      document.querySelectorAll<HTMLElement>('[data-spoiler]').forEach(node => {
+        const enabled = spoilerControls[node.dataset.spoiler || ''];
+        const interactive = node.closest('a, button');
+        const nativeControl = node.matches('a, button, input, select, textarea');
+        // A nested faux button inside a link is invalid. Native controls retain
+        // their own keyboard behavior; non-interactive content becomes a reveal trigger.
+        if (enabled && !interactive) {
+          node.tabIndex = 0;
+          node.setAttribute('role', 'button');
+          node.setAttribute('aria-label', `Reveal hidden ${node.dataset.spoiler}`);
+        } else {
+          if (!nativeControl) node.tabIndex = -1;
+          node.removeAttribute('role');
+          node.removeAttribute('aria-label');
+        }
+      });
     }
     syncSpoilerControls();
     document.addEventListener('spoiler-content-added', () => syncSpoilerControls());
@@ -539,9 +554,20 @@ const bottomNavItem = (active: boolean) =>
     spoilerPanel?.addEventListener('click', event => event.stopPropagation());
     spoilerToggles.forEach(toggle => toggle.addEventListener('change', () => { spoilerControls[toggle.dataset.spoilerToggle || ''] = toggle.checked; try { localStorage.setItem(SPOILER_KEY, JSON.stringify(spoilerControls)); } catch {} syncSpoilerControls(true); }));
     document.addEventListener('click', () => { spoilerPanel?.classList.add('hidden'); spoilerBtn?.setAttribute('aria-expanded', 'false'); });
-    function reveal(node: HTMLElement) { if (spoilerControls[node.dataset.spoiler || '']) node.dataset.spoilerRevealed = 'true'; }
+    function reveal(node: HTMLElement) {
+      const category = node.dataset.spoiler || '';
+      if (!spoilerControls[category]) return;
+      const interactive = node.closest('a, button');
+      // Reveal every matching marker inside the same native control. This lets
+      // the link's first Enter/click reveal and its second activation navigate.
+      if (interactive) {
+        if (interactive === node) node.dataset.spoilerRevealed = 'true';
+        interactive.querySelectorAll<HTMLElement>('[data-spoiler]').forEach(marker => { if (marker.dataset.spoiler === category) marker.dataset.spoilerRevealed = 'true'; });
+      }
+      else node.dataset.spoilerRevealed = 'true';
+    }
     document.addEventListener('click', event => { const node = (event.target as Element).closest<HTMLElement>('[data-spoiler]'); if (node && spoilerControls[node.dataset.spoiler || ''] && node.dataset.spoilerRevealed !== 'true') { event.preventDefault(); event.stopPropagation(); reveal(node); } }, true);
-    document.addEventListener('keydown', event => { if (event.key === 'Escape') { const wasOpen = !!spoilerPanel && !spoilerPanel.classList.contains('hidden'); spoilerPanel?.classList.add('hidden'); spoilerBtn?.setAttribute('aria-expanded', 'false'); if (wasOpen) spoilerBtn?.focus(); return; } const node = event.target instanceof Element ? event.target.closest<HTMLElement>('[data-spoiler]') : null; if (node && (event.key === 'Enter' || event.key === ' ') && spoilerControls[node.dataset.spoiler || '']) { event.preventDefault(); reveal(node); } });
+    document.addEventListener('keydown', event => { if (event.key === 'Escape') { const wasOpen = !!spoilerPanel && !spoilerPanel.classList.contains('hidden'); spoilerPanel?.classList.add('hidden'); spoilerBtn?.setAttribute('aria-expanded', 'false'); if (wasOpen) spoilerBtn?.focus(); return; } const target = event.target instanceof Element ? event.target : null; const node = target?.closest<HTMLElement>('[data-spoiler]') || Array.from(target?.matches('a, button') ? target.querySelectorAll<HTMLElement>('[data-spoiler]') : []).find(marker => spoilerControls[marker.dataset.spoiler || ''] && marker.dataset.spoilerRevealed !== 'true'); if (node && node.dataset.spoilerRevealed !== 'true' && (event.key === 'Enter' || event.key === ' ') && spoilerControls[node.dataset.spoiler || '']) { event.preventDefault(); reveal(node); } });
 
     // ── Theme toggle ───────────────────────────────────────────────────────────
     const themeToggle = document.getElementById('theme-toggle');

--- a/frontend/src/layouts/Base.astro
+++ b/frontend/src/layouts/Base.astro
@@ -71,6 +71,11 @@ const bottomNavItem = (active: boolean) =>
     #sun-icon { display: none; }
     html.light #sun-icon { display: inline; }
     html.light #moon-icon { display: none; }
+    html[data-spoilers~="ratings"] [data-spoiler="ratings"]:not([data-spoiler-revealed="true"]),
+    html[data-spoilers~="descriptions"] [data-spoiler="descriptions"]:not([data-spoiler-revealed="true"]),
+    html[data-spoilers~="runtime"] [data-spoiler="runtime"]:not([data-spoiler-revealed="true"]),
+    html[data-spoilers~="next"] [data-spoiler="next"]:not([data-spoiler-revealed="true"]) { filter: blur(.55rem); opacity: .65; cursor: pointer; }
+    [data-spoiler][role="button"]:focus-visible { outline: 2px solid #60a5fa; outline-offset: 3px; }
   </style>
   <script is:inline>
     // Theme initialization to avoid FOUC
@@ -97,6 +102,12 @@ const bottomNavItem = (active: boolean) =>
     } else {
       document.documentElement.removeAttribute('data-accent');
     }
+    try {
+      const parsed = JSON.parse(localStorage.getItem('spoilerControls') || '{}');
+      const saved = parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {};
+      const active = ['ratings', 'descriptions', 'runtime', 'next'].filter(function (key) { return saved[key] === true; });
+      if (active.length) document.documentElement.setAttribute('data-spoilers', active.join(' '));
+    } catch {}
 
     // TMDB image fallback — registered here (head, inline) so the capture-phase
     // listener is active before any <img> tags are parsed and start loading.
@@ -171,6 +182,18 @@ const bottomNavItem = (active: boolean) =>
               <svg xmlns="http://www.w3.org/2000/svg" width="19" height="19" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/></svg>
             </button>
           )}
+          <div class="relative">
+            <button id="spoiler-controls-btn" class="p-3 rounded-xl bg-zinc-900 border border-zinc-800 text-zinc-400 hover:text-zinc-100 transition-colors" aria-label="Spoiler controls" aria-expanded="false" aria-controls="spoiler-controls">Spoilers</button>
+            <div id="spoiler-controls" class="hidden absolute right-0 top-full mt-2 z-50 w-72 bg-zinc-900 border border-zinc-700 rounded-2xl shadow-2xl p-4" role="group" aria-label="Spoiler controls">
+              <p class="text-sm font-bold text-zinc-100">Spoiler controls</p><p class="text-xs text-zinc-400 mt-1 mb-3">Stored in this browser. Tap hidden content to reveal it for this page.</p>
+              <div class="space-y-2">
+                <label class="flex justify-between gap-3 text-sm text-zinc-300 cursor-pointer">Ratings <input data-spoiler-toggle="ratings" type="checkbox" class="w-4 accent-blue-500" /></label>
+                <label class="flex justify-between gap-3 text-sm text-zinc-300 cursor-pointer">Descriptions <input data-spoiler-toggle="descriptions" type="checkbox" class="w-4 accent-blue-500" /></label>
+                <label class="flex justify-between gap-3 text-sm text-zinc-300 cursor-pointer">Runtime <input data-spoiler-toggle="runtime" type="checkbox" class="w-4 accent-blue-500" /></label>
+                <label class="flex justify-between gap-3 text-sm text-zinc-300 cursor-pointer">Next episode title &amp; images <input data-spoiler-toggle="next" type="checkbox" class="w-4 accent-blue-500" /></label>
+              </div>
+            </div>
+          </div>
           <!-- Theme toggle -->
           <button id="theme-toggle" class="p-3 rounded-xl bg-zinc-900 border border-zinc-800 text-zinc-400 hover:text-zinc-100 transition-all hover:scale-110 active:scale-95" aria-label="Toggle Theme">
             <span id="sun-icon">
@@ -494,6 +517,32 @@ const bottomNavItem = (active: boolean) =>
   </div>
 
   <script>
+    const SPOILER_KEY = 'spoilerControls';
+    const spoilerBtn = document.getElementById('spoiler-controls-btn') as HTMLButtonElement | null;
+    const spoilerPanel = document.getElementById('spoiler-controls');
+    const spoilerToggles = Array.from(document.querySelectorAll<HTMLInputElement>('[data-spoiler-toggle]'));
+    let spoilerControls: Record<string, boolean> = {};
+    try {
+      const parsed = JSON.parse(localStorage.getItem(SPOILER_KEY) || '{}');
+      spoilerControls = parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {};
+    } catch {}
+    function syncSpoilerControls(reset = false) {
+      const active = ['ratings', 'descriptions', 'runtime', 'next'].filter(key => spoilerControls[key]);
+      if (active.length) document.documentElement.setAttribute('data-spoilers', active.join(' ')); else document.documentElement.removeAttribute('data-spoilers');
+      if (reset) document.querySelectorAll('[data-spoiler-revealed]').forEach(node => node.removeAttribute('data-spoiler-revealed'));
+      spoilerToggles.forEach(toggle => { toggle.checked = spoilerControls[toggle.dataset.spoilerToggle || ''] === true; });
+      document.querySelectorAll<HTMLElement>('[data-spoiler]').forEach(node => { const enabled = spoilerControls[node.dataset.spoiler || '']; node.tabIndex = enabled ? 0 : -1; if (enabled) { node.setAttribute('role', 'button'); node.setAttribute('aria-label', `Reveal hidden ${node.dataset.spoiler}`); } else { node.removeAttribute('role'); node.removeAttribute('aria-label'); } });
+    }
+    syncSpoilerControls();
+    document.addEventListener('spoiler-content-added', () => syncSpoilerControls());
+    spoilerBtn?.addEventListener('click', event => { event.stopPropagation(); const hidden = spoilerPanel?.classList.toggle('hidden'); spoilerBtn.setAttribute('aria-expanded', String(hidden === false)); });
+    spoilerPanel?.addEventListener('click', event => event.stopPropagation());
+    spoilerToggles.forEach(toggle => toggle.addEventListener('change', () => { spoilerControls[toggle.dataset.spoilerToggle || ''] = toggle.checked; try { localStorage.setItem(SPOILER_KEY, JSON.stringify(spoilerControls)); } catch {} syncSpoilerControls(true); }));
+    document.addEventListener('click', () => { spoilerPanel?.classList.add('hidden'); spoilerBtn?.setAttribute('aria-expanded', 'false'); });
+    function reveal(node: HTMLElement) { if (spoilerControls[node.dataset.spoiler || '']) node.dataset.spoilerRevealed = 'true'; }
+    document.addEventListener('click', event => { const node = (event.target as Element).closest<HTMLElement>('[data-spoiler]'); if (node && spoilerControls[node.dataset.spoiler || ''] && node.dataset.spoilerRevealed !== 'true') { event.preventDefault(); event.stopPropagation(); reveal(node); } }, true);
+    document.addEventListener('keydown', event => { if (event.key === 'Escape') { const wasOpen = !!spoilerPanel && !spoilerPanel.classList.contains('hidden'); spoilerPanel?.classList.add('hidden'); spoilerBtn?.setAttribute('aria-expanded', 'false'); if (wasOpen) spoilerBtn?.focus(); return; } const node = event.target instanceof Element ? event.target.closest<HTMLElement>('[data-spoiler]') : null; if (node && (event.key === 'Enter' || event.key === ' ') && spoilerControls[node.dataset.spoiler || '']) { event.preventDefault(); reveal(node); } });
+
     // ── Theme toggle ───────────────────────────────────────────────────────────
     const themeToggle = document.getElementById('theme-toggle');
 

--- a/frontend/src/pages/index.astro
+++ b/frontend/src/pages/index.astro
@@ -145,7 +145,7 @@ const discoverBackdropUrl = discoverPick?.backdrop_path
           <div class="flex-1 flex items-end pb-6 sm:pb-8">
             <a href={heroHref} class="block max-w-2xl group">
               {hero.tmdb_rating != null && hero.tmdb_rating > 0 && (
-                <span class="inline-flex items-center gap-1.5 text-xs font-bold uppercase tracking-widest text-yellow-400 bg-yellow-500/10 border border-yellow-500/20 px-3 py-1 rounded-full mb-3">
+                <span data-spoiler="ratings" class="inline-flex items-center gap-1.5 text-xs font-bold uppercase tracking-widest text-yellow-400 bg-yellow-500/10 border border-yellow-500/20 px-3 py-1 rounded-full mb-3">
                   <span class="text-sm leading-none">★</span> {hero.tmdb_rating.toFixed(1)}
                 </span>
               )}
@@ -153,7 +153,7 @@ const discoverBackdropUrl = discoverPick?.backdrop_path
                 {hero.title}
               </h3>
               {hero.overview && (
-                <p class="text-sm sm:text-base text-zinc-300 font-medium line-clamp-2 max-w-lg drop-shadow">{hero.overview}</p>
+                <p data-spoiler="descriptions" class="text-sm sm:text-base text-zinc-300 font-medium line-clamp-2 max-w-lg drop-shadow">{hero.overview}</p>
               )}
             </a>
           </div>

--- a/frontend/src/pages/index.astro
+++ b/frontend/src/pages/index.astro
@@ -178,7 +178,7 @@ const discoverBackdropUrl = discoverPick?.backdrop_path
       </div>
       <div class="flex gap-3 overflow-x-auto pb-3 scrollbar-none -mx-6 px-6 md:mx-0 md:px-0">
         {nextUp.map((item) => (
-          <div class="flex-shrink-0 w-56"><EpisodeCard item={item} /></div>
+          <div class="flex-shrink-0 w-56"><EpisodeCard item={item} spoilerNext /></div>
         ))}
       </div>
     </section>
@@ -195,7 +195,7 @@ const discoverBackdropUrl = discoverPick?.backdrop_path
     const heroBackdrop = tmdbImageUrl(rawBackdrop, "w1280");
     return (
       <section class="relative md:-mt-8 mb-16">
-        <div class="absolute top-0 left-1/2 -translate-x-1/2 w-screen overflow-hidden pointer-events-none" style="height: 100%;">
+        <div data-spoiler="next" class="absolute top-0 left-1/2 -translate-x-1/2 w-screen overflow-hidden" style="height: 100%;">
           {heroBackdrop ? (
             <img
               src={heroBackdrop}
@@ -231,7 +231,7 @@ const discoverBackdropUrl = discoverPick?.backdrop_path
                 {hero.show_title ?? hero.title}
               </h3>
               {hero.show_title && (
-                <p class="text-sm sm:text-base text-zinc-300 font-medium truncate">{hero.title}</p>
+                <p data-spoiler="next" class="text-sm sm:text-base text-zinc-300 font-medium truncate">{hero.title}</p>
               )}
               {formatEpisodesLeft(hero.episodes_left, hero.remaining_runtime) && (
                 <p class="text-xs sm:text-sm text-zinc-400 font-medium mt-1.5 drop-shadow">
@@ -244,7 +244,7 @@ const discoverBackdropUrl = discoverPick?.backdrop_path
 
         {rest.length > 0 && (
           <div class="relative flex gap-3 overflow-x-auto pb-3 scrollbar-none pt-6 -mx-6 px-6 md:mx-0 md:px-0">
-            {rest.map((item) => <div class="flex-shrink-0 w-40"><MediaCard item={item} /></div>)}
+            {rest.map((item) => <div class="flex-shrink-0 w-40"><MediaCard item={item} spoilerNext /></div>)}
           </div>
         )}
       </section>

--- a/frontend/src/pages/media/[type]/[id].astro
+++ b/frontend/src/pages/media/[type]/[id].astro
@@ -139,12 +139,12 @@ const refreshUrl = isEpisode
               <div class="flex flex-wrap items-center gap-4 text-zinc-300 text-sm bg-zinc-900/40 p-3 rounded-xl border border-zinc-800/50 backdrop-blur-sm">
                 {year && <span class="font-bold">{year}</span>}
                 {rating && (
-                  <span class="flex items-center gap-1.5 text-yellow-400 font-black item-rating">
+                  <span data-spoiler="ratings" class="flex items-center gap-1.5 text-yellow-400 font-black item-rating">
                     <span class="text-lg leading-none">★</span> {rating}
                   </span>
                 )}
                 {item.runtime && (
-                  <span class="flex items-center gap-1.5 font-medium">
+                  <span data-spoiler="runtime" class="flex items-center gap-1.5 font-medium">
                     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor" class="w-4 h-4 text-zinc-500">
                       <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
                     </svg>
@@ -313,7 +313,7 @@ const refreshUrl = isEpisode
                 <span class="w-2 h-2 bg-blue-500 rounded-full"></span>
                 Overview
               </h2>
-              <p class="text-zinc-300 leading-relaxed text-lg max-w-4xl font-medium opacity-90">
+              <p data-spoiler="descriptions" class="text-zinc-300 leading-relaxed text-lg max-w-4xl font-medium opacity-90">
                 {item.overview}
               </p>
             </div>

--- a/frontend/src/pages/next-up.astro
+++ b/frontend/src/pages/next-up.astro
@@ -156,19 +156,19 @@ Astro.response.headers.set("Cache-Control", "no-store");
       <div class="${wrapperClass}" data-next-up-hidden="${isHidden ? 'true' : 'false'}">
         <div class="group relative flex flex-col rounded-2xl overflow-hidden bg-zinc-900 border border-zinc-800 hover:border-blue-500/50 hover:shadow-2xl hover:shadow-blue-900/20 transition-all duration-300 transform hover:-translate-y-1">
           <a href="${esc(href)}" class="block active:scale-95 active:opacity-70 transition-all duration-100">
-            <div class="aspect-[2/3] bg-zinc-950 relative overflow-hidden ring-1 ring-white/5 group-hover:ring-blue-500/30 transition-all duration-300">
+            <div data-spoiler="next" class="aspect-[2/3] bg-zinc-950 relative overflow-hidden ring-1 ring-white/5 group-hover:ring-blue-500/30 transition-all duration-300">
               ${posterSrc
                 ? `<img src="${esc(posterSrc)}" alt="${esc(item.show_title ?? item.title)}" class="w-full h-full object-cover group-hover:scale-110 transition-transform duration-500" loading="lazy" decoding="async" />`
                 : `<div class="w-full h-full flex flex-col items-center justify-center text-zinc-700 bg-zinc-900 p-4 text-center"><span class="text-3xl mb-2 opacity-30">📺</span><span class="text-xs font-bold uppercase tracking-widest">${esc(item.show_title ?? item.title)}</span></div>`
               }
               <div class="absolute inset-0 bg-gradient-to-t from-black/80 via-transparent to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
-              ${rating ? `<div class="absolute top-2 left-2 bg-black/80 backdrop-blur-md text-yellow-400 text-[10px] font-black px-2 py-0.5 rounded-full shadow-lg border border-zinc-800 flex items-center gap-1"><span class="text-xs leading-none">★</span> ${esc(rating)}</div>` : ''}
+              ${rating ? `<div data-spoiler="ratings" class="absolute top-2 left-2 bg-black/80 backdrop-blur-md text-yellow-400 text-[10px] font-black px-2 py-0.5 rounded-full shadow-lg border border-zinc-800 flex items-center gap-1"><span class="text-xs leading-none">★</span> ${esc(rating)}</div>` : ''}
             </div>
           </a>
           ${hideBtn}
           <a href="${esc(href)}" class="block p-3 bg-gradient-to-b from-zinc-900 to-zinc-950 flex-1">
             ${item.show_title ? `<h3 class="text-xs font-medium text-zinc-400 truncate mb-0.5">${esc(item.show_title)}</h3>` : ''}
-            <h3 class="text-sm font-bold text-zinc-100 group-hover:text-blue-400 truncate transition-colors leading-tight mb-1">${esc(item.title)}</h3>
+            <h3 data-spoiler="next" class="text-sm font-bold text-zinc-100 group-hover:text-blue-400 truncate transition-colors leading-tight mb-1">${esc(item.title)}</h3>
             ${sxe ? `<p class="text-[11px] font-bold text-blue-400 tracking-wide">${esc(sxe)}</p>` : ''}
             ${episodesLeftLabel(item) ? `<p class="text-[11px] text-zinc-500 font-medium mt-0.5">${esc(episodesLeftLabel(item))}</p>` : ''}
           </a>
@@ -180,6 +180,7 @@ Astro.response.headers.set("Cache-Control", "no-store");
   function renderGrid() {
     const grid = document.getElementById('next-up-grid');
     grid.innerHTML = sortedItems().map(buildCard).join('');
+    document.dispatchEvent(new Event('spoiler-content-added'));
     grid.classList.remove('hidden');
     updateEmptyState();
     bindHideButtons();

--- a/frontend/src/pages/show/[id].astro
+++ b/frontend/src/pages/show/[id].astro
@@ -120,7 +120,7 @@ const originalLanguage = show?.original_language
               <div class="flex flex-wrap items-center gap-4 text-zinc-300 text-sm bg-zinc-900/40 p-3 rounded-xl border border-zinc-800/50 backdrop-blur-sm">
                 {year && <span class="font-bold">{year}</span>}
                 {rating && (
-                  <span class="flex items-center gap-1.5 text-yellow-400 font-black">
+                  <span data-spoiler="ratings" class="flex items-center gap-1.5 text-yellow-400 font-black">
                     <span class="text-lg leading-none">★</span> {rating}
                   </span>
                 )}
@@ -216,7 +216,7 @@ const originalLanguage = show?.original_language
                 <span class="w-2 h-2 bg-blue-500 rounded-full"></span>
                 Overview
               </h2>
-              <p class="text-zinc-300 leading-relaxed text-lg max-w-4xl font-medium opacity-90">
+              <p data-spoiler="descriptions" class="text-zinc-300 leading-relaxed text-lg max-w-4xl font-medium opacity-90">
                 {show.overview}
               </p>
             </div>
@@ -286,7 +286,7 @@ const originalLanguage = show?.original_language
                             <div class="flex items-start justify-between gap-4 mb-1">
                                 <h3 class="text-xl font-black text-zinc-100 group-hover/season:text-blue-400 transition-colors">{s.name || `Season ${seasonNum}`}</h3>
                                 {s.tmdb_rating != null && s.tmdb_rating > 0 && (
-                                    <div class="bg-zinc-950 border border-zinc-800 px-2 py-1 rounded-xl flex items-center gap-1.5 shrink-0 shadow-sm">
+                                    <div data-spoiler="ratings" class="bg-zinc-950 border border-zinc-800 px-2 py-1 rounded-xl flex items-center gap-1.5 shrink-0 shadow-sm">
                                         <span class="text-yellow-400 text-xs">★</span>
                                         <span class="text-zinc-100 text-xs font-bold">{s.tmdb_rating.toFixed(1)}</span>
                                     </div>
@@ -297,7 +297,7 @@ const originalLanguage = show?.original_language
                                     {s.episode_count || episodes.length} Episodes
                                 </span>
                             </div>
-                            <p class="text-xs text-zinc-400 line-clamp-3 leading-relaxed opacity-80">{s.overview || "No overview available."}</p>
+                            <p data-spoiler="descriptions" class="text-xs text-zinc-400 line-clamp-3 leading-relaxed opacity-80">{s.overview || "No overview available."}</p>
                         </div>
                     </a>
                     {user && (

--- a/frontend/src/pages/show/[id]/season/[season_number].astro
+++ b/frontend/src/pages/show/[id]/season/[season_number].astro
@@ -126,7 +126,7 @@ const show = season?.show;
             <div class="flex flex-wrap justify-center md:justify-start items-center gap-4 text-zinc-400 text-sm mb-8 bg-zinc-900/40 p-3 rounded-xl border border-zinc-800/50 backdrop-blur-sm inline-flex">
               <span class="font-bold text-zinc-300">{season.episodes?.length || 0} Episodes</span>
               {season.tmdb_rating != null && season.tmdb_rating > 0 && (
-                <span class="flex items-center gap-1.5 text-yellow-400 font-black">
+                <span data-spoiler="ratings" class="flex items-center gap-1.5 text-yellow-400 font-black">
                   <span class="text-base leading-none">★</span> {season.tmdb_rating.toFixed(1)}
                 </span>
               )}
@@ -180,7 +180,7 @@ const show = season?.show;
                   <span class="w-2 h-2 bg-blue-500 rounded-full"></span>
                   Season Overview
                 </h2>
-                <p class="text-zinc-300 leading-relaxed text-lg opacity-90">{season.overview}</p>
+                <p data-spoiler="descriptions" class="text-zinc-300 leading-relaxed text-lg opacity-90">{season.overview}</p>
               </div>
             )}
           </div>
@@ -229,14 +229,14 @@ const show = season?.show;
                       </div>
 
                       {ep.tmdb_rating > 0 && (
-                        <div class="bg-zinc-950 border border-zinc-800 px-2 py-1 rounded-xl flex items-center gap-1.5 shrink-0 shadow-sm">
+                        <div data-spoiler="ratings" class="bg-zinc-950 border border-zinc-800 px-2 py-1 rounded-xl flex items-center gap-1.5 shrink-0 shadow-sm">
                           <span class="text-yellow-400 text-xs">★</span>
                           <span class="text-zinc-100 text-xs font-bold">{ep.tmdb_rating.toFixed(1)}</span>
                         </div>
                       )}
                     </div>
 
-                    <p class="text-zinc-400 text-sm leading-relaxed line-clamp-3 mb-4 opacity-80">
+                    <p data-spoiler="descriptions" class="text-zinc-400 text-sm leading-relaxed line-clamp-3 mb-4 opacity-80">
                       {ep.overview || "No overview available for this episode."}
                     </p>
 
@@ -245,7 +245,7 @@ const show = season?.show;
                         View Details
                        </span>
                        {ep.runtime && (
-                         <span class="text-[10px] font-black uppercase tracking-[0.2em] text-zinc-700 flex items-center gap-1.5">
+                         <span data-spoiler="runtime" class="text-[10px] font-black uppercase tracking-[0.2em] text-zinc-700 flex items-center gap-1.5">
                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="3" stroke="currentColor" class="w-3 h-3">
                              <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
                            </svg>

--- a/frontend/src/pages/show/[id]/season/[season_number]/[episode_number].astro
+++ b/frontend/src/pages/show/[id]/season/[season_number]/[episode_number].astro
@@ -151,12 +151,12 @@ const thumbnail = episode?.still_path || show?.poster_path || null;
                 </span>
               )}
               {rating && (
-                <span class="flex items-center gap-1.5 text-yellow-400 font-black">
+                <span data-spoiler="ratings" class="flex items-center gap-1.5 text-yellow-400 font-black">
                   <span class="text-lg leading-none">★</span> {rating}
                 </span>
               )}
               {episode.runtime && (
-                <span class="flex items-center gap-1.5 font-medium">
+                <span data-spoiler="runtime" class="flex items-center gap-1.5 font-medium">
                   <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor" class="w-4 h-4 text-zinc-500">
                     <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
                   </svg>
@@ -257,7 +257,7 @@ const thumbnail = episode?.still_path || show?.poster_path || null;
                   <span class="w-2 h-2 bg-blue-500 rounded-full"></span>
                   Overview
                 </h2>
-                <p class="text-zinc-300 leading-relaxed text-lg max-w-3xl font-medium opacity-90">
+                <p data-spoiler="descriptions" class="text-zinc-300 leading-relaxed text-lg max-w-3xl font-medium opacity-90">
                   {episode.overview}
                 </p>
               </div>

--- a/frontend/src/pages/show/tvdb/[id].astro
+++ b/frontend/src/pages/show/tvdb/[id].astro
@@ -189,7 +189,7 @@ const originalLanguage = show?.original_language
                 <span class="w-2 h-2 bg-blue-500 rounded-full"></span>
                 Overview
               </h2>
-              <p class="text-zinc-300 leading-relaxed text-lg max-w-4xl font-medium opacity-90">
+              <p data-spoiler="descriptions" class="text-zinc-300 leading-relaxed text-lg max-w-4xl font-medium opacity-90">
                 {show.overview}
               </p>
             </div>
@@ -259,7 +259,7 @@ const originalLanguage = show?.original_language
                       <div class="flex items-start justify-between gap-4 mb-1">
                         <h3 class="text-xl font-black text-zinc-100 group-hover/season:text-blue-400 transition-colors">{seasonTitle}</h3>
                         {s.tmdb_rating != null && s.tmdb_rating > 0 && (
-                          <div class="bg-zinc-950 border border-zinc-800 px-2 py-1 rounded-xl flex items-center gap-1.5 shrink-0 shadow-sm">
+                          <div data-spoiler="ratings" class="bg-zinc-950 border border-zinc-800 px-2 py-1 rounded-xl flex items-center gap-1.5 shrink-0 shadow-sm">
                             <span class="text-yellow-400 text-xs">★</span>
                             <span class="text-zinc-100 text-xs font-bold">{s.tmdb_rating.toFixed(1)}</span>
                           </div>
@@ -270,7 +270,7 @@ const originalLanguage = show?.original_language
                           {s.episode_count} Episodes
                         </span>
                       </div>
-                      <p class="text-xs text-zinc-400 line-clamp-3 leading-relaxed opacity-80">{s.overview || "No overview available."}</p>
+                      <p data-spoiler="descriptions" class="text-xs text-zinc-400 line-clamp-3 leading-relaxed opacity-80">{s.overview || "No overview available."}</p>
                     </div>
                   </a>
                   {user && (

--- a/frontend/src/pages/show/tvdb/[id]/season/[season_number].astro
+++ b/frontend/src/pages/show/tvdb/[id]/season/[season_number].astro
@@ -128,7 +128,7 @@ const seasonTitle = season
             <div class="flex flex-wrap justify-center md:justify-start items-center gap-4 text-zinc-400 text-sm mb-8 bg-zinc-900/40 p-3 rounded-xl border border-zinc-800/50 backdrop-blur-sm inline-flex">
               <span class="font-bold text-zinc-300">{season.episodes?.length || 0} Episodes</span>
               {season.tmdb_rating != null && season.tmdb_rating > 0 && (
-                <span class="flex items-center gap-1.5 font-bold text-zinc-100">
+                <span data-spoiler="ratings" class="flex items-center gap-1.5 font-bold text-zinc-100">
                   <span class="text-yellow-400">★</span>
                   {season.tmdb_rating.toFixed(1)}
                 </span>
@@ -183,7 +183,7 @@ const seasonTitle = season
                   <span class="w-2 h-2 bg-blue-500 rounded-full"></span>
                   Season Overview
                 </h2>
-                <p class="text-zinc-300 leading-relaxed text-lg opacity-90">{season.overview}</p>
+                <p data-spoiler="descriptions" class="text-zinc-300 leading-relaxed text-lg opacity-90">{season.overview}</p>
               </div>
             )}
           </div>
@@ -231,7 +231,7 @@ const seasonTitle = season
                       </div>
                     </div>
 
-                    <p class="text-zinc-400 text-sm leading-relaxed line-clamp-3 mb-4 opacity-80">
+                    <p data-spoiler="descriptions" class="text-zinc-400 text-sm leading-relaxed line-clamp-3 mb-4 opacity-80">
                       {ep.overview || "No overview available for this episode."}
                     </p>
 
@@ -240,7 +240,7 @@ const seasonTitle = season
                         View Details
                       </span>
                       {ep.runtime && (
-                        <span class="text-[10px] font-black uppercase tracking-[0.2em] text-zinc-700 flex items-center gap-1.5">
+                        <span data-spoiler="runtime" class="text-[10px] font-black uppercase tracking-[0.2em] text-zinc-700 flex items-center gap-1.5">
                           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="3" stroke="currentColor" class="w-3 h-3">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
                           </svg>

--- a/frontend/src/pages/show/tvdb/[id]/season/[season_number]/[episode_number].astro
+++ b/frontend/src/pages/show/tvdb/[id]/season/[season_number]/[episode_number].astro
@@ -146,7 +146,7 @@ const thumbnail = episode?.image_url || show?.poster_path || null;
                 </span>
               )}
               {episode.runtime && (
-                <span class="flex items-center gap-1.5 font-medium">
+                <span data-spoiler="runtime" class="flex items-center gap-1.5 font-medium">
                   <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor" class="w-4 h-4 text-zinc-500">
                     <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
                   </svg>
@@ -262,7 +262,7 @@ const thumbnail = episode?.image_url || show?.poster_path || null;
                   <span class="w-2 h-2 bg-blue-500 rounded-full"></span>
                   Overview
                 </h2>
-                <p class="text-zinc-300 leading-relaxed text-lg max-w-3xl font-medium opacity-90">
+                <p data-spoiler="descriptions" class="text-zinc-300 leading-relaxed text-lg max-w-3xl font-medium opacity-90">
                   {episode.overview}
                 </p>
               </div>

--- a/frontend/test/spoiler-controls.test.mjs
+++ b/frontend/test/spoiler-controls.test.mjs
@@ -7,6 +7,16 @@ const card = readFileSync(new URL('../src/components/MediaCard.astro', import.me
 const episodeCard = readFileSync(new URL('../src/components/EpisodeCard.astro', import.meta.url), 'utf8');
 const nextUp = readFileSync(new URL('../src/pages/next-up.astro', import.meta.url), 'utf8');
 const home = readFileSync(new URL('../src/pages/index.astro', import.meta.url), 'utf8');
+const mediaDetail = readFileSync(new URL('../src/pages/media/[type]/[id].astro', import.meta.url), 'utf8');
+const comments = readFileSync(new URL('../src/components/CommentsSection.astro', import.meta.url), 'utf8');
+const detailRoutes = {
+  tmdbShow: readFileSync(new URL('../src/pages/show/[id].astro', import.meta.url), 'utf8'),
+  tvdbShow: readFileSync(new URL('../src/pages/show/tvdb/[id].astro', import.meta.url), 'utf8'),
+  tmdbSeason: readFileSync(new URL('../src/pages/show/[id]/season/[season_number].astro', import.meta.url), 'utf8'),
+  tvdbSeason: readFileSync(new URL('../src/pages/show/tvdb/[id]/season/[season_number].astro', import.meta.url), 'utf8'),
+  tmdbEpisode: readFileSync(new URL('../src/pages/show/[id]/season/[season_number]/[episode_number].astro', import.meta.url), 'utf8'),
+  tvdbEpisode: readFileSync(new URL('../src/pages/show/tvdb/[id]/season/[season_number]/[episode_number].astro', import.meta.url), 'utf8'),
+};
 
 test('spoiler controls are local, fail-closed before body render, and support keyboard reveal', () => {
   assert.match(base, /localStorage\.getItem\('spoilerControls'\)/);
@@ -18,6 +28,11 @@ test('spoiler controls are local, fail-closed before body render, and support ke
   assert.match(base, /parsed && typeof parsed === 'object' && !Array\.isArray\(parsed\)/);
   assert.match(base, /try \{ localStorage\.setItem\(SPOILER_KEY/);
   assert.match(base, /if \(wasOpen\) spoilerBtn\?\.focus\(\)/);
+  assert.match(base, /node\.closest\('a, button'\)/);
+  assert.match(base, /const nativeControl = node\.matches/);
+  assert.match(base, /interactive\.querySelectorAll/);
+  assert.match(base, /node\.dataset\.spoilerRevealed !== 'true'/);
+  assert.doesNotMatch(base, /node\.tabIndex = enabled/);
 });
 
 test('shared cards expose independently controllable ratings and opt-in next episode content', () => {
@@ -31,4 +46,32 @@ test('shared cards expose independently controllable ratings and opt-in next epi
   const nextUpHero = home.slice(home.indexOf('const hero = nextUp[0]'));
   assert.match(nextUpHero, /<div data-spoiler="next" class="absolute top-0/);
   assert.doesNotMatch(nextUpHero, /overflow-hidden pointer-events-none/);
+});
+
+test('all TMDB and TVDB detail route families mark every displayed spoiler category', () => {
+  assert.match(mediaDetail, /data-spoiler="ratings"/);
+  assert.match(mediaDetail, /data-spoiler="descriptions"/);
+  assert.match(mediaDetail, /data-spoiler="runtime"/);
+
+  for (const route of [detailRoutes.tmdbShow, detailRoutes.tvdbShow]) {
+    assert.match(route, /data-spoiler="descriptions"/);
+    assert.match(route, /data-spoiler="ratings"/);
+  }
+  for (const route of [detailRoutes.tmdbSeason, detailRoutes.tvdbSeason]) {
+    assert.match(route, /data-spoiler="ratings"/);
+    assert.match(route, /data-spoiler="descriptions"/);
+    assert.match(route, /data-spoiler="runtime"/);
+  }
+  for (const route of [detailRoutes.tmdbEpisode, detailRoutes.tvdbEpisode]) {
+    assert.match(route, /data-spoiler="descriptions"/);
+    assert.match(route, /data-spoiler="runtime"/);
+  }
+  assert.match(detailRoutes.tmdbEpisode, /data-spoiler="ratings"/);
+});
+
+test('comments keep their existing per-comment spoiler contract', () => {
+  assert.match(comments, /comment\.is_spoiler/);
+  assert.match(comments, /global media controls do not hide unflagged discussion/);
+  assert.match(comments, /spoiler-overlay/);
+  assert.match(comments, /blur-sm select-none pointer-events-none/);
 });

--- a/frontend/test/spoiler-controls.test.mjs
+++ b/frontend/test/spoiler-controls.test.mjs
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const base = readFileSync(new URL('../src/layouts/Base.astro', import.meta.url), 'utf8');
+const card = readFileSync(new URL('../src/components/MediaCard.astro', import.meta.url), 'utf8');
+const episodeCard = readFileSync(new URL('../src/components/EpisodeCard.astro', import.meta.url), 'utf8');
+const nextUp = readFileSync(new URL('../src/pages/next-up.astro', import.meta.url), 'utf8');
+const home = readFileSync(new URL('../src/pages/index.astro', import.meta.url), 'utf8');
+
+test('spoiler controls are local, fail-closed before body render, and support keyboard reveal', () => {
+  assert.match(base, /localStorage\.getItem\('spoilerControls'\)/);
+  assert.match(base, /document\.documentElement\.setAttribute\('data-spoilers'/);
+  assert.match(base, /event\.key === 'Enter' \|\| event\.key === ' '/);
+  assert.match(base, /data-spoiler-revealed/);
+  assert.match(base, /spoiler-content-added/);
+  assert.match(base, /event\.key === 'Escape'/);
+  assert.match(base, /parsed && typeof parsed === 'object' && !Array\.isArray\(parsed\)/);
+  assert.match(base, /try \{ localStorage\.setItem\(SPOILER_KEY/);
+  assert.match(base, /if \(wasOpen\) spoilerBtn\?\.focus\(\)/);
+});
+
+test('shared cards expose independently controllable ratings and opt-in next episode content', () => {
+  assert.match(card, /data-spoiler="ratings"/);
+  assert.match(card, /spoilerNext = false/);
+  assert.match(episodeCard, /spoilerNext = false/);
+  assert.match(episodeCard, /data-spoiler=\{spoilerNext \? "next"/);
+  assert.match(nextUp, /data-spoiler="next"/);
+  assert.match(nextUp, /data-spoiler="ratings"/);
+  assert.match(home, /<div data-spoiler="next" class="absolute top-0/);
+  const nextUpHero = home.slice(home.indexOf('const hero = nextUp[0]'));
+  assert.match(nextUpHero, /<div data-spoiler="next" class="absolute top-0/);
+  assert.doesNotMatch(nextUpHero, /overflow-hidden pointer-events-none/);
+});


### PR DESCRIPTION
## Summary
- add browser-local controls to hide ratings, descriptions, runtime, and next-episode titles/images
- cover shared cards, home/Next Up, media details, and TMDB/TVDB show, season, and episode routes
- keep native links and buttons accessible with first-activation reveal and preserve existing author-marked comment spoilers

## Verification
- `cd frontend && npm test` (4 passed)
- `cd frontend && npm run build`
- `git diff --check`

Closes #150