### PR TITLE
[Plex] Extract IDs from HAMA

### DIFF
--- a/backend/core/plex.py
+++ b/backend/core/plex.py
@@ -25,6 +25,7 @@ def get_guids(item: Dict) -> List[Dict]:
     Modern Plex returns a 'Guid' array: [{"id": "tmdb://123"}, ...].
     Legacy items may have an empty/missing 'Guid' but a single lowercase 'guid'
     string like 'com.plexapp.agents.thetvdb://73762/1/1'.
+    HAMA items have a guid string like 'com.plexapp.agents.hama://tvdb-73762/1/1'.
     """
     guids = item.get("Guid") or []
     if not guids:
@@ -38,13 +39,12 @@ def extract_tmdb_id(guids: List[Dict]) -> Optional[int]:
     if not guids:
         return None
     for guid in guids:
-        id_str = guid.get("id", "")
-        for prefix in ("tmdb://", "com.plexapp.agents.themoviedb://"):
-            if id_str.startswith(prefix):
-                try:
-                    return int(id_str[len(prefix):].split("/")[0])
-                except ValueError:
-                    break
+        id_match = re.search(r"t(?:he)?m(?:ovie)?db(?:://|-)(?P<id>\d+)", guid.get("id", ""))
+        if id_match:
+            try:
+                return int(id_match.group("id"))
+            except ValueError:
+                continue
     return None
 
 
@@ -62,11 +62,9 @@ def extract_imdb_id(guids: List[Dict]) -> Optional[str]:
     if not guids:
         return None
     for guid in guids:
-        id_str = guid.get("id", "")
-        for prefix in ("imdb://", "com.plexapp.agents.imdb://"):
-            if id_str.startswith(prefix):
-                val = id_str[len(prefix):].split("/")[0].strip()
-                return val if val else None
+        id_match = re.search(r"imdb(?:://|-)(?P<id>tt\d+)", guid.get("id", ""))
+        if id_match:
+            return id_match.group("id")
     return None
 
 def extract_quality(media_list: List[Dict]) -> Dict:

--- a/backend/core/plex.py
+++ b/backend/core/plex.py
@@ -35,37 +35,39 @@ def get_guids(item: Dict) -> List[Dict]:
     return guids
 
 
-def extract_tmdb_id(guids: List[Dict]) -> Optional[int]:
-    if not guids:
-        return None
-    for guid in guids:
-        id_match = re.search(r"t(?:he)?m(?:ovie)?db(?:://|-)(?P<id>\d+)", guid.get("id", ""))
-        if id_match:
-            try:
-                return int(id_match.group("id"))
-            except ValueError:
-                continue
+# Plex exposes a source id in a Guid two ways:
+#   * the plain scheme - "tmdb://123", or the legacy agent form
+#     "com.plexapp.agents.themoviedb://123/1/1"
+#   * the HAMA / Absolute Series Scanner agent, which packs the real source
+#     behind its own scheme: "com.plexapp.agents.hama://tvdb-73762/1/1"
+#     (and "tvdb2-", "tvdb3-" ... for TheTVDB's alternate episode orders).
+# Anchoring each alternative on the "://" boundary keeps a stray "tmdb-123"
+# elsewhere in the string from being read as an id, and \d+ stops at the
+# season/episode path and any "?lang=" suffix on its own.
+_TMDB_GUID_RE = re.compile(r"(?:tmdb|themoviedb)://(\d+)|://tmdb-(\d+)")
+_TVDB_GUID_RE = re.compile(r"tvdb://(\d+)|://tvdb[2-9]?-(\d+)")
+_IMDB_GUID_RE = re.compile(r"imdb://(tt\d+)|://imdb-(tt\d+)")
+
+
+def _first_guid_match(guids: List[Dict], pattern: "re.Pattern[str]") -> Optional[str]:
+    for guid in guids or []:
+        match = pattern.search(guid.get("id", "") or "")
+        if match:
+            return next((g for g in match.groups() if g), None)
     return None
+
+
+def extract_tmdb_id(guids: List[Dict]) -> Optional[int]:
+    raw = _first_guid_match(guids, _TMDB_GUID_RE)
+    return int(raw) if raw is not None else None
 
 
 def extract_tvdb_id(guids: List[Dict]) -> Optional[str]:
-    if not guids:
-        return None
-    for guid in guids:
-        id_match = re.search(r"tvdb(?:://|[2-5]?-)(?P<id>\d+)", guid.get("id", ""))
-        if id_match:
-            return id_match.group("id")
-    return None
+    return _first_guid_match(guids, _TVDB_GUID_RE)
 
 
 def extract_imdb_id(guids: List[Dict]) -> Optional[str]:
-    if not guids:
-        return None
-    for guid in guids:
-        id_match = re.search(r"imdb(?:://|-)(?P<id>tt\d+)", guid.get("id", ""))
-        if id_match:
-            return id_match.group("id")
-    return None
+    return _first_guid_match(guids, _IMDB_GUID_RE)
 
 def extract_quality(media_list: List[Dict]) -> Dict:
     if not media_list:

--- a/backend/core/plex.py
+++ b/backend/core/plex.py
@@ -1,4 +1,5 @@
 import logging
+import re
 import httpx
 import xmltodict
 from datetime import datetime, timezone
@@ -51,11 +52,9 @@ def extract_tvdb_id(guids: List[Dict]) -> Optional[str]:
     if not guids:
         return None
     for guid in guids:
-        id_str = guid.get("id", "")
-        for prefix in ("tvdb://", "com.plexapp.agents.thetvdb://"):
-            if id_str.startswith(prefix):
-                val = id_str[len(prefix):].split("/")[0].strip()
-                return val if val else None
+        id_match = re.search(r"tvdb(?:://|[2-5]?-)(?P<id>\d+)", guid.get("id", ""))
+        if id_match:
+            return id_match.group("id")
     return None
 
 

--- a/backend/tests/test_plex.py
+++ b/backend/tests/test_plex.py
@@ -267,5 +267,82 @@ class ResolveTmdbRatingkeyTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(len(checked_metadata_paths), plex._RESOLVE_CANDIDATE_CHECK_LIMIT)
 
 
+def _g(*ids: str) -> list[dict]:
+    return [{"id": i} for i in ids]
+
+
+class GuidIdExtractionTests(unittest.TestCase):
+    """extract_{tmdb,tvdb,imdb}_id must read the plain scheme, the legacy
+    com.plexapp.agents.* form, and the HAMA / Absolute Series Scanner agent
+    form (com.plexapp.agents.hama://tvdb-73762/1/1), without mistaking an
+    unrelated GUID for an id (PR #337)."""
+
+    # ── TMDB ──────────────────────────────────────────────────────────────
+    def test_tmdb_plain_and_legacy_schemes(self):
+        self.assertEqual(plex.extract_tmdb_id(_g("tmdb://1396")), 1396)
+        self.assertEqual(
+            plex.extract_tmdb_id(_g("com.plexapp.agents.themoviedb://1396?lang=en")), 1396
+        )
+
+    def test_tmdb_hama_form(self):
+        self.assertEqual(
+            plex.extract_tmdb_id(_g("com.plexapp.agents.hama://tmdb-1396/1/1")), 1396
+        )
+
+    def test_tmdb_returns_int_or_none(self):
+        self.assertIsInstance(plex.extract_tmdb_id(_g("tmdb://5")), int)
+        self.assertIsNone(plex.extract_tmdb_id(_g("imdb://tt0111161", "plex://movie/abc")))
+        self.assertIsNone(plex.extract_tmdb_id([]))
+        self.assertIsNone(plex.extract_tmdb_id(_g("com.plexapp.agents.hama://anidb-999/1/1")))
+
+    # ── TVDB ──────────────────────────────────────────────────────────────
+    def test_tvdb_plain_and_legacy_schemes(self):
+        self.assertEqual(plex.extract_tvdb_id(_g("tvdb://73762")), "73762")
+        self.assertEqual(
+            plex.extract_tvdb_id(_g("com.plexapp.agents.thetvdb://73762/1/1")), "73762"
+        )
+
+    def test_tvdb_hama_form_including_alternate_order_suffix(self):
+        self.assertEqual(
+            plex.extract_tvdb_id(_g("com.plexapp.agents.hama://tvdb-73762/1/1")), "73762"
+        )
+        # HAMA uses tvdb2-/tvdb3-... for TheTVDB's alternate episode orders;
+        # we still want the series id.
+        self.assertEqual(
+            plex.extract_tvdb_id(_g("com.plexapp.agents.hama://tvdb2-73762/1/5")), "73762"
+        )
+
+    def test_tvdb_ignores_other_sources(self):
+        self.assertIsNone(plex.extract_tvdb_id(_g("tmdb://1396", "imdb://tt0903747")))
+        self.assertIsNone(plex.extract_tvdb_id(_g("com.plexapp.agents.hama://anidb-999/1/1")))
+        self.assertIsNone(plex.extract_tvdb_id([]))
+
+    # ── IMDB ──────────────────────────────────────────────────────────────
+    def test_imdb_all_forms(self):
+        self.assertEqual(plex.extract_imdb_id(_g("imdb://tt0111161")), "tt0111161")
+        self.assertEqual(
+            plex.extract_imdb_id(_g("com.plexapp.agents.imdb://tt0111161")), "tt0111161"
+        )
+        self.assertEqual(
+            plex.extract_imdb_id(_g("com.plexapp.agents.hama://imdb-tt0111161/1/1")), "tt0111161"
+        )
+
+    def test_imdb_requires_the_tt_prefix(self):
+        self.assertIsNone(plex.extract_imdb_id(_g("tmdb://1396")))
+        self.assertIsNone(plex.extract_imdb_id(_g("imdb://12345")))
+        self.assertIsNone(plex.extract_imdb_id([]))
+
+    # ── ordering / get_guids ─────────────────────────────────────────────
+    def test_first_matching_guid_in_the_list_wins(self):
+        guids = _g("plex://episode/5d9c", "tvdb://73762", "tvdb://99999")
+        self.assertEqual(plex.extract_tvdb_id(guids), "73762")
+
+    def test_get_guids_wraps_a_legacy_hama_string(self):
+        item = {"guid": "com.plexapp.agents.hama://tvdb-73762/1/1"}
+        guids = plex.get_guids(item)
+        self.assertEqual(guids, [{"id": "com.plexapp.agents.hama://tvdb-73762/1/1"}])
+        self.assertEqual(plex.extract_tvdb_id(guids), "73762")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Add support for [Absolute Series Scanner](https://github.com/ZeroQI/Absolute-Series-Scanner) + [HAMA](https://github.com/ZeroQI/Hama.bundle) entries on Plex input.