### PR TITLE
fix(auth): allow unauthenticated access to proxy auth endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Scrob syncs your libraries from **Jellyfin**, **Plex**, **Emby**, **Nuvio**, **A
 - **Logged-out browsing (opt-in)**: Public profiles and lists require an account to view by default. An admin can enable **Allow browsing without an account** in the admin panel to let visitors browse without signing in.
 - **Progressive Web App**: Install Scrob on any device - Android, iOS, or desktop - for a native app feel.
 - **Single container**: Frontend and backend ship as one image on one port. No separate services to manage.
-- **API documentation**: Full interactive OpenAPI docs at `/docs` (Swagger UI) and `/redoc` (ReDoc), useful if you're scripting against Scrob directly.
+- **API documentation**: Full interactive OpenAPI docs at `/docs` (Swagger UI) and `/redoc` (ReDoc), useful if you're scripting against Scrob directly. Admins also get `/docs/proxy`, a Swagger UI of the same API as exposed through the frontend's `/api/proxy/` gateway - every path shown there is callable from the browser with a logged-in session (or a Bearer token / `X-Api-Key`).
 
 ## Screenshots
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,4 +1,5 @@
 import asyncio
+from copy import deepcopy
 from fastapi import Depends, FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.openapi.docs import get_redoc_html, get_swagger_ui_html
@@ -578,6 +579,61 @@ async def get_docs(_: User = Depends(require_admin)):
 @app.get("/redoc", include_in_schema=False)
 async def get_redoc(_: User = Depends(require_admin)):
     return get_redoc_html(openapi_url="/openapi.json", title=f"{app.title} - ReDoc")
+
+
+# Proxy-facing API docs. The browser never calls this backend directly - every
+# frontend request goes through the Astro catch-all at /api/proxy/, which
+# forwards paths 1:1 (session cookie -> Bearer header, X-Api-Key passed
+# through). This derived schema rewrites the real one so it documents what
+# clients actually call: every path prefixed with /api/proxy and resolved
+# against the public frontend origin. Same admin gate as /docs above.
+_PROXY_SCHEMA_EXCLUDED_PATHS = {"/health"}
+
+
+def _build_proxy_openapi() -> dict:
+    # app.openapi() returns its cached schema by reference - mutating it here
+    # would re-prefix the paths on every call (and corrupt the plain /docs
+    # schema, which shares the same dict), so work on a deep copy.
+    spec = deepcopy(app.openapi())
+    spec["info"]["title"] = f"{app.title} - Frontend Proxy API"
+    spec["info"]["description"] = (
+        "Browser-facing view of the Scrob API.\n\n"
+        "Every endpoint is reached through the frontend's generic proxy at "
+        "`/api/proxy/<path>` - the Astro server forwards each request 1:1 to the "
+        "internal backend - so all paths below carry that prefix and resolve "
+        "against the public frontend origin, not the backend port.\n\n"
+        "**Auth:** a logged-in browser session works automatically (the proxy "
+        "converts the session cookie into a Bearer token). For scripts, send "
+        "`Authorization: Bearer <JWT>` or an `X-Api-Key` header (the user API key "
+        "from Profile Settings); both are forwarded as-is. Webhook and "
+        "Radarr/Sonarr-compat endpoints additionally accept `?api_key=`."
+    )
+    spec["servers"] = [{"url": settings.server_url}]
+    spec["paths"] = {
+        f"/api/proxy{path}": ops
+        for path, ops in spec["paths"].items()
+        if path not in _PROXY_SCHEMA_EXCLUDED_PATHS
+    }
+    # Rewrite security scheme URLs so Swagger UI resolves them against the
+    # frontend origin (which already carries the /api/proxy prefix).
+    for scheme in spec.get("components", {}).get("securitySchemes", {}).values():
+        if scheme.get("type") == "oauth2":
+            for flow in scheme.get("flows", {}).values():
+                if "tokenUrl" in flow:
+                    flow["tokenUrl"] = "/api/proxy/" + flow["tokenUrl"].lstrip("/")
+                if "authorizationUrl" in flow:
+                    flow["authorizationUrl"] = "/api/proxy/" + flow["authorizationUrl"].lstrip("/")
+    return spec
+
+
+@app.get("/proxy-openapi.json", include_in_schema=False)
+async def get_proxy_openapi_schema(_: User = Depends(require_admin)):
+    return JSONResponse(_build_proxy_openapi())
+
+
+@app.get("/docs/proxy", include_in_schema=False)
+async def get_proxy_docs(_: User = Depends(require_admin)):
+    return get_swagger_ui_html(openapi_url="/proxy-openapi.json", title=f"{app.title} - Proxy Swagger UI")
 
 # The backend is internal-only (localhost), but lock CORS to the configured
 # frontend origin as defence-in-depth. The backend uses Bearer token auth only

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -43,7 +43,7 @@ const PUBLIC_MEDIA_ROWS_PROXY_RE =
 // API docs reveal the full endpoint surface and exact app version - admin-only,
 // never public, regardless of the isStaticAsset check below (which would
 // otherwise treat /openapi.json as a public static file just from its extension).
-const ADMIN_ONLY_ROUTES = ["/docs", "/redoc", "/openapi.json"];
+const ADMIN_ONLY_ROUTES = ["/docs", "/redoc", "/openapi.json", "/docs/proxy", "/proxy-openapi.json"];
 
 // Security headers added to every response.
 // CSP is intentionally omitted — Astro's define:vars emits inline <script>

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -2,7 +2,7 @@ import { defineMiddleware } from "astro:middleware";
 import { api } from "./lib/api";
 
 const PUBLIC_ROUTES = ["/login", "/register", "/logout", "/oidc-callback", "/oidc-start", "/site.webmanifest", "/favicon.ico", "/favicon.svg", "/apple-touch-icon.png", "/sw.js", "/offline.html"];
-const PUBLIC_PREFIXES = ["/auth/activate/", "/forgot-password", "/reset-password/", "/api/proxy/webhooks/", "/api/proxy/auth/has-users", "/api/proxy/auth/bootstrap-restore", "/api/proxy/media/stream/", "/api/proxy/radarr-compat/", "/api/proxy/sonarr-compat/"];
+const PUBLIC_PREFIXES = ["/auth/activate/", "/forgot-password", "/reset-password/", "/api/proxy/webhooks/", "/api/proxy/auth/has-users", "/api/proxy/auth/bootstrap-restore", "/api/proxy/auth/login", "/api/proxy/auth/register", "/api/proxy/auth/oidc/config", "/api/proxy/auth/oidc/authorize", "/api/proxy/auth/oidc/exchange", "/api/proxy/auth/forgot-password", "/api/proxy/auth/reset-password/", "/api/proxy/media/stream/", "/api/proxy/radarr-compat/", "/api/proxy/sonarr-compat/"];
 // Matches /profile/{id} (someone else's public profile page) but not the bare
 // /profile page (the logged-in user's own profile management), which must stay gated.
 const PUBLIC_PROFILE_PAGE_RE = /^\/profile\/\d+\/?$/;

--- a/frontend/src/pages/docs/proxy.ts
+++ b/frontend/src/pages/docs/proxy.ts
@@ -1,0 +1,4 @@
+import type { APIRoute } from "astro";
+import { proxyBackendPath } from "../../lib/backend-proxy";
+
+export const GET: APIRoute = (ctx) => proxyBackendPath("/docs/proxy", ctx.locals.token);

--- a/frontend/src/pages/proxy-openapi.json.ts
+++ b/frontend/src/pages/proxy-openapi.json.ts
@@ -1,0 +1,4 @@
+import type { APIRoute } from "astro";
+import { proxyBackendPath } from "../lib/backend-proxy";
+
+export const GET: APIRoute = (ctx) => proxyBackendPath("/proxy-openapi.json", ctx.locals.token);


### PR DESCRIPTION
Allow unauthenticated browser-initiated requests to reach `/api/proxy/auth/login`, `/api/proxy/auth/register`, `/api/proxy/auth/oidc/*`, and other public auth endpoints through the frontend proxy.

Previously, the Astro middleware required a session cookie for every `/api/proxy/*` request not explicitly allowlisted, which meant tools like Apidog/Postman could not reach `/api/proxy/auth/login` without a valid JWT — a catch-22 since the login endpoint is how you obtain one.

The new `/api/proxy/auth/login`, `/api/proxy/auth/register`, `/api/proxy/auth/oidc/*`, `/api/proxy/auth/forgot-password`, and `/api/proxy/auth/reset-password/` paths are added to `PUBLIC_PREFIXES` alongside the existing webhooks and bootstrap endpoints.