### PR TITLE
fix: use is_admin instead of role=="admin" in profile access checks

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -1,6 +1,7 @@
 import gzip
 import io
 import json
+import secrets
 import struct
 from datetime import datetime
 
@@ -17,11 +18,12 @@ from models.global_settings import GlobalSettings
 from models.media import Media
 from models.collection import Collection
 from models.sync import SyncJob, SyncStatus
-from models.base import CollectionSource, MediaType
+from models.base import CollectionSource, MediaType, UserRole
 from models.media_request import MediaRequest, RequestStatus
 from models.users import UserSettings
 from dependencies import require_admin
 from core.url_validator import validate_service_url
+from core.security import get_password_hash
 from core.backup import asyncpg_conn, restore_backup
 import schemas
 
@@ -92,6 +94,37 @@ async def list_users(
         )
         for u, p in result.all()
     ]
+
+
+@router.post("/users", response_model=schemas.AdminUser, status_code=status.HTTP_201_CREATED)
+async def create_user(
+    body: schemas.AdminUserCreate,
+    db: AsyncSession = Depends(get_db),
+    _: User = Depends(require_admin),
+):
+    result = await db.execute(
+        select(User).where((User.email == body.email) | (User.username == body.username))
+    )
+    if result.scalar_one_or_none():
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="User with this email or username already exists",
+        )
+
+    new_user = User(
+        email=body.email,
+        username=body.username,
+        password_hash=get_password_hash(body.password),
+        api_key=secrets.token_urlsafe(32),
+        role=UserRole.admin if body.is_admin else UserRole.user,
+        is_admin=body.is_admin,
+        # Admin-created accounts are trusted, so skip e-mail activation.
+        email_confirmed=True,
+    )
+    db.add(new_user)
+    await db.commit()
+    await db.refresh(new_user)
+    return new_user
 
 
 @router.patch("/users/{user_id}/toggle-admin", response_model=schemas.AdminUser)

--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -150,6 +150,7 @@ async def toggle_admin(
             )
 
     target.is_admin = not target.is_admin
+    target.role = UserRole.admin if target.is_admin else UserRole.user
     await db.commit()
     await db.refresh(target)
     return target

--- a/backend/routers/profile.py
+++ b/backend/routers/profile.py
@@ -62,7 +62,7 @@ async def _check_profile_access(user_id: int, current_user, db: AsyncSession):
     profile = profile_result.scalar_one_or_none()
 
     is_owner = current_user and current_user.id == user_id
-    is_admin = current_user and current_user.role == "admin"
+    is_admin = current_user and current_user.is_admin
     privacy = profile.privacy_level if profile else PrivacyLevel.private
 
     is_mutual_follow = False
@@ -607,7 +607,7 @@ async def get_public_profile(
 ):
     user, profile = await _check_profile_access(user_id, current_user, db)
     is_owner = current_user and current_user.id == user_id
-    is_admin = current_user and current_user.role == "admin"
+    is_admin = current_user and current_user.is_admin
 
     # --- Stats ---
     watched_q = await db.execute(

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -449,6 +449,13 @@ class MediaRequestOut(BaseModel):
         from_attributes = True
 
 
+class AdminUserCreate(BaseModel):
+    username : str
+    email    : EmailStr
+    password : str
+    is_admin : bool = False
+
+
 class AdminUser(BaseModel):
     id         : int
     username   : str

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1374,6 +1374,8 @@ export const api = {
       patch<GlobalSettings>("/admin/settings", body, token),
     listUsers: (token: string) =>
       get<AdminUser[]>("/admin/users", undefined, token),
+    createUser: (body: { username: string; email: string; password: string; is_admin?: boolean }, token: string) =>
+      post<AdminUser>("/admin/users", body, token),
     toggleAdmin: (userId: number, token: string) =>
       patch<AdminUser>(`/admin/users/${userId}/toggle-admin`, undefined, token),
     deleteUser: (userId: number, token: string) =>

--- a/frontend/src/pages/admin.astro
+++ b/frontend/src/pages/admin.astro
@@ -376,7 +376,16 @@ const adminCount = users.filter((u: AdminUser) => u.is_admin).length;
 
     <!-- ── Users ── -->
     <section>
-      <h2 class="section-headline border-b border-zinc-800 pb-2 mb-6">Users</h2>
+      <div class="flex items-center justify-between gap-4 border-b border-zinc-800 pb-2 mb-6">
+        <h2 class="section-headline">Users</h2>
+        <button id="add-user-btn"
+          class="shrink-0 inline-flex items-center gap-1.5 px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white text-sm font-semibold rounded-xl transition-colors cursor-pointer">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-4 h-4">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
+          </svg>
+          Add User
+        </button>
+      </div>
 
       <div class="bg-zinc-900 border border-zinc-800 rounded-2xl overflow-hidden">
         <table class="w-full text-sm">
@@ -592,6 +601,67 @@ const adminCount = users.filter((u: AdminUser) => u.is_admin).length;
         Delete
       </button>
     </div>
+  </div>
+</div>
+
+<!-- Add User Modal -->
+<div id="add-user-modal" class="hidden fixed inset-0 z-50 flex items-center justify-center p-4">
+  <div id="add-user-modal-backdrop" class="absolute inset-0 bg-black/70 backdrop-blur-sm"></div>
+  <div class="relative bg-zinc-900 border border-zinc-800 rounded-3xl p-8 w-full max-w-md shadow-2xl max-h-[90vh] overflow-y-auto">
+    <h2 class="text-xl font-black text-zinc-100 mb-6">Add User</h2>
+    <form id="add-user-form" class="space-y-4" novalidate>
+      <div class="space-y-2">
+        <label for="new-user-username" class="block text-sm font-medium text-zinc-400">Username</label>
+        <input type="text" id="new-user-username" autocomplete="off" placeholder="johndoe"
+          class="w-full bg-zinc-950 border border-zinc-800 rounded-lg px-4 py-3 text-zinc-100 focus:outline-none focus:ring-2 focus:ring-blue-500 transition-all" />
+      </div>
+      <div class="space-y-2">
+        <label for="new-user-email" class="block text-sm font-medium text-zinc-400">Email</label>
+        <input type="email" id="new-user-email" autocomplete="off" placeholder="john@example.com"
+          class="w-full bg-zinc-950 border border-zinc-800 rounded-lg px-4 py-3 text-zinc-100 focus:outline-none focus:ring-2 focus:ring-blue-500 transition-all" />
+      </div>
+      <div class="space-y-2">
+        <label for="new-user-password" class="block text-sm font-medium text-zinc-400">Password</label>
+        <div class="relative group/field">
+          <input type="password" id="new-user-password" autocomplete="new-password" spellcheck="false"
+            class="w-full bg-zinc-950 border border-zinc-800 rounded-lg pl-4 pr-24 py-3 text-zinc-100 font-mono focus:outline-none focus:ring-2 focus:ring-blue-500 transition-all" />
+          <div class="absolute right-2 top-1/2 -translate-y-1/2 flex items-center gap-0.5">
+            <button type="button" id="gen-password-btn" title="Generate password" aria-label="Generate password"
+              class="p-1.5 text-zinc-500 hover:text-blue-400 rounded-md hover:bg-zinc-800 transition-colors cursor-pointer">
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09zM18.259 8.715L18 9.75l-.259-1.035a3.375 3.375 0 00-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 002.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 002.456 2.456L21.75 6l-1.035.259a3.375 3.375 0 00-2.456 2.456z" />
+              </svg>
+            </button>
+            <button type="button" id="copy-password-btn" title="Copy password" aria-label="Copy password"
+              class="p-1.5 text-zinc-500 hover:text-zinc-300 rounded-md hover:bg-zinc-800 transition-colors cursor-pointer">
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 17.25v3.375c0 .621-.504 1.125-1.125 1.125h-9.75a1.125 1.125 0 01-1.125-1.125V7.875c0-.621.504-1.125 1.125-1.125H6.75a9.06 9.06 0 011.5.124m7.5 10.376h3.375c.621 0 1.125-.504 1.125-1.125V11.25c0-4.46-3.243-8.161-7.5-8.976a9.06 9.06 0 00-1.5-.124H9.375c-.621 0-1.125.504-1.125 1.125v3.5m7.5 10.375H9.375a1.125 1.125 0 01-1.125-1.125v-9.25m12 6.625v-1.875a3.375 3.375 0 00-3.375-3.375h-1.5a1.125 1.125 0 01-1.125-1.125v-1.5a3.375 3.375 0 00-3.375-3.375H9.75" />
+              </svg>
+            </button>
+            <button type="button" class="password-toggle p-1 text-zinc-500 hover:text-zinc-300 transition-colors cursor-pointer" aria-label="Toggle visibility">
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 eye-icon"><path stroke-linecap="round" stroke-linejoin="round" d="M2.036 12.322a1.012 1.012 0 010-.644C3.412 7.943 7.213 5 12 5c4.787 0 8.588 2.943 9.964 6.678.066.18.066.362 0 .544C20.588 16.057 16.787 19 12 19c-4.787 0-8.588-2.943-9.964-6.678z" /><path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" /></svg>
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 eye-slash-icon hidden"><path stroke-linecap="round" stroke-linejoin="round" d="M3.98 8.223A10.477 10.477 0 001.934 12C3.226 16.338 7.244 19.5 12 19.5c.993 0 1.953-.138 2.863-.395M6.228 6.228A10.45 10.45 0 0112 4.5c4.756 0 8.773 3.162 10.065 7.498a10.523 10.523 0 01-4.293 5.774M6.228 6.228L3 3m3.228 3.228l3.65 3.65m7.894 7.894L21 21m-3.228-3.228l-3.65-3.65m0 0a3 3 0 10-4.243-4.243m4.242 4.242L9.88 9.88" /></svg>
+            </button>
+          </div>
+        </div>
+        <p class="text-xs text-zinc-500">16 characters with uppercase, lowercase, numbers and symbols.</p>
+      </div>
+      <label class="flex items-center gap-3 cursor-pointer select-none pt-1">
+        <input type="checkbox" id="new-user-is-admin"
+          class="w-4 h-4 rounded border-zinc-600 bg-zinc-950 text-blue-500 focus:ring-blue-500 cursor-pointer" />
+        <span class="text-sm text-zinc-300">Make this user an admin</span>
+      </label>
+      <div class="flex gap-3 pt-2">
+        <button type="button" id="add-user-cancel-btn"
+          class="flex-1 px-4 py-3 bg-zinc-800 hover:bg-zinc-700 text-zinc-300 font-bold rounded-xl transition-colors text-sm cursor-pointer">
+          Cancel
+        </button>
+        <button type="submit" id="add-user-submit-btn"
+          class="flex-1 px-4 py-3 bg-blue-600 hover:bg-blue-500 text-white font-bold rounded-xl transition-colors text-sm cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed">
+          Create User
+        </button>
+      </div>
+    </form>
   </div>
 </div>
 
@@ -1084,7 +1154,7 @@ const adminCount = users.filter((u: AdminUser) => u.is_admin).length;
   }
 
   // ── Row expand/collapse ──
-  document.querySelectorAll<HTMLTableRowElement>('#users-table-body tr.user-main-row').forEach(mainRow => {
+  function bindRowExpand(mainRow: HTMLTableRowElement) {
     mainRow.addEventListener('click', (e) => {
       const target = e.target as HTMLElement;
       if (target.closest('button')) return;
@@ -1095,7 +1165,9 @@ const adminCount = users.filter((u: AdminUser) => u.is_admin).length;
       detailRow.classList.toggle('hidden', isOpen);
       mainRow.querySelector('.row-chevron')?.classList.toggle('rotate-180', !isOpen);
     });
-  });
+  }
+
+  document.querySelectorAll<HTMLTableRowElement>('#users-table-body tr.user-main-row').forEach(bindRowExpand);
 
   // ── Copy API key ──
   document.getElementById('users-table-body')!.addEventListener('click', async (e) => {
@@ -1166,6 +1238,156 @@ const adminCount = users.filter((u: AdminUser) => u.is_admin).length;
       btn.disabled = false;
     }
   });
+
+  // ── Add user ──
+  const addUserModal = document.getElementById('add-user-modal')!;
+  const addUserForm = document.getElementById('add-user-form') as HTMLFormElement;
+  const addUserSubmitBtn = document.getElementById('add-user-submit-btn') as HTMLButtonElement;
+  const newUsernameInput = document.getElementById('new-user-username') as HTMLInputElement;
+  const newEmailInput = document.getElementById('new-user-email') as HTMLInputElement;
+  const newPasswordInput = document.getElementById('new-user-password') as HTMLInputElement;
+  const newIsAdminInput = document.getElementById('new-user-is-admin') as HTMLInputElement;
+
+  function generatePassword(length: number = 16): string {
+    const lower = 'abcdefghijklmnopqrstuvwxyz';
+    const upper = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+    const digits = '0123456789';
+    const special = '!@#$%^&*-_=+?';
+    const all = lower + upper + digits + special;
+    const randFrom = (set: string): string => {
+      const buf = new Uint32Array(1);
+      crypto.getRandomValues(buf);
+      return set[buf[0] % set.length];
+    };
+    // Guarantee at least one character from each class, then fill the rest.
+    const chars = [randFrom(lower), randFrom(upper), randFrom(digits), randFrom(special)];
+    while (chars.length < length) chars.push(randFrom(all));
+    // Fisher-Yates shuffle so the guaranteed characters aren't always first.
+    for (let i = chars.length - 1; i > 0; i--) {
+      const buf = new Uint32Array(1);
+      crypto.getRandomValues(buf);
+      const j = buf[0] % (i + 1);
+      [chars[i], chars[j]] = [chars[j], chars[i]];
+    }
+    return chars.join('');
+  }
+
+  function openAddUserModal() {
+    addUserForm.reset();
+    newPasswordInput.value = generatePassword();
+    newPasswordInput.type = 'password';
+    addUserModal.querySelector('.eye-icon')?.classList.remove('hidden');
+    addUserModal.querySelector('.eye-slash-icon')?.classList.add('hidden');
+    addUserModal.classList.remove('hidden');
+    setTimeout(() => newUsernameInput.focus(), 50);
+  }
+
+  function closeAddUserModal() {
+    addUserModal.classList.add('hidden');
+  }
+
+  document.getElementById('add-user-btn')?.addEventListener('click', openAddUserModal);
+  document.getElementById('add-user-cancel-btn')?.addEventListener('click', closeAddUserModal);
+  document.getElementById('add-user-modal-backdrop')?.addEventListener('click', closeAddUserModal);
+
+  document.getElementById('gen-password-btn')?.addEventListener('click', () => {
+    newPasswordInput.value = generatePassword();
+  });
+
+  document.getElementById('copy-password-btn')?.addEventListener('click', async () => {
+    if (!newPasswordInput.value) return;
+    await navigator.clipboard.writeText(newPasswordInput.value);
+    showMessage('Password copied to clipboard.');
+  });
+
+  addUserForm.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const username = newUsernameInput.value.trim();
+    const email = newEmailInput.value.trim();
+    const password = newPasswordInput.value;
+    if (!username || !email || !password) {
+      showMessage('Username, email and password are required.', 'error');
+      return;
+    }
+    addUserSubmitBtn.disabled = true;
+    try {
+      const res = await fetch('/api/proxy/admin/users', {
+        method: 'POST',
+        headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, email, password, is_admin: newIsAdminInput.checked }),
+      });
+      if (!res.ok) throw new Error((await res.json()).detail || 'Failed to create user');
+      const created = await res.json();
+      appendUserRow(created);
+      closeAddUserModal();
+      showMessage(`User "${created.username}" created.`);
+    } catch (err: unknown) {
+      showMessage(err instanceof Error ? err.message : 'Failed to create user', 'error');
+    } finally {
+      addUserSubmitBtn.disabled = false;
+    }
+  });
+
+  function appendUserRow(u: { id: number; username: string; email: string; is_admin: boolean; api_key: string }) {
+    const tbody = document.getElementById('users-table-body')!;
+    const initial = esc((u.username[0] ?? '?').toUpperCase());
+    const isAdmin = !!u.is_admin;
+    const badgeClass = isAdmin
+      ? 'bg-amber-500/10 text-amber-400 border-amber-500/20'
+      : 'bg-zinc-700/50 text-zinc-400 border-zinc-700';
+    const toggleBtnClass = isAdmin
+      ? 'toggle-admin-btn px-3 py-1.5 text-xs font-semibold rounded-lg transition-all active:scale-95 cursor-pointer border bg-zinc-800 hover:bg-zinc-700 text-zinc-300 border-zinc-700'
+      : 'toggle-admin-btn px-3 py-1.5 text-xs font-semibold rounded-lg transition-all active:scale-95 cursor-pointer border bg-amber-500/10 hover:bg-amber-500/20 text-amber-400 border-amber-500/20';
+    tbody.insertAdjacentHTML('beforeend', `
+      <tr class="user-main-row border-b border-zinc-800/50 hover:bg-zinc-800/30 transition cursor-pointer select-none"
+          data-user-id="${u.id}" data-is-admin="${isAdmin}" data-api-key="${esc(u.api_key)}">
+        <td class="px-4 py-3 text-zinc-100 font-medium">
+          <div class="flex items-center gap-3">
+            <div class="w-8 h-8 shrink-0 rounded-full overflow-hidden bg-zinc-800 border border-zinc-700 flex items-center justify-center">
+              <span class="text-xs font-black text-zinc-400">${initial}</span>
+            </div>
+            ${esc(u.username)}
+          </div>
+        </td>
+        <td class="px-4 py-3 text-zinc-400 hidden md:table-cell">${esc(u.email)}</td>
+        <td class="px-4 py-3">
+          <span class="inline-flex items-center px-2 py-0.5 rounded-md text-xs font-semibold border ${badgeClass}">${isAdmin ? 'Admin' : 'User'}</span>
+        </td>
+        <td class="px-4 py-3 text-right hidden md:table-cell">
+          <div class="flex items-center justify-end gap-2">
+            <button class="${toggleBtnClass}">${isAdmin ? 'Remove Admin' : 'Make Admin'}</button>
+            <button class="delete-user-btn px-3 py-1.5 text-xs font-semibold rounded-lg bg-red-500/10 hover:bg-red-500/20 text-red-400 border border-red-500/20 transition-all active:scale-95 cursor-pointer">Delete</button>
+          </div>
+        </td>
+        <td class="px-4 py-3 md:hidden">
+          <svg class="row-chevron w-4 h-4 text-zinc-500 transition-transform ml-auto" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" /></svg>
+        </td>
+      </tr>
+      <tr class="user-detail-row hidden border-b border-zinc-800/50 bg-zinc-800/20" data-detail-for="${u.id}">
+        <td colspan="5" class="px-4 py-4">
+          <div class="space-y-3">
+            <div class="md:hidden text-xs text-zinc-400">${esc(u.email)}</div>
+            <div>
+              <div class="text-xs text-zinc-500 mb-1">API Key</div>
+              <div class="flex items-center gap-2">
+                <code class="user-api-key flex-1 block bg-zinc-950 border border-zinc-800 rounded-lg px-3 py-2 text-xs text-zinc-300 font-mono break-all">${esc(u.api_key)}</code>
+                <button class="copy-api-key-btn shrink-0 p-2 text-zinc-500 hover:text-zinc-300 hover:bg-zinc-700 rounded-lg transition-colors cursor-pointer" title="Copy API key" aria-label="Copy API key">
+                  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 17.25v3.375c0 .621-.504 1.125-1.125 1.125h-9.75a1.125 1.125 0 01-1.125-1.125V7.875c0-.621.504-1.125 1.125-1.125H6.75a9.06 9.06 0 011.5.124m7.5 10.376h3.375c.621 0 1.125-.504 1.125-1.125V11.25c0-4.46-3.243-8.161-7.5-8.976a9.06 9.06 0 00-1.5-.124H9.375c-.621 0-1.125.504-1.125 1.125v3.5m7.5 10.375H9.375a1.125 1.125 0 01-1.125-1.125v-9.25m12 6.625v-1.875a3.375 3.375 0 00-3.375-3.375h-1.5a1.125 1.125 0 01-1.125-1.125v-1.5a3.375 3.375 0 00-3.375-3.375H9.75" />
+                  </svg>
+                </button>
+              </div>
+            </div>
+            <div class="flex flex-wrap gap-2 md:hidden">
+              <button class="${toggleBtnClass}">${isAdmin ? 'Remove Admin' : 'Make Admin'}</button>
+              <button class="delete-user-btn px-3 py-1.5 text-xs font-semibold rounded-lg bg-red-500/10 hover:bg-red-500/20 text-red-400 border border-red-500/20 transition-all active:scale-95 cursor-pointer">Delete</button>
+            </div>
+          </div>
+        </td>
+      </tr>`);
+    bindRowExpand(tbody.querySelector<HTMLTableRowElement>(`tr.user-main-row[data-user-id="${u.id}"]`)!);
+    refreshToggleButtons();
+  }
 
   // ── Admin heal ──
   const adminHealBtn = document.getElementById('admin-heal-btn') as HTMLButtonElement;


### PR DESCRIPTION
## Problem

`_check_profile_access` in `profile.py` checked admin status via `current_user.role == "admin"` (string comparison), while the entire rest of the codebase uses `current_user.is_admin` (boolean field).

Since `role` (enum) and `is_admin` (bool) can get out of sync — e.g. when toggling admin via the admin panel — admin API keys would get **403 This profile is private** on all profile endpoints that use `_check_profile_access`:

- `GET /profile/avatar/{user_id}`
- `GET /profile/{user_id}`
- `GET /profile/{user_id}/stats`

## Fix

- **`profile.py`**: Replace `current_user.role == "admin"` with `current_user.is_admin` in `_check_profile_access` and `get_public_profile`
- **`admin.py`**: Sync the `role` field when toggling `is_admin` to prevent future desync

## Verified

`GET /profile/avatar/5?api_key=...` returns **200** with an admin API key (was 403 before).