### PR TITLE
feat(history): mark previous episodes watched

### DIFF
--- a/backend/routers/history.py
+++ b/backend/routers/history.py
@@ -1076,6 +1076,11 @@ class SeasonWatchRequest(BaseModel):
     watched_at: datetime | None = None  # omitted = now; explicit null = unknown date
 
 
+class PreviousEpisodesWatchRequest(SeasonWatchRequest):
+    """Episode cap in the selected (TMDB or TVDB) season order."""
+    up_to_episode_number: int
+
+
 class ShowWatchRequest(BaseModel):
     series_tmdb_id: int
     series_tvdb_id: int | None = None  # links the show to TVDB on demand, see #101
@@ -1448,6 +1453,7 @@ async def mark_season_watched(
     current_user: User = Depends(get_current_user_or_api_key),
 ):
     """Mark all aired episodes of a season as watched, fetching from TMDB if needed."""
+    up_to_episode_number = getattr(body, "up_to_episode_number", None)
     # 1. Ensure show exists
     show_q = await db.execute(select(Show).where(Show.tmdb_id == body.series_tmdb_id))
     show = show_q.scalar_one_or_none()
@@ -1495,6 +1501,10 @@ async def mark_season_watched(
             )
         )
         mappings = list(mapping_result.scalars().all())
+        if up_to_episode_number is not None:
+            # A TVDB season can span TMDB seasons, so apply the cap before
+            # translating back to the canonical positions stored locally.
+            mappings = [m for m in mappings if m.tvdb_episode_number <= up_to_episode_number]
         if not mappings:
             # No computed mapping — if TMDB doesn't even have a season with
             # this number, it's confidently absent (see #101): fetch straight
@@ -1551,6 +1561,8 @@ async def mark_season_watched(
         }
         for tvdb_ep in tvdb_fallback_episodes:
             if tvdb_ep.get("episode_number") is None or not _has_aired(tvdb_ep.get("air_date"), today):
+                continue
+            if up_to_episode_number is not None and tvdb_ep["episode_number"] > up_to_episode_number:
                 continue
             position = (body.season_number, tvdb_ep["episode_number"])
             existing = existing_map.get(position)
@@ -1615,6 +1627,12 @@ async def mark_season_watched(
             for ep in season_data.get("episodes", []):
                 position = (canonical_season, ep["episode_number"])
                 if target_positions is not None and position not in target_positions:
+                    continue
+                if (
+                    up_to_episode_number is not None
+                    and target_positions is None
+                    and ep["episode_number"] > up_to_episode_number
+                ):
                     continue
                 air_date_str = ep.get("air_date")
                 if not air_date_str:
@@ -1682,8 +1700,25 @@ async def mark_season_watched(
         for event in new_events:
             await record_rewatch_progress(db, current_user.id, event.media_id, event.id)
         await db.commit()
-    await _push_watch_state(db, current_user.id, newly_watched, watched=True)
+    await _push_watch_state(
+        db, current_user.id, newly_watched, watched=True,
+        watched_at_by_media={media_id: resolved_watched_at for media_id in newly_watched},
+    )
     return {"status": "ok", "count": len(newly_watched)}
+
+
+@router.post("/previous-episodes")
+async def mark_previous_episodes_watched(
+    body: PreviousEpisodesWatchRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user_or_api_key),
+):
+    """Mark this and earlier aired episodes in one normal season only."""
+    if body.season_number <= 0:
+        raise HTTPException(status_code=400, detail="Previous-episode marking is only available for normal seasons")
+    if body.up_to_episode_number <= 1:
+        raise HTTPException(status_code=400, detail="Previous-episode marking requires an episode after episode 1")
+    return await mark_season_watched(body, db, current_user)
 
 
 @router.delete("/season")

--- a/backend/tests/test_history.py
+++ b/backend/tests/test_history.py
@@ -4,6 +4,8 @@ from datetime import datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
+from fastapi import HTTPException
+
 os.environ.setdefault("SECRET_KEY", "test-secret")
 os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://test:test@localhost/test")
 
@@ -462,6 +464,76 @@ class ClearHistoryTests(unittest.IsolatedAsyncioTestCase):
         }
         self.assertEqual(tables_deleted, {ShowRewatch.__tablename__, WatchEvent.__tablename__, PlaybackProgress.__tablename__})
         db.commit.assert_awaited_once()
+
+
+class PreviousEpisodesWatchValidationTests(unittest.IsolatedAsyncioTestCase):
+    async def test_specials_and_episode_one_are_rejected_before_any_database_write(self) -> None:
+        user = SimpleNamespace(id=7)
+        db = SimpleNamespace()
+        for season, episode in ((0, 2), (1, 1)):
+            with self.assertRaises(HTTPException):
+                await history.mark_previous_episodes_watched(
+                    history.PreviousEpisodesWatchRequest(
+                        series_tmdb_id=100, season_number=season, up_to_episode_number=episode,
+                    ), db, user,
+                )
+
+    async def test_tvdb_cap_is_applied_before_mapping_to_canonical_episode_number(self) -> None:
+        show = Show(id=55, tmdb_id=100, tvdb_id=900, title="Test Show")
+        mapping = EpisodeOrderMapping(
+            series_tmdb_id=100,
+            tmdb_season_number=4,
+            tmdb_episode_number=12,
+            tmdb_episode_id=1200,
+            tvdb_id=2200,
+            tvdb_season_number=1,
+            tvdb_episode_number=2,
+            match_method="external_id",
+        )
+        episode = Media(
+            id=12,
+            tmdb_id=1200,
+            media_type=MediaType.episode,
+            show_id=55,
+            season_number=4,
+            episode_number=12,
+            title="Canonical episode 12",
+        )
+        db = _FakeSession([show, [mapping], [episode], None])
+        db.info["tmdb_key_7"] = "test-key"
+        season_payload = {
+            "episodes": [
+                {
+                    "episode_number": 12,
+                    "id": 1200,
+                    "name": "Canonical episode 12",
+                    "air_date": "2020-01-01",
+                    "vote_average": 8.0,
+                    "still_path": None,
+                },
+            ],
+        }
+        body = history.PreviousEpisodesWatchRequest(
+            series_tmdb_id=100,
+            series_tvdb_id=900,
+            season_number=1,
+            episode_order="tvdb",
+            up_to_episode_number=2,
+        )
+
+        with (
+            patch.object(history.tmdb, "get_season", AsyncMock(return_value=season_payload)),
+            patch("routers.history.get_already_watched_for_bulk_mark", AsyncMock(return_value=set())),
+            patch("routers.history.record_rewatch_progress", AsyncMock()),
+            patch("routers.history._push_watch_state", new_callable=AsyncMock),
+        ):
+            response = await history.mark_previous_episodes_watched(
+                body, db, SimpleNamespace(id=7),
+            )
+
+        self.assertEqual(response["count"], 1)
+        event = next(value for value in db.added if isinstance(value, WatchEvent))
+        self.assertEqual(event.media_id, 12)
 
 
 if __name__ == "__main__":

--- a/frontend/src/components/ActionBar.astro
+++ b/frontend/src/components/ActionBar.astro
@@ -12,6 +12,7 @@ interface Props {
   seasonNumber?: number;
   episodeNumber?: number;
   displaySeasonNumber?: number;
+  displayEpisodeNumber?: number;
   episodeOrder?: "tmdb" | "tvdb";
   tvdbId?: number;
   hideRequest?: boolean;
@@ -40,6 +41,7 @@ const {
   seasonNumber,
   episodeNumber,
   displaySeasonNumber,
+  displayEpisodeNumber,
   episodeOrder = "tmdb",
   tvdbId,
   hideRequest = false,
@@ -121,6 +123,7 @@ const requestTitle = isMonitored
   data-air-date={airDate ?? ""}
   data-tvdb-id={tvdbId != null ? String(tvdbId) : ""}
   data-display-season={displaySeasonNumber != null ? String(displaySeasonNumber) : ""}
+  data-display-episode={displayEpisodeNumber != null ? String(displayEpisodeNumber) : ""}
   data-media-id={mediaId != null ? String(mediaId) : ""}
   class="flex w-fit"
 >

--- a/frontend/src/layouts/Base.astro
+++ b/frontend/src/layouts/Base.astro
@@ -436,6 +436,14 @@ const bottomNavItem = (active: boolean) =>
           Mark as unwatched
         </button>
         <p id="watch-history-add-play-label" class="text-[10px] font-bold uppercase tracking-wider text-zinc-500">Add a play</p>
+        <div id="watch-history-previous-options" class="hidden rounded-xl border border-green-500/20 bg-green-500/5 p-3 space-y-2">
+          <p class="text-xs font-semibold text-zinc-300">Include earlier aired episodes in this season?</p>
+          <p class="text-[11px] leading-snug text-zinc-500">Already watched episodes are left alone. Future episodes and specials are never included.</p>
+          <div class="grid grid-cols-2 gap-2">
+            <button id="watch-history-this-episode-btn" class="px-2 py-2 rounded-lg text-xs font-bold bg-green-600 text-white">Only this episode</button>
+            <button id="watch-history-previous-episodes-btn" class="px-2 py-2 rounded-lg text-xs font-bold bg-zinc-800 text-zinc-300 border border-zinc-700 hover:bg-zinc-700">This and previous</button>
+          </div>
+        </div>
         <div class="flex gap-2">
           <button id="watch-history-now-btn" class="flex-1 px-3 py-2 rounded-xl text-sm font-bold transition-all cursor-pointer bg-blue-600 text-white">Just now</button>
           <button id="watch-history-custom-btn" class="flex-1 px-3 py-2 rounded-xl text-sm font-bold transition-all cursor-pointer bg-zinc-800 text-zinc-400 border border-zinc-700 hover:text-zinc-200">Custom</button>
@@ -1393,6 +1401,9 @@ const bottomNavItem = (active: boolean) =>
     let _watchHistoryShowTvdbId = '';
     let _watchHistorySeasonNumber = '';
     let _watchHistoryEpisodeNumber = '';
+    let _watchHistoryDisplayEpisodeNumber = '';
+    let _watchHistoryEpisodeOrder = 'tmdb';
+    let _watchHistoryIncludePrevious = false;
     // Set when the modal is being used to mark a whole season/show watched
     // (no single item's history applies) rather than logging one item's play.
     let _watchHistoryBulkMode: { kind: 'season' | 'show'; seriesId: string; season: string; episodeOrder: string; btn: HTMLElement; tvdbId: string } | null = null;
@@ -1424,7 +1435,15 @@ const bottomNavItem = (active: boolean) =>
       dateInput.max = toLocal(new Date());
     }
 
-    async function openWatchHistoryModal(_btn: HTMLElement, tmdbId: string, mediaType: string, showTmdbId = '', seasonNumber = '', episodeNumber = '', showTvdbId = '') {
+    function setPreviousEpisodeChoice(includePrevious: boolean) {
+      _watchHistoryIncludePrevious = includePrevious;
+      const only = document.getElementById('watch-history-this-episode-btn')!;
+      const previous = document.getElementById('watch-history-previous-episodes-btn')!;
+      only.className = includePrevious ? 'px-2 py-2 rounded-lg text-xs font-bold bg-zinc-800 text-zinc-300 border border-zinc-700 hover:bg-zinc-700' : 'px-2 py-2 rounded-lg text-xs font-bold bg-green-600 text-white';
+      previous.className = includePrevious ? 'px-2 py-2 rounded-lg text-xs font-bold bg-green-600 text-white' : 'px-2 py-2 rounded-lg text-xs font-bold bg-zinc-800 text-zinc-300 border border-zinc-700 hover:bg-zinc-700';
+    }
+
+    async function openWatchHistoryModal(btn: HTMLElement, tmdbId: string, mediaType: string, showTmdbId = '', seasonNumber = '', episodeNumber = '', showTvdbId = '') {
       _watchHistoryBulkMode = null;
       _watchHistoryTmdbId = tmdbId;
       _watchHistoryMediaType = mediaType;
@@ -1432,6 +1451,11 @@ const bottomNavItem = (active: boolean) =>
       _watchHistoryShowTvdbId = showTvdbId;
       _watchHistorySeasonNumber = seasonNumber;
       _watchHistoryEpisodeNumber = episodeNumber;
+      _watchHistoryDisplayEpisodeNumber = btn.closest<HTMLElement>('[data-card]')?.dataset.displayEpisode || episodeNumber;
+      _watchHistoryEpisodeOrder = btn.closest<HTMLElement>('[data-card]')?.dataset.episodeOrder || 'tmdb';
+      const canIncludePrevious = mediaType === 'episode' && Number(seasonNumber) > 0 && Number(_watchHistoryDisplayEpisodeNumber) > 1;
+      document.getElementById('watch-history-previous-options')!.classList.toggle('hidden', !canIncludePrevious);
+      setPreviousEpisodeChoice(false);
 
       document.getElementById('watch-history-modal-title')!.textContent = 'Watch History';
       document.getElementById('watch-history-modal-events')!.classList.remove('hidden');
@@ -1450,6 +1474,7 @@ const bottomNavItem = (active: boolean) =>
       document.getElementById('watch-history-modal-events')!.classList.add('hidden');
       document.getElementById('watch-history-unwatch-btn')!.classList.add('hidden');
       document.getElementById('watch-history-add-play-label')!.classList.add('hidden');
+      document.getElementById('watch-history-previous-options')!.classList.add('hidden');
       resetWatchHistoryDateUI();
 
       document.getElementById('watch-history-log-btn')!.textContent = 'Mark as watched';
@@ -1533,6 +1558,8 @@ const bottomNavItem = (active: boolean) =>
     }
 
     document.getElementById('watch-history-modal-close')!.addEventListener('click', closeWatchHistoryModal);
+    document.getElementById('watch-history-this-episode-btn')!.addEventListener('click', () => setPreviousEpisodeChoice(false));
+    document.getElementById('watch-history-previous-episodes-btn')!.addEventListener('click', () => setPreviousEpisodeChoice(true));
     document.getElementById('watch-history-modal')!.addEventListener('click', (e) => {
       if (e.target === document.getElementById('watch-history-modal')) closeWatchHistoryModal();
     });
@@ -1662,7 +1689,19 @@ const bottomNavItem = (active: boolean) =>
             if (_watchHistorySeasonNumber) watchBody.season_number = Number(_watchHistorySeasonNumber);
             if (_watchHistoryEpisodeNumber) watchBody.episode_number = Number(_watchHistoryEpisodeNumber);
           }
-          await apiFetch('/history', 'POST', watchBody);
+          if (_watchHistoryIncludePrevious) {
+            const previousBody: Record<string, unknown> = {
+              series_tmdb_id: Number(_watchHistoryShowTmdbId),
+              season_number: Number(_watchHistorySeasonNumber),
+              up_to_episode_number: Number(_watchHistoryDisplayEpisodeNumber),
+              watched_at: watchedAt,
+            };
+            if (_watchHistoryShowTvdbId) previousBody.series_tvdb_id = Number(_watchHistoryShowTvdbId);
+            if (_watchHistoryEpisodeOrder === 'tvdb') previousBody.episode_order = 'tvdb';
+            await apiFetch('/history/previous-episodes', 'POST', previousBody);
+          } else {
+            await apiFetch('/history', 'POST', watchBody);
+          }
           await loadWatchHistoryEvents();
           syncSeasonWatchPctFromDOM(_watchHistoryShowTmdbId, _watchHistorySeasonNumber);
           // Reset to "Just now" after logging

--- a/frontend/src/pages/show/tvdb/[id]/season/[season_number].astro
+++ b/frontend/src/pages/show/tvdb/[id]/season/[season_number].astro
@@ -268,6 +268,7 @@ const seasonTitle = season
                         seasonNumber={ep.tmdb_season_number}
                         episodeNumber={ep.tmdb_episode_number}
                         displaySeasonNumber={Number(season_number)}
+                        displayEpisodeNumber={ep.episode_number}
                         episodeOrder="tvdb"
                         tvdbId={Number(id)}
                         hideRequest={true}

--- a/frontend/src/pages/show/tvdb/[id]/season/[season_number]/[episode_number].astro
+++ b/frontend/src/pages/show/tvdb/[id]/season/[season_number]/[episode_number].astro
@@ -175,6 +175,7 @@ const thumbnail = episode?.image_url || show?.poster_path || null;
                   seasonNumber={episode.tmdb_season_number}
                   episodeNumber={episode.tmdb_episode_number}
                   displaySeasonNumber={Number(season_number)}
+                  displayEpisodeNumber={Number(episode_number)}
                   episodeOrder="tvdb"
                   tvdbId={Number(id)}
                   mediaId={episode.id}


### PR DESCRIPTION
## Summary
- offer an explicit, default-safe choice to mark only an episode or it plus earlier aired episodes in the same normal season
- reuse the season bulk workflow while skipping future, special, and already-watched episodes and preserving the chosen watch date
- respect TMDB and TVDB display order and fan the resulting watch state out to configured providers

## Verification
- `cd backend && PYTHONPATH=. /private/tmp/scrob-188.gts4iC/backend/.venv/bin/python -m unittest tests.test_history` (18 passed)
- `cd frontend && npm run build`
- `git diff --check`

The additional choice is shown for later normal-season episodes; when no earlier unwatched episode remains, the bulk operation safely leaves existing events unchanged.

Closes #65