### PR TITLE
feat(api): expose last watched time in Next Up

### DIFF
--- a/backend/routers/history.py
+++ b/backend/routers/history.py
@@ -670,7 +670,7 @@ async def dismiss_continue_watching(
     return {"status": "ok"}
 
 
-def _format_media_item(media: Media) -> dict:
+def _format_media_item(media: Media, *, last_watched_at: datetime | None = None) -> dict:
     data = {
         "id": media.id,
         "tmdb_id": media.tmdb_id,
@@ -689,6 +689,7 @@ def _format_media_item(media: Media) -> dict:
         "in_library": False,
         "show_id": media.show_id,
         "tvdb_sourced": is_unmapped_tvdb_episode(media),
+        "last_watched_at": last_watched_at.isoformat() if last_watched_at else None,
     }
     if media.media_type == MediaType.episode and media.show:
         data["show_title"] = media.show.title
@@ -1289,7 +1290,10 @@ async def get_next_up(
         db, current_user.id, next_up, active_rewatch_by_show
     )
 
-    items = [_format_media_item(m) for m in next_up]
+    items = [
+        _format_media_item(m, last_watched_at=last_watched_at.get(m.show_id))
+        for m in next_up
+    ]
     for item in items:
         item["next_up_hidden"] = item.get("show_id") in hidden_set
         item["dropped"] = item.get("show_id") in dropped_show_ids

--- a/backend/tests/test_next_up.py
+++ b/backend/tests/test_next_up.py
@@ -8,8 +8,9 @@ from unittest.mock import AsyncMock, patch
 os.environ.setdefault("SECRET_KEY", "test-secret")
 os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://test:test@localhost/test")
 
-from routers.history import _compute_next_episode, _group_last_watched, _has_aired, _has_confirmed_air_date, _next_up_needs_live_fetch, _remaining_episode_stats, _stream_next_up_refresh
+from routers.history import _compute_next_episode, _format_media_item, _group_last_watched, _has_aired, _has_confirmed_air_date, _next_up_needs_live_fetch, _remaining_episode_stats, _stream_next_up_refresh
 from core.rewatch import capped_season_episode_counts
+from models.base import MediaType
 
 
 class ComputeNextEpisodeTests(unittest.TestCase):
@@ -88,6 +89,41 @@ class GroupLastWatchedTests(unittest.TestCase):
         rows = [(1, None, 1, None), (1, None, 2, None)]
         last_per_show, last_watched_at = _group_last_watched(rows)
         self.assertNotIn(1, last_per_show)
+
+
+class NextUpMediaFormattingTests(unittest.TestCase):
+    """Next Up exposes the timestamp used to order shows (#237)."""
+
+    def _media(self):
+        return SimpleNamespace(
+            id=7,
+            tmdb_id=42,
+            media_type=MediaType.episode,
+            title="Episode 3",
+            overview="Overview",
+            poster_path=None,
+            backdrop_path=None,
+            release_date="2026-01-01",
+            tmdb_rating=8.0,
+            season_number=1,
+            episode_number=3,
+            runtime=45,
+            tagline=None,
+            tmdb_data={},
+            show_id=9,
+            show=None,
+        )
+
+    def test_last_watched_at_is_serialized_as_iso_datetime(self):
+        payload = _format_media_item(
+            self._media(),
+            last_watched_at=datetime(2026, 8, 31, 9, 30),
+        )
+        self.assertEqual(payload["last_watched_at"], "2026-08-31T09:30:00")
+
+    def test_missing_last_watched_at_is_null(self):
+        payload = _format_media_item(self._media())
+        self.assertIsNone(payload["last_watched_at"])
 
 
 class HasAiredTests(unittest.TestCase):

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -650,6 +650,9 @@ export interface MediaItem {
   // for the show and their estimated total runtime in minutes.
   episodes_left?: number | null;
   remaining_runtime?: number | null;
+  // Most recent completed/significantly-viewed episode for this show, used by
+  // API clients to order Next Up consistently with the web app (#237).
+  last_watched_at?: string | null;
   known_for_department?: string | null;
   in_library?: boolean;
   playable?: boolean;


### PR DESCRIPTION
## Summary

- Expose the most recent watched timestamp already used to order Next Up items.
- Return it as `last_watched_at` on each `/history/next-up` item.
- Document the field in the frontend API type.

Closes #237

## Tests

- `python -m unittest tests.test_next_up -v` (49 passed)