### PR TITLE
feat(home): add seven-day airing window

### DIFF
--- a/backend/routers/media.py
+++ b/backend/routers/media.py
@@ -4,7 +4,9 @@ import logging
 import re
 import urllib.parse
 import uuid
-from typing import Optional
+from datetime import date, datetime, timedelta
+from typing import Literal, Optional
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 logger = logging.getLogger(__name__)
 from pydantic import BaseModel
@@ -84,6 +86,34 @@ TV_GENRE_IDS: dict[str, int] = {
 
 MOVIE_GENRE_NAMES: dict[int, str] = {v: k for k, v in MOVIE_GENRE_IDS.items()}
 TV_GENRE_NAMES: dict[int, str] = {v: k for k, v in TV_GENRE_IDS.items()}
+
+
+def _browser_timezone(timezone_name: str) -> ZoneInfo:
+    """Return the browser-supplied IANA zone, with a safe UTC fallback."""
+    try:
+        return ZoneInfo(timezone_name)
+    except (ZoneInfoNotFoundError, KeyError):
+        return ZoneInfo("UTC")
+
+
+def _airing_window(timezone_name: str, days: int, now: datetime | None = None) -> tuple[date, date]:
+    """Calendar-date bounds for the homepage rail.
+
+    TMDB gives episode air *dates*, not reliable universal air instants, so all
+    comparisons deliberately remain date-only in the viewer's timezone.
+    """
+    user_tz = _browser_timezone(timezone_name)
+    start = (now.astimezone(user_tz) if now else datetime.now(user_tz)).date()
+    return start, start + timedelta(days=days - 1)
+
+
+def _air_date_in_window(air_date: str | None, start: date, end: date) -> bool:
+    if not air_date:
+        return False
+    try:
+        return start <= date.fromisoformat(air_date) <= end
+    except ValueError:
+        return False
 
 
 def _genre_weight(genre_ids: list[int], liked: set[str], disliked: set[str], name_map: dict[int, str]) -> float:
@@ -1617,10 +1647,16 @@ async def on_air_today(
 @router.get("/airing-today/collected")
 async def airing_today_collected(
     timezone: str = Query(default="UTC"),
+    days: Literal[1, 7] = Query(default=1),
     db: AsyncSession = Depends(get_db),
     current_user: User | None = Depends(get_optional_user_or_api_key),
 ):
-    """Return shows airing today on TMDB that the user has in their collection."""
+    """Return collected-show episodes with date-only air dates in a short window.
+
+    ``days`` intentionally accepts only the homepage's two UI states: today
+    (1) and today plus the next six calendar dates (7). This is not a live
+    guide: TMDB provides an air_date rather than a reliable universal airtime.
+    """
     if current_user is None:
         await require_anon_nav_allowed(db)
     effective_user_id = current_user.id if current_user else ANON_USER_ID
@@ -1629,15 +1665,7 @@ async def airing_today_collected(
     if not check_tmdb_key(tmdb_key):
         return {"results": []}
 
-    from datetime import datetime
-    from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
-
-    try:
-        user_tz = ZoneInfo(timezone)
-    except (ZoneInfoNotFoundError, KeyError):
-        user_tz = ZoneInfo("UTC")
-
-    today = datetime.now(user_tz).date().isoformat()
+    window_start, window_end = _airing_window(timezone, days)
 
     # Collect the user's show TMDB IDs in one query
     collected_q = await db.execute(
@@ -1652,79 +1680,82 @@ async def airing_today_collected(
     if not collected_tmdb_ids:
         return {"results": []}
 
-    # Fetch page 1 to discover total_pages, then fetch remaining pages concurrently.
-    # timezone forwarded to TMDB itself, not just the local air_date check below -
-    # otherwise TMDB pre-filters "airing today" against its own default timezone,
-    # which can miss (or wrongly include) shows relative to the user's real today.
-    try:
-        first = await tmdb.get_on_air_today(page=1, api_key=tmdb_key, timezone=timezone)
-    except Exception as e:
-        print(f"Error fetching airing-today from TMDB: {e}")
-        return {"results": []}
-    total_pages = min(first.get("total_pages", 1), 20)
-    all_shows = list(first.get("results", []))
+    # The global /airing_today discovery list cannot represent a seven-day
+    # range and is only an approximate "around today" signal. Fetch the
+    # user's collected shows directly, then filter their date-only episode
+    # metadata using the browser's calendar boundaries.
+    shows_q = await db.execute(
+        select(ShowModel).where(ShowModel.tmdb_id.in_(collected_tmdb_ids))
+    )
+    collected_shows = sorted(
+        (show for show in shows_q.scalars().all() if show.tmdb_id),
+        key=lambda show: (show.title or "").casefold(),
+    )
+    semaphore = asyncio.Semaphore(8)
 
-    if total_pages > 1:
-        pages = await asyncio.gather(
-            *[tmdb.get_on_air_today(page=p, api_key=tmdb_key, timezone=timezone) for p in range(2, total_pages + 1)],
-            return_exceptions=True,
-        )
-        for page_data in pages:
-            if isinstance(page_data, Exception):
-                continue
-            all_shows.extend(page_data.get("results", []))
-
-    collected_shows = [s for s in all_shows if s.get("id") in collected_tmdb_ids]
-
-    if not collected_shows:
-        return {"results": []}
-
-    semaphore = asyncio.Semaphore(10)
-
-    async def fetch_episode(show: dict) -> dict | None:
+    async def fetch_episodes(show: ShowModel) -> list[dict]:
         async with semaphore:
             try:
-                detail = await tmdb.get_show_light(show["id"], api_key=tmdb_key)
+                detail = await tmdb.get_show_light(show.tmdb_id, api_key=tmdb_key)
             except Exception:
-                detail = {}
+                return []
 
-        episode: dict | None = None
-        for candidate in (detail.get("last_episode_to_air"), detail.get("next_episode_to_air")):
-            if candidate and candidate.get("air_date") == today:
-                episode = candidate
-                break
+            # The last pointer matters for today's view: TMDB can move an
+            # episode there shortly after its release. The next pointer finds
+            # the current season for future entries.
+            season_numbers = {
+                candidate.get("season_number")
+                for candidate in (detail.get("last_episode_to_air"), detail.get("next_episode_to_air"))
+                if candidate
+                and _air_date_in_window(candidate.get("air_date"), window_start, window_end)
+                and candidate.get("season_number") is not None
+            }
+            if not season_numbers:
+                return []
+            seasons = await asyncio.gather(
+                *[tmdb.get_season(show.tmdb_id, season_number, api_key=tmdb_key) for season_number in season_numbers],
+                return_exceptions=True,
+            )
 
-        # TMDB's own /tv/airing_today list is a looser "has something airing
-        # around today" signal than an exact per-episode date match - a show
-        # can appear on it while its actual next/last episode is tomorrow (or
-        # yesterday). Without this check, that mismatch used to be masked by
-        # falling back to a generic "still airing" entry instead of excluding
-        # the show, which is how a show could show up here a day early/late.
-        if not episode:
-            return None
+        show_name = detail.get("name") or show.title
+        backdrop_path = detail.get("backdrop_path") or show.backdrop_path
+        results: list[dict] = []
+        for season in seasons:
+            if isinstance(season, Exception):
+                continue
+            for episode in season.get("episodes") or []:
+                air_date = episode.get("air_date")
+                if not _air_date_in_window(air_date, window_start, window_end):
+                    continue
+                results.append({
+                    "id": None,
+                    "tmdb_id": episode.get("id"),
+                    "type": "episode",
+                    "title": episode.get("name") or show_name,
+                    "show_title": show_name,
+                    "show_tmdb_id": show.tmdb_id,
+                    "season_number": episode.get("season_number"),
+                    "episode_number": episode.get("episode_number"),
+                    "poster_path": tmdb.poster_url(episode.get("still_path"), size="w780")
+                        or tmdb.poster_url(backdrop_path, size="w780"),
+                    "backdrop_path": tmdb.poster_url(backdrop_path, size="w780"),
+                    "tmdb_rating": episode.get("vote_average") or detail.get("vote_average") or show.tmdb_rating,
+                    "release_date": air_date,
+                    "adult": detail.get("adult", False),
+                })
+        return results
 
-        show_name = show.get("name")
-        return {
-            "id": None,
-            "tmdb_id": show["id"],
-            "type": "episode",
-            "title": episode.get("name") or show_name,
-            "show_title": show_name,
-            "show_tmdb_id": show["id"],
-            "season_number": episode.get("season_number"),
-            "episode_number": episode.get("episode_number"),
-            "poster_path": tmdb.poster_url(episode.get("still_path"), size="w780")
-                or tmdb.poster_url(show.get("backdrop_path"), size="w780"),
-            "backdrop_path": tmdb.poster_url(show.get("backdrop_path"), size="w780"),
-            "tmdb_rating": show.get("vote_average"),
-            "release_date": episode.get("air_date"),
-            "adult": show.get("adult", False),
-        }
-
-    fetched = await asyncio.gather(*[fetch_episode(s) for s in collected_shows])
-    results = [r for r in fetched if r is not None]
-    await enrich_with_state(db, current_user.id, results)
-    return {"results": results}
+    fetched = await asyncio.gather(*(fetch_episodes(show) for show in collected_shows))
+    results = [episode for episodes in fetched for episode in episodes]
+    results.sort(key=lambda episode: (
+        episode.get("release_date") or "",
+        (episode.get("show_title") or "").casefold(),
+        episode.get("season_number") if episode.get("season_number") is not None else -1,
+        episode.get("episode_number") if episode.get("episode_number") is not None else -1,
+        episode.get("tmdb_id") or -1,
+    ))
+    await enrich_with_state(db, effective_user_id, results)
+    return {"results": results, "today": window_start.isoformat(), "window_days": days}
 
 
 def recently_added_order(max_added):

--- a/backend/tests/test_airing_window.py
+++ b/backend/tests/test_airing_window.py
@@ -1,0 +1,37 @@
+import os
+import unittest
+from datetime import datetime, timezone
+
+from pydantic import TypeAdapter, ValidationError
+
+os.environ.setdefault("SECRET_KEY", "test-secret")
+os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://test:test@localhost/test")
+
+from routers.media import _air_date_in_window, _airing_window
+from typing import Literal
+
+
+class AiringWindowTests(unittest.TestCase):
+    def test_uses_the_browser_timezone_for_date_boundaries(self):
+        start, end = _airing_window(
+            "America/Los_Angeles",
+            7,
+            now=datetime(2026, 1, 8, 2, 30, tzinfo=timezone.utc),
+        )
+        self.assertEqual(start.isoformat(), "2026-01-07")
+        self.assertEqual(end.isoformat(), "2026-01-13")
+
+    def test_window_is_inclusive_and_date_only(self):
+        start, end = _airing_window("UTC", 7, now=datetime(2026, 1, 7, 12, tzinfo=timezone.utc))
+        self.assertTrue(_air_date_in_window("2026-01-07", start, end))
+        self.assertTrue(_air_date_in_window("2026-01-13", start, end))
+        self.assertFalse(_air_date_in_window("2026-01-14", start, end))
+        self.assertFalse(_air_date_in_window("2026-01-07T20:00:00Z", start, end))
+        self.assertFalse(_air_date_in_window("not-a-date", start, end))
+
+    def test_only_the_supported_homepage_window_values_are_valid(self):
+        adapter = TypeAdapter(Literal[1, 7])
+        self.assertEqual(adapter.validate_python(1), 1)
+        self.assertEqual(adapter.validate_python(7), 7)
+        with self.assertRaises(ValidationError):
+            adapter.validate_python(2)

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
     "dev": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
+    "test": "node --test test/*.test.mjs",
     "astro": "astro"
   },
   "dependencies": {

--- a/frontend/src/pages/index.astro
+++ b/frontend/src/pages/index.astro
@@ -366,12 +366,23 @@ const discoverBackdropUrl = discoverPick?.backdrop_path
       <!-- Airing Today -->
       <section class="mb-16" id="section-airing-today">
         <div class="flex items-center justify-between mb-8">
-          <h2 class="section-headline">Airing Today</h2>
-          <a href="/airing-today" class="text-sm font-bold uppercase tracking-widest text-zinc-500 hover:text-blue-400 transition-all flex items-center gap-2 group/all">
-            See All <span class="group-hover/all:translate-x-1 transition-transform">→</span>
-          </a>
+          <div>
+            <h2 class="section-headline" id="airing-window-heading">Airing Today</h2>
+            <p id="airing-window-description" class="mt-1 text-xs text-zinc-500">Episode release dates for shows in your collection</p>
+          </div>
+          <div class="flex items-center gap-4">
+            {user && (
+              <div class="flex rounded-lg border border-zinc-800 bg-zinc-900 p-1" role="group" aria-label="Airing episode date range">
+                <button type="button" data-airing-window="1" aria-pressed="true" class="rounded-md px-2.5 py-1 text-xs font-bold text-zinc-100 bg-zinc-800 transition-colors">Today</button>
+                <button type="button" data-airing-window="7" aria-pressed="false" class="rounded-md px-2.5 py-1 text-xs font-bold text-zinc-400 hover:text-zinc-100 transition-colors">7 days</button>
+              </div>
+            )}
+            <a href="/airing-today" class="text-sm font-bold uppercase tracking-widest text-zinc-500 hover:text-blue-400 transition-all flex items-center gap-2 group/all">
+              See All <span class="group-hover/all:translate-x-1 transition-transform">→</span>
+            </a>
+          </div>
         </div>
-        <div class="flex gap-3 overflow-x-auto pb-3 scrollbar-none -mx-6 px-6 md:mx-0 md:px-0" id="grid-airing-today">
+        <div class="flex gap-3 overflow-x-auto pb-3 scrollbar-none -mx-6 px-6 md:mx-0 md:px-0" id="grid-airing-today" aria-live="polite">
           {Array.from({ length: 10 }).map(() => (
             <div class="flex-shrink-0 w-56 animate-pulse rounded-2xl overflow-hidden bg-zinc-900 border border-zinc-800">
               <div class="aspect-[3/2] bg-zinc-800"></div>
@@ -385,6 +396,9 @@ const discoverBackdropUrl = discoverPick?.backdrop_path
 </Base>
 
 <script define:vars={{ token, hasUser: !!user }}>
+
+  const airingPreferenceKey = 'scrob:home-airing-window-days';
+  const userTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
 
   function esc(str) {
           if (str == null) return '';
@@ -403,6 +417,26 @@ const discoverBackdropUrl = discoverPick?.backdrop_path
       return path;
     }
     return `/api/proxy/media/image/${size}${path.startsWith('/') ? path : '/' + path}`;
+  }
+
+  function localIsoDate() {
+    const parts = new Intl.DateTimeFormat('en-CA', {
+      timeZone: userTimezone, year: 'numeric', month: '2-digit', day: '2-digit',
+    }).formatToParts(new Date());
+    const value = Object.fromEntries(parts.map((part) => [part.type, part.value]));
+    return `${value.year}-${value.month}-${value.day}`;
+  }
+
+  function episodeDateLabel(iso) {
+    if (!iso || !/^\d{4}-\d{2}-\d{2}$/.test(iso)) return '';
+    const current = Date.UTC(...localIsoDate().split('-').map(Number));
+    const target = Date.UTC(...iso.split('-').map(Number));
+    const diff = Math.round((target - current) / 86400000);
+    if (diff === 0) return 'Today';
+    if (diff === 1) return 'Tomorrow';
+    return new Date(`${iso}T00:00:00Z`).toLocaleDateString(undefined, {
+      weekday: 'short', month: 'short', day: 'numeric', timeZone: 'UTC',
+    });
   }
 
   // ─────────────────────────────────────────────────────────────────────────
@@ -511,6 +545,7 @@ const discoverBackdropUrl = discoverPick?.backdrop_path
           const sxe = item.season_number != null && item.episode_number != null
             ? `S${String(item.season_number).padStart(2, '0')}E${String(item.episode_number).padStart(2, '0')}`
             : null;
+          const airDate = episodeDateLabel(item.release_date);
 
           return `<a href="${esc(href)}" class="flex-shrink-0 w-56 group relative block rounded-2xl overflow-hidden bg-zinc-900 border border-zinc-800 hover:border-blue-500/50 hover:shadow-2xl hover:shadow-blue-900/20 transition-all duration-300 transform hover:-translate-y-1 active:scale-95 active:opacity-70">
             <div class="aspect-[3/2] bg-zinc-950 relative overflow-hidden ring-1 ring-white/5 group-hover:ring-blue-500/30 transition-all duration-300">
@@ -521,33 +556,43 @@ const discoverBackdropUrl = discoverPick?.backdrop_path
               <div class="absolute inset-0 bg-gradient-to-t from-black/80 via-black/20 to-transparent"></div>
               ${sxe ? `<div class="absolute top-2 left-2 bg-blue-600/90 backdrop-blur-md text-white text-[10px] font-black px-2 py-0.5 rounded-full shadow-lg border border-blue-500/30">${esc(sxe)}</div>` : ''}
               <div class="absolute bottom-0 left-0 right-0 p-3">
-                ${item.show_title ? `<p class="text-[11px] font-bold text-white/70 truncate leading-tight">${esc(item.show_title)}</p>` : ''}
+                <div class="flex items-center justify-between gap-2">
+                  ${item.show_title ? `<p class="text-[11px] font-bold text-white/70 truncate leading-tight">${esc(item.show_title)}</p>` : ''}
+                  ${airDate ? `<span class="shrink-0 text-[10px] font-bold text-blue-200">${esc(airDate)}</span>` : ''}
+                </div>
                 <h3 class="text-sm font-bold text-white truncate group-hover:text-blue-300 transition-colors leading-tight">${esc(item.title)}</h3>
               </div>
             </div>
           </a>`;
         }
 
-        async function loadSection(url, gridId, renderFn, limit) {
+        async function loadSection(url, gridId, renderFn, limit, emptyMessage = null) {
           const grid = document.getElementById(gridId);
           if (!grid) return;
+          const clearOrRemove = () => {
+            if (emptyMessage) {
+              grid.innerHTML = `<p class="w-full py-5 text-sm text-zinc-500">${esc(emptyMessage)}</p>`;
+            } else {
+              grid.closest('section').remove();
+            }
+          };
           try {
             const res = await fetch(url, {
               headers: token ? { 'Authorization': `Bearer ${token}` } : {},
             });
             if (!res.ok) {
-              grid.closest('section').remove();
+              clearOrRemove();
               return;
             }
             const data = await res.json();
             const items = (data.results ?? []).slice(0, limit);
             if (items.length === 0) {
-              grid.closest('section').remove();
+              clearOrRemove();
               return;
             }
             grid.innerHTML = items.map(renderFn).join('');
           } catch {
-            grid.closest('section').remove();
+            clearOrRemove();
           }
         }
 
@@ -558,8 +603,41 @@ const discoverBackdropUrl = discoverPick?.backdrop_path
           loadSection('/api/proxy/media/trending/shows', 'grid-trending-shows', mediaCardHtml, 12);
         }
         if (hasUser) {
-          const userTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-          loadSection(`/api/proxy/media/airing-today/collected?timezone=${encodeURIComponent(userTimezone)}`, 'grid-airing-today', episodeCardHtml, 12);
+          const heading = document.getElementById('airing-window-heading');
+          const description = document.getElementById('airing-window-description');
+          const windowButtons = Array.from(document.querySelectorAll('[data-airing-window]'));
+          let selectedDays = 1;
+          try {
+            selectedDays = localStorage.getItem(airingPreferenceKey) === '7' ? 7 : 1;
+          } catch {}
+
+          const loadAiringWindow = (days) => {
+            const isWeek = days === 7;
+            heading.textContent = isWeek ? 'Airing Next 7 Days' : 'Airing Today';
+            description.textContent = isWeek
+              ? 'Episode release dates for the next 7 calendar days — no airtimes are implied'
+              : 'Episode release dates for shows in your collection';
+            windowButtons.forEach((button) => {
+              const active = Number(button.dataset.airingWindow) === days;
+              button.setAttribute('aria-pressed', String(active));
+              button.classList.toggle('bg-zinc-800', active);
+              button.classList.toggle('text-zinc-100', active);
+              button.classList.toggle('text-zinc-400', !active);
+            });
+            loadSection(
+              `/api/proxy/media/airing-today/collected?timezone=${encodeURIComponent(userTimezone)}&days=${days}`,
+              'grid-airing-today',
+              episodeCardHtml,
+              12,
+              isWeek ? 'No collected episodes are scheduled in the next 7 calendar days.' : 'No collected episodes are scheduled today.',
+            );
+          };
+          windowButtons.forEach((button) => button.addEventListener('click', () => {
+            selectedDays = Number(button.dataset.airingWindow);
+            try { localStorage.setItem(airingPreferenceKey, String(selectedDays)); } catch {}
+            loadAiringWindow(selectedDays);
+          }));
+          loadAiringWindow(selectedDays);
         } else {
           // No personal collection to filter by when logged out - show a
           // small generic sample of what's airing today instead.

--- a/frontend/test/upcoming-window.test.mjs
+++ b/frontend/test/upcoming-window.test.mjs
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const page = await readFile(new URL("../src/pages/index.astro", import.meta.url), "utf8");
+
+test("homepage has an accessible persisted Today/7 days chooser", () => {
+  assert.match(page, /role="group" aria-label="Airing episode date range"/);
+  assert.match(page, /data-airing-window="1"/);
+  assert.match(page, /data-airing-window="7"/);
+  assert.match(page, /localStorage\.getItem\(airingPreferenceKey\)/);
+  assert.match(page, /localStorage\.setItem\(airingPreferenceKey/);
+});
+
+test("seven-day requests pass the browser timezone and label only calendar dates", () => {
+  assert.match(page, /Intl\.DateTimeFormat\(\)\.resolvedOptions\(\)\.timeZone/);
+  assert.match(page, /airing-today\/collected\?timezone=/);
+  assert.match(page, /&days=\$\{days\}/);
+  assert.match(page, /no airtimes are implied/);
+  assert.match(page, /episodeDateLabel\(item\.release_date\)/);
+});


### PR DESCRIPTION
## Summary
- add an accessible, browser-local Today / 7 days chooser to the collected-show airing rail
- compute inclusive calendar-day bounds from the browser-supplied IANA timezone and return deterministically sorted episode dates
- keep the feed collection-scoped and date-only, with clear labels that do not imply exact airtimes

## Verification
- `cd backend && PYTHONPATH=. /private/tmp/scrob-188.gts4iC/backend/.venv/bin/python -m unittest tests.test_airing_window` (3 passed)
- `cd backend && PYTHONPATH=. /private/tmp/scrob-188.gts4iC/backend/.venv/bin/python -m compileall -q routers/media.py`
- `cd frontend && npm test` (2 passed)
- `cd frontend && ASTRO_TELEMETRY_DISABLED=1 npm run build`
- `git diff --check`

TMDB supplies episode dates rather than reliable universal airtimes. The implementation therefore deliberately makes date-only claims and inspects the current season(s) identified by TMDB’s last/next episode pointers.

Closes #113