### PR TITLE
Fix: Next Up episodes left / time left counts unaired episodes (#296)

### DIFF
--- a/backend/routers/history.py
+++ b/backend/routers/history.py
@@ -759,9 +759,34 @@ async def _next_up_remaining_stats(
     )
     avg_by_show = {sid: float(avg) for sid, avg in avg_rows.all() if avg is not None}
 
+    # Shows still airing whose cached metadata has no last_episode_to_air can't
+    # be capped to aired episodes, so the count would include episodes that
+    # haven't aired yet (#296). Fetch it live for exactly those shows: Next Up
+    # is a short list, and finished shows never need it.
+    FINAL_STATUSES = {"Ended", "Canceled"}
+    needs_last_ep = [
+        sid for sid, show in shows_by_id.items()
+        if show.tmdb_id
+        and not (show.tmdb_data or {}).get("last_episode_to_air")
+        and (show.status or "") not in FINAL_STATUSES
+    ]
+    last_ep_by_show: dict[int, dict] = {}
+    if needs_last_ep:
+        tmdb_key = await get_user_tmdb_key(db, user_id)
+        if check_tmdb_key(tmdb_key):
+            async def _fetch_show_light(sid: int) -> tuple[int, dict | None]:
+                try:
+                    return sid, await tmdb.get_show_light(shows_by_id[sid].tmdb_id, api_key=tmdb_key)
+                except Exception:
+                    return sid, None
+
+            for sid, data in await asyncio.gather(*[_fetch_show_light(sid) for sid in needs_last_ep]):
+                if data:
+                    last_ep_by_show[sid] = data
+
     stats: dict[int, dict] = {}
     for sid, show in shows_by_id.items():
-        season_counts = capped_season_episode_counts(show)
+        season_counts = capped_season_episode_counts(show, last_ep_by_show.get(sid))
         avg_runtime = avg_by_show.get(sid)
         if not avg_runtime:
             run_times = (show.tmdb_data or {}).get("episode_run_time") or []
@@ -1805,6 +1830,7 @@ async def mark_show_watched(
             data = await tmdb.get_show(body.series_tmdb_id, api_key=api_key)
             show.tmdb_data = {
                 "genres": [g["name"] for g in data.get("genres", [])],
+                "last_episode_to_air": data.get("last_episode_to_air"),
                 "seasons": [
                     {
                         "season_number": s["season_number"],

--- a/backend/routers/shows.py
+++ b/backend/routers/shows.py
@@ -1694,6 +1694,9 @@ async def refresh_show_metadata(
         "genres": [g["name"] for g in data.get("genres", [])],
         "external_ids": data.get("external_ids", {}),
         "original_language": data.get("original_language"),
+        # Kept so capped_season_episode_counts() can exclude unaired episodes
+        # from cache-only callers like Next Up, which have no tmdb_extra (#296).
+        "last_episode_to_air": data.get("last_episode_to_air"),
         "seasons": [
             {
                 "season_number": s["season_number"],

--- a/backend/tests/test_next_up.py
+++ b/backend/tests/test_next_up.py
@@ -6,6 +6,7 @@ os.environ.setdefault("SECRET_KEY", "test-secret")
 os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://test:test@localhost/test")
 
 from routers.history import _compute_next_episode, _group_last_watched, _has_aired, _has_confirmed_air_date, _remaining_episode_stats
+from core.rewatch import capped_season_episode_counts
 
 
 class ComputeNextEpisodeTests(unittest.TestCase):
@@ -168,6 +169,38 @@ class RemainingEpisodeStatsTests(unittest.TestCase):
     def test_no_aired_episodes_returns_none(self):
         self.assertIsNone(_remaining_episode_stats({}, {}, avg_runtime=30.0))
         self.assertIsNone(_remaining_episode_stats({0: 3}, {}, avg_runtime=30.0))
+
+
+class CappedSeasonCountsFromCacheTests(unittest.TestCase):
+    """#296: unaired episodes must not be counted on the Next Up card."""
+
+    class _Show:
+        def __init__(self, tmdb_data):
+            self.tmdb_data = tmdb_data
+
+    def _show(self, last_ep):
+        data = {"seasons": [{"season_number": 1, "episode_count": 10},
+                            {"season_number": 2, "episode_count": 10}]}
+        if last_ep is not None:
+            data["last_episode_to_air"] = last_ep
+        return self._Show(data)
+
+    def test_current_season_capped_at_last_aired_episode(self):
+        # Season 2 is mid-flight: 8 of 10 episodes out.
+        counts = capped_season_episode_counts(
+            self._show({"season_number": 2, "episode_number": 8})
+        )
+        self.assertEqual(counts[2], 8)
+        # 7 watched of the 8 aired -> exactly 1 left, not 3.
+        stats = _remaining_episode_stats(counts, {1: 10, 2: 7}, avg_runtime=51.0)
+        self.assertEqual(stats["episodes_left"], 1)
+
+    def test_future_seasons_are_zeroed(self):
+        counts = capped_season_episode_counts(
+            self._show({"season_number": 1, "episode_number": 4})
+        )
+        self.assertEqual(counts[1], 4)
+        self.assertEqual(counts[2], 0)
 
     def test_fractional_average_runtime_rounds(self):
         stats = _remaining_episode_stats({1: 4}, {1: 1}, avg_runtime=42.5)


### PR DESCRIPTION
Fixes #296. The Next Up card's "episodes left / time left" counted episodes that haven't aired yet, so a show mid-season overstated both numbers (reported example: a card saying "3 episodes left · ~2h33m" when only one aired episode was left to watch). The show detail page was already correct, which is what makes the mismatch visible.

`capped_season_episode_counts()` caps the current season at `last_episode_to_air` and zeroes later seasons, but it can only do that when the field is on the Show row. The writers that store a show's `tmdb_data` build a trimmed dict and drop it, so the detail page (which passes a freshly fetched `tmdb_extra`) capped correctly while Next Up — reading the cache only — did not.

Two parts:
- **Persist `last_episode_to_air`** in the trimmed `tmdb_data` written by the show refresh and by the history path that fetches show metadata. It's already in the TMDB response, so this costs nothing extra and makes the existing capping work for every cache-only caller.
- **Live fallback in Next Up** for shows that are still airing and whose cached metadata predates this change, so existing installs are correct right away instead of waiting for a metadata refresh. Scoped tightly: only Next Up shows, only non-Ended/Canceled ones, only when the field is missing, fetched concurrently with `get_show_light` and failing open — the same approach `routers/media.py` already uses for watched percentages.

Tests: two regression cases covering the mid-season cap (10-episode season with 8 aired → 1 left, not 3) and future seasons being zeroed. Full suite passes (664).
