### PR TITLE
fix(sync): preserve Nuvio library added dates

### DIFF
--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -225,9 +225,13 @@ def provider_added_at(item: dict, source: CollectionSource) -> datetime | None:
     Returns None when the source has no such concept or the value is missing
     or unparseable, in which case the caller leaves the column on its server
     default. Sources are matched explicitly rather than through
-    _MEDIA_BROWSER_ITEM_SOURCES: Nuvio and Stremio items are synthesized with
-    a fixed key set and carry no date, and matching them here would only wait
-    for a key rename to start feeding in something wrong."""
+    _MEDIA_BROWSER_ITEM_SOURCES: Nuvio items carry an epoch-millisecond
+    ``AddedAt`` value after normalization, while Stremio items carry no date.
+    Sources are matched explicitly so a key rename cannot feed an unrelated
+    timestamp into this column."""
+    if source is CollectionSource.nuvio:
+        return _nuvio_datetime(item.get("AddedAt"))
+
     if source is CollectionSource.plex:
         raw = item.get("addedAt")
         if raw is None:
@@ -3980,6 +3984,10 @@ def _normalize_nuvio_item(
     item = {
         "Id": source_id,
         "Name": title,
+        # Keep Nuvio's epoch-millisecond library add date in the normalized
+        # media-browser shape. provider_added_at converts it to the naive UTC
+        # datetime Scrob stores on Collection/CollectionFile.
+        "AddedAt": record.get("added_at"),
         "ProviderIds": {} if is_episode else {"Tmdb": str(tmdb_id)},
         "MediaStreams": [],
         "Path": None,

--- a/backend/tests/test_nuvio.py
+++ b/backend/tests/test_nuvio.py
@@ -11,7 +11,7 @@ os.environ.setdefault("SECRET_KEY", "test-secret")
 os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://test:test@localhost/test")
 
 from core import nuvio
-from models.base import MediaType
+from models.base import CollectionSource, MediaType
 from models.media import Media
 from models.playback_progress import PlaybackProgress
 from models.show import Show
@@ -25,6 +25,7 @@ from routers.sync import (
     _nuvio_watched_item,
     _push_nuvio_library_delta,
     _run_full_push,
+    provider_added_at,
 )
 
 
@@ -702,6 +703,41 @@ class NuvioWatchHistoryTests(unittest.IsolatedAsyncioTestCase):
         )
 
 class NuvioNormalizationTests(unittest.TestCase):
+    def test_library_added_at_survives_normalization_and_provider_parsing(self) -> None:
+        added_at = 1784419200000
+        normalized = _normalize_nuvio_item(
+            {
+                "content_id": "tmdb:550",
+                "content_type": "movie",
+                "name": "Fight Club",
+                "added_at": added_at,
+            },
+            profile_id=1,
+        )
+
+        self.assertIsNotNone(normalized)
+        _, item = normalized
+        self.assertEqual(item["AddedAt"], added_at)
+        self.assertEqual(
+            provider_added_at(item, CollectionSource.nuvio),
+            datetime(2026, 7, 19),
+        )
+
+    def test_missing_or_invalid_library_added_at_is_ignored(self) -> None:
+        for added_at in (None, "not-a-timestamp"):
+            normalized = _normalize_nuvio_item(
+                {
+                    "content_id": "tmdb:550",
+                    "content_type": "movie",
+                    "added_at": added_at,
+                },
+                profile_id=1,
+            )
+
+            self.assertIsNotNone(normalized)
+            _, item = normalized
+            self.assertIsNone(provider_added_at(item, CollectionSource.nuvio))
+
     def test_episode_history_maps_to_tmdb_series_and_watch_state(self) -> None:
         normalized = _normalize_nuvio_item(
             {

--- a/backend/tests/test_sync.py
+++ b/backend/tests/test_sync.py
@@ -773,9 +773,9 @@ class ProviderAddedAtTests(unittest.TestCase):
         )
         self.assertEqual(got, datetime(2026, 8, 1, 9, 30, 0))
 
-    def test_sources_without_a_library_date_return_none(self):
-        # Nuvio and Stremio items are synthesized with a fixed key set, so they
-        # must never be read as if they were a media browser payload.
+    def test_sources_ignore_unrecognized_library_date_fields(self):
+        # Stremio has no library date, and Nuvio's date is carried in its
+        # normalized AddedAt field rather than the media-browser DateCreated key.
         for source in (sync.CollectionSource.nuvio, sync.CollectionSource.stremio):
             self.assertIsNone(
                 sync.provider_added_at({"DateCreated": "2026-08-01T09:30:00Z"}, source)


### PR DESCRIPTION
Fixes #244.

Nuvio library records include an epoch-millisecond `added_at`, but normalization discarded it before the shared collection sync path ran. Carry it as `AddedAt`, parse it only for Nuvio in `provider_added_at`, and let the existing Collection/CollectionFile insert and monotonic collection-date heal logic apply it. Missing or invalid values remain safe no-ops.

Tests:
- `/tmp/scrob-review/.venv/bin/python -m unittest tests.test_nuvio tests.test_sync`
- `/tmp/scrob-review/.venv/bin/python -m compileall -q routers/sync.py tests/test_nuvio.py`