### PR TITLE
feat(api): add dedicated proxy Swagger UI at /docs/proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Scrob syncs your libraries from **Jellyfin**, **Plex**, **Emby**, **Nuvio**, **A
 - **Logged-out browsing (opt-in)**: Public profiles and lists require an account to view by default. An admin can enable **Allow browsing without an account** in the admin panel to let visitors browse without signing in.
 - **Progressive Web App**: Install Scrob on any device - Android, iOS, or desktop - for a native app feel.
 - **Single container**: Frontend and backend ship as one image on one port. No separate services to manage.
-- **API documentation**: Full interactive OpenAPI docs at `/docs` (Swagger UI) and `/redoc` (ReDoc), useful if you're scripting against Scrob directly.
+- **API documentation**: Full interactive OpenAPI docs at `/docs` (Swagger UI) and `/redoc` (ReDoc), useful if you're scripting against Scrob directly. Admins also get `/docs/proxy`, a Swagger UI of the same API as exposed through the frontend's `/api/proxy/` gateway - every path shown there is callable from the browser with a logged-in session (or a Bearer token / `X-Api-Key`).
 
 ## Screenshots
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,4 +1,5 @@
 import asyncio
+from copy import deepcopy
 from fastapi import Depends, FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.openapi.docs import get_redoc_html, get_swagger_ui_html
@@ -578,6 +579,61 @@ async def get_docs(_: User = Depends(require_admin)):
 @app.get("/redoc", include_in_schema=False)
 async def get_redoc(_: User = Depends(require_admin)):
     return get_redoc_html(openapi_url="/openapi.json", title=f"{app.title} - ReDoc")
+
+
+# Proxy-facing API docs. The browser never calls this backend directly - every
+# frontend request goes through the Astro catch-all at /api/proxy/, which
+# forwards paths 1:1 (session cookie -> Bearer header, X-Api-Key passed
+# through). This derived schema rewrites the real one so it documents what
+# clients actually call: every path prefixed with /api/proxy and resolved
+# against the public frontend origin. Same admin gate as /docs above.
+_PROXY_SCHEMA_EXCLUDED_PATHS = {"/health"}
+
+
+def _build_proxy_openapi() -> dict:
+    # app.openapi() returns its cached schema by reference - mutating it here
+    # would re-prefix the paths on every call (and corrupt the plain /docs
+    # schema, which shares the same dict), so work on a deep copy.
+    spec = deepcopy(app.openapi())
+    spec["info"]["title"] = f"{app.title} - Frontend Proxy API"
+    spec["info"]["description"] = (
+        "Browser-facing view of the Scrob API.\n\n"
+        "Every endpoint is reached through the frontend's generic proxy at "
+        "`/api/proxy/<path>` - the Astro server forwards each request 1:1 to the "
+        "internal backend - so all paths below carry that prefix and resolve "
+        "against the public frontend origin, not the backend port.\n\n"
+        "**Auth:** a logged-in browser session works automatically (the proxy "
+        "converts the session cookie into a Bearer token). For scripts, send "
+        "`Authorization: Bearer <JWT>` or an `X-Api-Key` header (the user API key "
+        "from Profile Settings); both are forwarded as-is. Webhook and "
+        "Radarr/Sonarr-compat endpoints additionally accept `?api_key=`."
+    )
+    spec["servers"] = [{"url": settings.server_url}]
+    spec["paths"] = {
+        f"/api/proxy{path}": ops
+        for path, ops in spec["paths"].items()
+        if path not in _PROXY_SCHEMA_EXCLUDED_PATHS
+    }
+    # Rewrite security scheme URLs so Swagger UI resolves them against the
+    # frontend origin (which already carries the /api/proxy prefix).
+    for scheme in spec.get("components", {}).get("securitySchemes", {}).values():
+        if scheme.get("type") == "oauth2":
+            for flow in scheme.get("flows", {}).values():
+                if "tokenUrl" in flow:
+                    flow["tokenUrl"] = "/api/proxy/" + flow["tokenUrl"].lstrip("/")
+                if "authorizationUrl" in flow:
+                    flow["authorizationUrl"] = "/api/proxy/" + flow["authorizationUrl"].lstrip("/")
+    return spec
+
+
+@app.get("/proxy-openapi.json", include_in_schema=False)
+async def get_proxy_openapi_schema(_: User = Depends(require_admin)):
+    return JSONResponse(_build_proxy_openapi())
+
+
+@app.get("/docs/proxy", include_in_schema=False)
+async def get_proxy_docs(_: User = Depends(require_admin)):
+    return get_swagger_ui_html(openapi_url="/proxy-openapi.json", title=f"{app.title} - Proxy Swagger UI")
 
 # The backend is internal-only (localhost), but lock CORS to the configured
 # frontend origin as defence-in-depth. The backend uses Bearer token auth only

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -43,7 +43,7 @@ const PUBLIC_MEDIA_ROWS_PROXY_RE =
 // API docs reveal the full endpoint surface and exact app version - admin-only,
 // never public, regardless of the isStaticAsset check below (which would
 // otherwise treat /openapi.json as a public static file just from its extension).
-const ADMIN_ONLY_ROUTES = ["/docs", "/redoc", "/openapi.json"];
+const ADMIN_ONLY_ROUTES = ["/docs", "/redoc", "/openapi.json", "/docs/proxy", "/proxy-openapi.json"];
 
 // Security headers added to every response.
 // CSP is intentionally omitted — Astro's define:vars emits inline <script>

--- a/frontend/src/pages/docs/proxy.ts
+++ b/frontend/src/pages/docs/proxy.ts
@@ -1,0 +1,4 @@
+import type { APIRoute } from "astro";
+import { proxyBackendPath } from "../../lib/backend-proxy";
+
+export const GET: APIRoute = (ctx) => proxyBackendPath("/docs/proxy", ctx.locals.token);

--- a/frontend/src/pages/proxy-openapi.json.ts
+++ b/frontend/src/pages/proxy-openapi.json.ts
@@ -1,0 +1,4 @@
+import type { APIRoute } from "astro";
+import { proxyBackendPath } from "../lib/backend-proxy";
+
+export const GET: APIRoute = (ctx) => proxyBackendPath("/proxy-openapi.json", ctx.locals.token);


### PR DESCRIPTION
Adds a second Swagger UI endpoint at `/docs/proxy` that documents the Scrob API as seen through the frontend `/api/proxy/` gateway. Every path carries the `/api/proxy` prefix and resolves against the public frontend origin, so **Try-it-out** works directly from a logged-in browser session — no manual token copy-pasting needed.

**Changes:**
- **`backend/main.py`** — build a derived OpenAPI schema via `deepcopy()`: prefix all paths with `/api/proxy`, rewrite `tokenUrl` in OAuth2 security schemes to `/api/proxy/auth/login`, set `servers` to the public `server_url`, exclude `/health`.
- **`frontend/src/pages/docs/proxy.ts`** + **`proxy-openapi.json.ts`** — Astro endpoints proxying the new backend routes through `proxyBackendPath()`.
- **`frontend/src/middleware.ts`** — add `/docs/proxy` and `/proxy-openapi.json` to `ADMIN_ONLY_ROUTES`.
- **`README.md`** — document the new endpoint.
- fix(auth): allow unauthenticated access to proxy auth endpoints

**Why:** Until now, users who wanted to script against the Scrob API through the browser had to guess which endpoints were accessible via `/api/proxy/` and manually obtain a Bearer token. The new proxy Swagger UI makes the full browser-facing surface self-documenting and interactive.