### PR TITLE
feat(ui): add external metadata provider links

### DIFF
--- a/backend/routers/shows.py
+++ b/backend/routers/shows.py
@@ -202,6 +202,7 @@ def format_show(show: ShowModel) -> dict:
         "genres": [g["name"] if isinstance(g, dict) else g for g in (show.tmdb_data or {}).get("genres", [])],
         "seasons_meta": (show.tmdb_data or {}).get("seasons", []),
         "original_language": (show.tmdb_data or {}).get("original_language"),
+        "imdb_id": (show.tmdb_data or {}).get("external_ids", {}).get("imdb_id"),
         "adult": (show.tmdb_data or {}).get("adult", False),
     }
 
@@ -1154,6 +1155,8 @@ async def get_show_season(
                 show_info = {
                     "id": None,
                     "tmdb_id": series_tmdb_id,
+                    "tvdb_id": tmdb_show_data.get("external_ids", {}).get("tvdb_id"),
+                    "imdb_id": tmdb_show_data.get("external_ids", {}).get("imdb_id"),
                     "title": tmdb_show_data.get("name"),
                     "poster_path": tmdb.poster_url(tmdb_show_data.get("poster_path")),
                     "backdrop_path": tmdb.poster_url(
@@ -1557,6 +1560,8 @@ async def get_episode_detail(
             show_info = {
                 "id": None,
                 "tmdb_id": series_tmdb_id,
+                "tvdb_id": show_tmdb.get("external_ids", {}).get("tvdb_id"),
+                "imdb_id": show_tmdb.get("external_ids", {}).get("imdb_id"),
                 "title": show_tmdb.get("name"),
                 "poster_path": tmdb.poster_url(show_tmdb.get("poster_path")),
                 "backdrop_path": tmdb.poster_url(
@@ -2576,6 +2581,7 @@ async def get_tvdb_season(
             "id": show.id if show else None,
             "tvdb_id": tvdb_id,
             "tmdb_id": series_tmdb_id,
+            "imdb_id": show_data.get("imdb_id"),
             "episode_order": "tvdb",
             "title": show_data["title"],
             "poster_path": show_data["poster_path"],
@@ -2864,6 +2870,7 @@ async def get_tvdb_episode(
             "id": show.id if show else None,
             "tvdb_id": tvdb_id,
             "tmdb_id": series_tmdb_id,
+            "imdb_id": show_data.get("imdb_id"),
             "episode_order": "tvdb",
             "title": show_data["title"],
             "poster_path": show_data["poster_path"],

--- a/frontend/src/components/ExternalProviderLinks.astro
+++ b/frontend/src/components/ExternalProviderLinks.astro
@@ -1,0 +1,71 @@
+---
+interface Props {
+  tmdbId?: number | null;
+  tmdbType?: "movie" | "tv";
+  tvdbId?: number | null;
+  tvdbRecordType?: "series" | "season" | "episode";
+  imdbId?: string | null;
+  seasonNumber?: number | null;
+  episodeNumber?: number | null;
+  class?: string;
+}
+
+const {
+  tmdbId,
+  tmdbType = "tv",
+  tvdbId,
+  tvdbRecordType = "series",
+  imdbId,
+  seasonNumber,
+  episodeNumber,
+  class: className = "",
+} = Astro.props;
+
+const tmdbHref = tmdbId
+  ? tmdbType === "movie"
+    ? `https://www.themoviedb.org/movie/${tmdbId}`
+    : seasonNumber != null && episodeNumber != null
+      ? `https://www.themoviedb.org/tv/${tmdbId}/season/${seasonNumber}/episode/${episodeNumber}`
+      : seasonNumber != null
+        ? `https://www.themoviedb.org/tv/${tmdbId}/season/${seasonNumber}`
+        : `https://www.themoviedb.org/tv/${tmdbId}`
+  : null;
+const tvdbHref = tvdbId
+  ? `https://thetvdb.com/dereferrer/${tvdbRecordType}/${tvdbId}`
+  : null;
+const imdbHref = imdbId ? `https://www.imdb.com/title/${imdbId}/` : null;
+
+---
+
+{(tmdbHref || tvdbHref || imdbHref) && <div class={`flex flex-wrap items-center gap-2 ${className}`} aria-label="External metadata links">
+  {tmdbHref && (
+    <a
+      href={tmdbHref}
+      target="_blank"
+      rel="noopener noreferrer"
+      class="inline-flex items-center rounded-lg border border-blue-500/30 bg-blue-500/10 px-2.5 py-1 text-[10px] font-black uppercase tracking-widest text-blue-300 transition-colors hover:border-blue-400/60 hover:bg-blue-500/20 hover:text-blue-200"
+    >
+      TMDB
+    </a>
+  )}
+  {tvdbHref && (
+    <a
+      href={tvdbHref}
+      target="_blank"
+      rel="noopener noreferrer"
+      class="inline-flex items-center rounded-lg border border-emerald-500/30 bg-emerald-500/10 px-2.5 py-1 text-[10px] font-black uppercase tracking-widest text-emerald-300 transition-colors hover:border-emerald-400/60 hover:bg-emerald-500/20 hover:text-emerald-200"
+    >
+      TVDB
+    </a>
+  )}
+  {imdbHref && (
+    <a
+      href={imdbHref}
+      target="_blank"
+      rel="noopener noreferrer"
+      class="inline-flex items-center rounded-lg border border-yellow-500/40 bg-yellow-400/10 px-2.5 py-1 text-[10px] font-black uppercase tracking-widest text-yellow-300 transition-colors hover:border-yellow-400/70 hover:bg-yellow-400/20 hover:text-yellow-200"
+    >
+      IMDb
+    </a>
+  )}
+</div>}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -131,6 +131,8 @@ export interface EpisodeItem {
 
 export interface ShowSummary {
   tmdb_id: number;
+  tvdb_id?: number | null;
+  imdb_id?: string | null;
   title: string;
   poster_path: string | null;
   backdrop_path: string | null;
@@ -139,6 +141,7 @@ export interface ShowSummary {
 
 export interface Season {
   show: ShowSummary;
+  tvdb_id?: number | null;
   name: string;
   overview: string | null;
   poster_path: string | null;
@@ -816,7 +819,7 @@ export interface TvdbEpisodeDetail {
   } | null;
   cast: { tmdb_id: null; person_id: number | null; name: string; character: string; profile_path: string | null }[];
   episodes: { episode_number: number; name: string | null }[];
-  show: { id: number | null; tvdb_id: number; tmdb_id: number | null; episode_order: "tvdb"; title: string; poster_path: string | null; backdrop_path: string | null };
+  show: { id: number | null; tvdb_id: number; tmdb_id: number | null; imdb_id: string | null; episode_order: "tvdb"; title: string; poster_path: string | null; backdrop_path: string | null };
   season: { name: string; season_number: number; poster_path: string | null };
 }
 
@@ -841,6 +844,7 @@ export interface TvdbSeason {
     id: number | null;
     tvdb_id: number;
     tmdb_id: number | null;
+    imdb_id: string | null;
     episode_order: "tvdb";
     title: string;
     poster_path: string | null;

--- a/frontend/src/pages/media/[type]/[id].astro
+++ b/frontend/src/pages/media/[type]/[id].astro
@@ -5,6 +5,7 @@ import ActionBar from "../../../components/ActionBar.astro";
 import CommentsSection from "../../../components/CommentsSection.astro";
 import VideoPlayer from "../../../components/VideoPlayer.astro";
 import ManualScrobble from "../../../components/ManualScrobble.astro";
+import ExternalProviderLinks from "../../../components/ExternalProviderLinks.astro";
 import { api, type MediaItem } from "../../../lib/api";
 export const prerender = false;
 
@@ -164,11 +165,7 @@ const refreshUrl = isEpisode
                     {item.age_rating}
                   </span>
                 )}
-                {item.imdb_id && (
-                  <a href={`https://www.imdb.com/title/${item.imdb_id}/`} target="_blank" rel="noopener noreferrer" class="px-2 py-0.5 bg-[#f5c518] rounded text-[10px] font-black text-black tracking-widest hover:bg-[#e6b800] transition-colors">
-                    IMDb
-                  </a>
-                )}
+
                 {item.status && (
                   isMovie ? (
                     <button id="release-schedule-btn" class="capitalize px-2 py-0.5 bg-zinc-800 border border-zinc-700 rounded text-[10px] font-black text-zinc-400 tracking-widest hover:bg-zinc-700 hover:text-zinc-300 transition-colors cursor-pointer">
@@ -218,6 +215,15 @@ const refreshUrl = isEpisode
                   </span>
                 )}
               </div>
+              <ExternalProviderLinks
+                tmdbId={item.tvdb_sourced ? null : (isEpisode ? item.show_tmdb_id : item.tmdb_id)}
+                tmdbType={isEpisode ? "tv" : "movie"}
+                tvdbId={isEpisode ? item.show_tvdb_id : item.tvdb_id}
+                imdbId={isEpisode ? null : item.imdb_id}
+                seasonNumber={isEpisode ? item.season_number : null}
+                episodeNumber={isEpisode ? item.episode_number : null}
+                class="mt-3"
+              />
               {!isEpisode && (() => { const c = item.production_companies?.find(c => c.logo_path); return c ? <div class="bg-zinc-900/40 p-3 rounded-xl border border-zinc-800/50 backdrop-blur-sm flex items-center"><img src={c.logo_path!} alt={c.name} title={c.name} class="h-5 max-w-[80px] object-contain" loading="lazy" /></div> : null; })()}
             </div>
 

--- a/frontend/src/pages/show/[id].astro
+++ b/frontend/src/pages/show/[id].astro
@@ -4,6 +4,7 @@ import MediaRow from "../../components/MediaRow.astro";
 import ActionBar from "../../components/ActionBar.astro";
 import CommentsSection from "../../components/CommentsSection.astro";
 import EpisodeOrderSelector from "../../components/EpisodeOrderSelector.astro";
+import ExternalProviderLinks from "../../components/ExternalProviderLinks.astro";
 import { api, type Show } from "../../lib/api";
 export const prerender = false;
 
@@ -130,11 +131,7 @@ const originalLanguage = show?.original_language
                     {show.age_rating}
                   </span>
                 )}
-                {show.imdb_id && (
-                  <a href={`https://www.imdb.com/title/${show.imdb_id}/`} target="_blank" rel="noopener noreferrer" class="px-2 py-0.5 bg-[#f5c518] rounded text-[10px] font-black text-black tracking-widest hover:bg-[#e6b800] transition-colors">
-                    IMDb
-                  </a>
-                )}
+
                 {show.status && (
                   <span class="capitalize px-2 py-0.5 bg-zinc-800 border border-zinc-700 rounded text-[10px] font-black text-zinc-400 tracking-widest">
                     {show.status}
@@ -159,6 +156,13 @@ const originalLanguage = show?.original_language
                   </span>
                 )}
               </div>
+              <ExternalProviderLinks
+                tmdbId={show.tmdb_id}
+                tmdbType="tv"
+                tvdbId={show.tvdb_id}
+                imdbId={show.imdb_id}
+                class="mt-3"
+              />
               {(() => { const n = show.networks?.find(n => n.logo_path); return n ? <div class="bg-zinc-900/40 p-3 rounded-xl border border-zinc-800/50 backdrop-blur-sm flex items-center"><img src={n.logo_path!} alt={n.name} title={n.name} class="h-5 max-w-[80px] object-contain" loading="lazy" /></div> : null; })()}
             </div>
 

--- a/frontend/src/pages/show/[id]/season/[season_number].astro
+++ b/frontend/src/pages/show/[id]/season/[season_number].astro
@@ -3,6 +3,7 @@ import Base from "../../../../layouts/Base.astro";
 import ActionBar from "../../../../components/ActionBar.astro";
 import CommentsSection from "../../../../components/CommentsSection.astro";
 import { api, type Season } from "../../../../lib/api";
+import ExternalProviderLinks from "../../../../components/ExternalProviderLinks.astro";
 export const prerender = false;
 
 const { id, season_number } = Astro.params;
@@ -136,6 +137,14 @@ const show = season?.show;
                 </>
               )}
             </div>
+            <ExternalProviderLinks
+              tmdbId={show?.tmdb_id}
+              tmdbType="tv"
+              tvdbId={show?.tvdb_id ?? season.tvdb_id}
+              imdbId={show?.imdb_id}
+              seasonNumber={Number(season_number)}
+              class="justify-center md:justify-start mb-6"
+            />
 
             {user && (
               <div class="mb-6">

--- a/frontend/src/pages/show/tvdb/[id].astro
+++ b/frontend/src/pages/show/tvdb/[id].astro
@@ -4,6 +4,7 @@ import ActionBar from "../../../components/ActionBar.astro";
 import CommentsSection from "../../../components/CommentsSection.astro";
 import EpisodeOrderSelector from "../../../components/EpisodeOrderSelector.astro";
 import TvdbAttribution from "../../../components/TvdbAttribution.astro";
+import ExternalProviderLinks from "../../../components/ExternalProviderLinks.astro";
 import { api, type TvdbShow } from "../../../lib/api";
 import { formatSeasonTitle } from "../../../lib/media-format";
 export const prerender = false;
@@ -111,11 +112,7 @@ const originalLanguage = show?.original_language
                     {show.age_rating}
                   </span>
                 )}
-                {show.imdb_id && (
-                  <a href={`https://www.imdb.com/title/${show.imdb_id}/`} target="_blank" rel="noopener noreferrer" class="px-2 py-0.5 bg-[#f5c518] rounded text-[10px] font-black text-black tracking-widest hover:bg-[#e6b800] transition-colors">
-                    IMDb
-                  </a>
-                )}
+
                 {show.status && (
                   <span class="capitalize px-2 py-0.5 bg-zinc-800 border border-zinc-700 rounded text-[10px] font-black text-zinc-400 tracking-widest">
                     {show.status}
@@ -130,6 +127,13 @@ const originalLanguage = show?.original_language
                   </span>
                 )}
               </div>
+              <ExternalProviderLinks
+                tmdbId={show.tmdb_id_cross}
+                tmdbType="tv"
+                tvdbId={show.tvdb_id}
+                imdbId={show.imdb_id}
+                class="mt-3"
+              />
               {show.network && (
                 <div class="bg-zinc-900/40 p-3 rounded-xl border border-zinc-800/50 backdrop-blur-sm flex items-center">
                   <span class="text-zinc-400 text-xs font-semibold">{show.network}</span>

--- a/frontend/src/pages/show/tvdb/[id]/season/[season_number].astro
+++ b/frontend/src/pages/show/tvdb/[id]/season/[season_number].astro
@@ -3,6 +3,7 @@ import Base from "../../../../../layouts/Base.astro";
 import ActionBar from "../../../../../components/ActionBar.astro";
 import CommentsSection from "../../../../../components/CommentsSection.astro";
 import TvdbAttribution from "../../../../../components/TvdbAttribution.astro";
+import ExternalProviderLinks from "../../../../../components/ExternalProviderLinks.astro";
 import { api, type TvdbSeason } from "../../../../../lib/api";
 import { formatSeasonTitle } from "../../../../../lib/media-format";
 export const prerender = false;
@@ -138,6 +139,13 @@ const seasonTitle = season
                 <span>Premiered {new Date(season.air_date).toLocaleDateString(undefined, { year: "numeric", month: "long", day: "numeric" })}</span>
               )}
             </div>
+            <ExternalProviderLinks
+              tmdbId={show?.tmdb_id}
+              tmdbType="tv"
+              tvdbId={show?.tvdb_id ?? Number(id)}
+              imdbId={show?.imdb_id}
+              class="justify-center md:justify-start mb-6"
+            />
 
             {user && (
               <div class="mb-6">

--- a/frontend/src/pages/show/tvdb/[id]/season/[season_number]/[episode_number].astro
+++ b/frontend/src/pages/show/tvdb/[id]/season/[season_number]/[episode_number].astro
@@ -5,6 +5,7 @@ import CommentsSection from "../../../../../../components/CommentsSection.astro"
 import TvdbAttribution from "../../../../../../components/TvdbAttribution.astro";
 import ManualScrobble from "../../../../../../components/ManualScrobble.astro";
 import VideoPlayer from "../../../../../../components/VideoPlayer.astro";
+import ExternalProviderLinks from "../../../../../../components/ExternalProviderLinks.astro";
 import { api, type TvdbEpisodeDetail } from "../../../../../../lib/api";
 export const prerender = false;
 
@@ -155,6 +156,15 @@ const thumbnail = episode?.image_url || show?.poster_path || null;
                 </span>
               )}
             </div>
+            <ExternalProviderLinks
+              tmdbId={episode.show_tmdb_id ?? show?.tmdb_id}
+              tmdbType="tv"
+              tvdbId={show?.tvdb_id ?? Number(id)}
+              imdbId={show?.imdb_id}
+              seasonNumber={episode.tmdb_season_number}
+              episodeNumber={episode.tmdb_episode_number}
+              class="mt-4"
+            />
 
             {user && (episode.unmatched ? (
               <div class="mb-4 p-4 bg-amber-500/10 border border-amber-500/20 rounded-xl text-sm">


### PR DESCRIPTION
## What does this PR do?
Adds compact TMDB, TVDB, and IMDb links to media, show, season, and episode detail pages.

## Changes
- Replaces the existing standalone IMDb badge with a shared external-provider link component.
- Builds exact TMDB URLs for movies, shows, seasons, and episodes where IDs are available.
- Adds stable TVDB dereferrer links.
- Passes cached IMDb/TVDB IDs through nested season and episode show payloads.

## Verification
- `npm run build`
- `/tmp/scrob-review/.venv/bin/python -m unittest tests.test_shows -v` (4 passed)