### PR TITLE
fix(kodi): don't resolve episodes through the show's TMDB id

### DIFF
--- a/backend/routers/history.py
+++ b/backend/routers/history.py
@@ -1293,6 +1293,14 @@ async def get_next_up(
     for item in items:
         item["next_up_hidden"] = item.get("show_id") in hidden_set
         item["dropped"] = item.get("show_id") in dropped_show_ids
+        # The show's most recent watch (or, mid-rewatch, the rewatch's own
+        # progress/start time) - already computed above for the sort just
+        # below, just not previously returned. Lets a client interleave this
+        # feed with /continue-watching (whose items already carry a
+        # comparable top-level watched_at) into one activity-sorted row, the
+        # way Stremio/Nuvio-style addons do (#237).
+        show_last_watched_at = last_watched_at.get(item.get("show_id"))
+        item["last_watched_at"] = show_last_watched_at.isoformat() if show_last_watched_at else None
         show_stats = remaining_stats.get(item.get("show_id"))
         if show_stats:
             item["episodes_left"] = show_stats["episodes_left"]

--- a/backend/routers/webhooks.py
+++ b/backend/routers/webhooks.py
@@ -2968,6 +2968,17 @@ def parse_kodi_payload(payload: dict) -> dict | None:
     }
 
 
+def _kodi_episode_matches(media: Media, data: dict, show: Show | None) -> bool:
+    """Is a tmdb_id hit really the episode Kodi is playing?"""
+    if show is not None and media.show_id is not None and media.show_id != show.id:
+        return False
+    for field, key in (("season_number", "season_number"), ("episode_number", "episode_number")):
+        want = data.get(key)
+        if want is not None and getattr(media, field) is not None and getattr(media, field) != want:
+            return False
+    return True
+
+
 async def find_or_create_media_kodi(
     data: dict, db: AsyncSession, api_key: str = None, user_id: int | None = None
 ) -> Media | None:
@@ -3003,6 +3014,19 @@ async def find_or_create_media_kodi(
                 except Exception:
                     pass
 
+    # Kodi stores the *show* TMDB id in an episode's uniqueid when its scraper
+    # has no episode-level id, so an episode payload's tmdb_id is only a hint.
+    episode_tmdb_id_unverified = data["media_type"] == "episode" and bool(data.get("tmdb_id"))
+    if episode_tmdb_id_unverified and not series_tmdb_id:
+        try:
+            candidate = int(data["tmdb_id"])
+        except (TypeError, ValueError):
+            candidate = None
+        if candidate:
+            local = await db.execute(select(Show).where(Show.tmdb_id == candidate))
+            if local.scalars().first() is not None:
+                series_tmdb_id = candidate
+
     show = None
     if series_tmdb_id:
         try:
@@ -3018,6 +3042,11 @@ async def find_or_create_media_kodi(
             )
         )
         media = result.scalars().first()
+        if media and episode_tmdb_id_unverified and not _kodi_episode_matches(media, data, show):
+            # Show and episode ids share one number space on TMDB, so an
+            # unverified id can land on an unrelated episode. Fall through to
+            # the show + season/episode lookup instead.
+            media = None
         if media:
             if media.media_type == MediaType.episode and media.show_id is None and show:
                 media.show_id = show.id
@@ -3067,12 +3096,14 @@ async def find_or_create_media_kodi(
         if media:
             return media
 
-    if data["media_type"] == "episode" and not data.get("tmdb_id") and data.get("season_number") is None:
-        return None
+    if data["media_type"] == "episode" and data.get("season_number") is None:
+        if not data.get("tmdb_id") or episode_tmdb_id_unverified:
+            return None
 
+    new_tmdb_id = None if episode_tmdb_id_unverified else data.get("tmdb_id")
     media, _created = await create_media_safely(
         db,
-        int(data["tmdb_id"]) if data.get("tmdb_id") else None,
+        int(new_tmdb_id) if new_tmdb_id else None,
         MediaType(data["media_type"]),
         title=data["title"],
         season_number=data.get("season_number"),

--- a/backend/routers/webhooks.py
+++ b/backend/routers/webhooks.py
@@ -3107,6 +3107,30 @@ async def find_or_create_media_kodi(
             return None
 
     new_tmdb_id = None if episode_tmdb_id_unverified else data.get("tmdb_id")
+    if (
+        data["media_type"] == "episode"
+        and show is None
+        and new_tmdb_id is None
+        and data.get("season_number") is not None
+        and data.get("episode_number") is not None
+    ):
+        # create_media_safely's unique index skips a null tmdb_id entirely, so
+        # without this the next webhook for this same episode (pause/resume/
+        # stop, a repeat play) would fail the tmdb_id lookup above and mint a
+        # fresh duplicate row every time, forever.
+        result = await db.execute(
+            select(Media).where(
+                Media.media_type == MediaType.episode,
+                Media.show_id.is_(None),
+                Media.season_number == data["season_number"],
+                Media.episode_number == data["episode_number"],
+                Media.title.ilike(data["title"]),
+            )
+        )
+        media = result.scalars().first()
+        if media:
+            return media
+
     media, _created = await create_media_safely(
         db,
         int(new_tmdb_id) if new_tmdb_id else None,

--- a/backend/routers/webhooks.py
+++ b/backend/routers/webhooks.py
@@ -3017,6 +3017,7 @@ async def find_or_create_media_kodi(
     # Kodi stores the *show* TMDB id in an episode's uniqueid when its scraper
     # has no episode-level id, so an episode payload's tmdb_id is only a hint.
     episode_tmdb_id_unverified = data["media_type"] == "episode" and bool(data.get("tmdb_id"))
+    show = None
     if episode_tmdb_id_unverified and not series_tmdb_id:
         try:
             candidate = int(data["tmdb_id"])
@@ -3024,11 +3025,16 @@ async def find_or_create_media_kodi(
             candidate = None
         if candidate:
             local = await db.execute(select(Show).where(Show.tmdb_id == candidate))
-            if local.scalars().first() is not None:
+            candidate_show = local.scalars().first()
+            if candidate_show is not None:
                 series_tmdb_id = candidate
+                # Already fetched the row above - _find_or_create_show below
+                # would only repeat this exact query and hit its found-branch
+                # again, never its create-from-TMDB one, since a match is
+                # what was just confirmed.
+                show = candidate_show
 
-    show = None
-    if series_tmdb_id:
+    if series_tmdb_id and show is None:
         try:
             show = await _find_or_create_show(db, series_tmdb_id, api_key)
         except Exception:

--- a/backend/tests/test_webhooks.py
+++ b/backend/tests/test_webhooks.py
@@ -1460,13 +1460,16 @@ class FindOrCreateMediaKodiShowIdTests(IsolatedAsyncioTestCase):
         episode = SimpleNamespace(id=50001, media_type=MediaType.episode, show_id=1,
                                   season_number=3, episode_number=6)
         show = SimpleNamespace(id=1, tmdb_id=214546)
-        db = _QueueDB(SimpleNamespace(tmdb_id=214546), None, episode)
+        db = _QueueDB(show, None, episode)
 
-        with patch("routers.webhooks._find_or_create_show", AsyncMock(return_value=show)) as find_show:
+        with patch("routers.webhooks._find_or_create_show", AsyncMock()) as find_show:
             result = await find_or_create_media_kodi(self._episode_data(series_name=None), db)
 
         self.assertIs(result, episode)
-        self.assertEqual(find_show.await_args.args[1], 214546)
+        # The local Show row is already in hand from the candidate-id lookup
+        # above - calling _find_or_create_show would just repeat that exact
+        # query for nothing.
+        find_show.assert_not_awaited()
 
     async def test_unverified_show_id_is_not_stored_on_a_new_episode(self):
         show = SimpleNamespace(id=1, tmdb_id=214546)

--- a/backend/tests/test_webhooks.py
+++ b/backend/tests/test_webhooks.py
@@ -27,6 +27,7 @@ from routers.webhooks import (
     _write_watch_event,
     find_or_create_media_jellyfin,
     find_or_create_media_jellyfin_multi,
+    find_or_create_media_kodi,
     mark_pushed_watched,
     parse_jellyfin_payload,
     parse_kodi_payload,
@@ -1390,6 +1391,94 @@ class ParseKodiPayloadTests(unittest.TestCase):
         self.assertTrue(data["ended"])
         self.assertEqual(data["progress_percent"], 1.0)
         self.assertEqual(data["session_id"], "7")
+
+
+class _QueueDB:
+    """Fakes just enough of AsyncSession for find_or_create_media_kodi: each
+    execute() pops the next queued row, so a test can script exactly what the
+    show lookup, the TMDB-ID match and the season/episode match each return."""
+
+    def __init__(self, *rows):
+        self._rows = list(rows)
+        self.calls = 0
+
+    async def execute(self, stmt):
+        self.calls += 1
+        row = self._rows.pop(0) if self._rows else None
+        return _FastPathResult(row)
+
+
+class FindOrCreateMediaKodiShowIdTests(IsolatedAsyncioTestCase):
+    """Kodi puts the *show* TMDB id in an episode's uniqueid whenever its
+    scraper has no episode-level id, and add-ons forward it as-is. Shows and
+    episodes are separate TMDB id spaces that reuse the same numbers, so
+    matching that id against Media.tmdb_id can land on a completely unrelated
+    episode - show 214546 (Sleepers) collides with episode 214546 (Law &
+    Order: SVU S04E10). Worse, that match was tried before the show +
+    season/episode lookup, so a payload carrying a perfectly good showtitle
+    and S/E still scrobbled the wrong episode."""
+
+    def _episode_data(self, **overrides):
+        data = {
+            "media_type": "episode",
+            "title": "Episode 6",
+            "series_name": "Sleepers",
+            "season_number": 3,
+            "episode_number": 6,
+            "tmdb_id": "214546",
+        }
+        data.update(overrides)
+        return data
+
+    async def test_colliding_tmdb_id_falls_through_to_season_episode(self):
+        wrong = SimpleNamespace(id=37092, media_type=MediaType.episode, show_id=2,
+                                season_number=4, episode_number=10)
+        right = SimpleNamespace(id=50001, media_type=MediaType.episode, show_id=1,
+                                season_number=3, episode_number=6)
+        show = SimpleNamespace(id=1, tmdb_id=214546)
+        db = _QueueDB(SimpleNamespace(tmdb_id=214546), wrong, right)
+
+        with patch("routers.webhooks._find_or_create_show", AsyncMock(return_value=show)):
+            result = await find_or_create_media_kodi(self._episode_data(), db)
+
+        self.assertIs(result, right)
+
+    async def test_matching_tmdb_id_is_still_accepted(self):
+        episode = SimpleNamespace(id=50001, media_type=MediaType.episode, show_id=1,
+                                  season_number=3, episode_number=6)
+        show = SimpleNamespace(id=1, tmdb_id=999)
+        db = _QueueDB(SimpleNamespace(tmdb_id=999), episode)
+
+        with patch("routers.webhooks._find_or_create_show", AsyncMock(return_value=show)):
+            result = await find_or_create_media_kodi(self._episode_data(), db)
+
+        self.assertIs(result, episode)
+
+    async def test_show_id_resolves_series_when_payload_has_no_showtitle(self):
+        # No showtitle/tvdb/imdb: the only hint is the uniqueid, which is the
+        # show's id - use it to resolve the series instead of as an episode id.
+        episode = SimpleNamespace(id=50001, media_type=MediaType.episode, show_id=1,
+                                  season_number=3, episode_number=6)
+        show = SimpleNamespace(id=1, tmdb_id=214546)
+        db = _QueueDB(SimpleNamespace(tmdb_id=214546), None, episode)
+
+        with patch("routers.webhooks._find_or_create_show", AsyncMock(return_value=show)) as find_show:
+            result = await find_or_create_media_kodi(self._episode_data(series_name=None), db)
+
+        self.assertIs(result, episode)
+        self.assertEqual(find_show.await_args.args[1], 214546)
+
+    async def test_unverified_show_id_is_not_stored_on_a_new_episode(self):
+        show = SimpleNamespace(id=1, tmdb_id=214546)
+        created = SimpleNamespace(id=60001, media_type=MediaType.episode, show_id=1,
+                                  season_number=3, episode_number=6)
+        db = _QueueDB(SimpleNamespace(tmdb_id=214546), None, None)
+
+        with patch("routers.webhooks._find_or_create_show", AsyncMock(return_value=show)),              patch("routers.webhooks._resolve_tvdb_fallback", AsyncMock(return_value=(None, None, None))),              patch("routers.webhooks.enrich_media_safely", AsyncMock(return_value=created)),              patch("routers.webhooks.create_media_safely",
+                   AsyncMock(return_value=(created, True))) as create_mock:
+            await find_or_create_media_kodi(self._episode_data(), db)
+
+        self.assertIsNone(create_mock.await_args.args[1])
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_webhooks.py
+++ b/backend/tests/test_webhooks.py
@@ -1393,21 +1393,6 @@ class ParseKodiPayloadTests(unittest.TestCase):
         self.assertEqual(data["session_id"], "7")
 
 
-class _QueueDB:
-    """Fakes just enough of AsyncSession for find_or_create_media_kodi: each
-    execute() pops the next queued row, so a test can script exactly what the
-    show lookup, the TMDB-ID match and the season/episode match each return."""
-
-    def __init__(self, *rows):
-        self._rows = list(rows)
-        self.calls = 0
-
-    async def execute(self, stmt):
-        self.calls += 1
-        row = self._rows.pop(0) if self._rows else None
-        return _FastPathResult(row)
-
-
 class FindOrCreateMediaKodiShowIdTests(IsolatedAsyncioTestCase):
     """Kodi puts the *show* TMDB id in an episode's uniqueid whenever its
     scraper has no episode-level id, and add-ons forward it as-is. Shows and
@@ -1436,7 +1421,7 @@ class FindOrCreateMediaKodiShowIdTests(IsolatedAsyncioTestCase):
         right = SimpleNamespace(id=50001, media_type=MediaType.episode, show_id=1,
                                 season_number=3, episode_number=6)
         show = SimpleNamespace(id=1, tmdb_id=214546)
-        db = _QueueDB(SimpleNamespace(tmdb_id=214546), wrong, right)
+        db = _QueuedResultDB([SimpleNamespace(tmdb_id=214546), wrong, right])
 
         with patch("routers.webhooks._find_or_create_show", AsyncMock(return_value=show)):
             result = await find_or_create_media_kodi(self._episode_data(), db)
@@ -1447,7 +1432,7 @@ class FindOrCreateMediaKodiShowIdTests(IsolatedAsyncioTestCase):
         episode = SimpleNamespace(id=50001, media_type=MediaType.episode, show_id=1,
                                   season_number=3, episode_number=6)
         show = SimpleNamespace(id=1, tmdb_id=999)
-        db = _QueueDB(SimpleNamespace(tmdb_id=999), episode)
+        db = _QueuedResultDB([SimpleNamespace(tmdb_id=999), episode])
 
         with patch("routers.webhooks._find_or_create_show", AsyncMock(return_value=show)):
             result = await find_or_create_media_kodi(self._episode_data(), db)
@@ -1460,7 +1445,7 @@ class FindOrCreateMediaKodiShowIdTests(IsolatedAsyncioTestCase):
         episode = SimpleNamespace(id=50001, media_type=MediaType.episode, show_id=1,
                                   season_number=3, episode_number=6)
         show = SimpleNamespace(id=1, tmdb_id=214546)
-        db = _QueueDB(show, None, episode)
+        db = _QueuedResultDB([show, None, episode])
 
         with patch("routers.webhooks._find_or_create_show", AsyncMock()) as find_show:
             result = await find_or_create_media_kodi(self._episode_data(series_name=None), db)
@@ -1475,13 +1460,31 @@ class FindOrCreateMediaKodiShowIdTests(IsolatedAsyncioTestCase):
         show = SimpleNamespace(id=1, tmdb_id=214546)
         created = SimpleNamespace(id=60001, media_type=MediaType.episode, show_id=1,
                                   season_number=3, episode_number=6)
-        db = _QueueDB(SimpleNamespace(tmdb_id=214546), None, None)
+        db = _QueuedResultDB([SimpleNamespace(tmdb_id=214546), None, None])
 
         with patch("routers.webhooks._find_or_create_show", AsyncMock(return_value=show)),              patch("routers.webhooks._resolve_tvdb_fallback", AsyncMock(return_value=(None, None, None))),              patch("routers.webhooks.enrich_media_safely", AsyncMock(return_value=created)),              patch("routers.webhooks.create_media_safely",
                    AsyncMock(return_value=(created, True))) as create_mock:
             await find_or_create_media_kodi(self._episode_data(), db)
 
         self.assertIsNone(create_mock.await_args.args[1])
+
+    async def test_unresolved_show_dedups_by_title_season_episode_before_creating(self):
+        # No showtitle/tvdb/imdb and the uniqueid doesn't match any local
+        # show - series_tmdb_id/show never resolve, so the row this same
+        # episode created on an earlier webhook call has show_id=None and
+        # tmdb_id=None (unverified ids are never stored). Without a
+        # season/episode dedup lookup here, every later webhook for this
+        # episode (pause/resume/stop, a repeat play) would mint a fresh
+        # duplicate instead of finding it.
+        existing = SimpleNamespace(id=70001, media_type=MediaType.episode, show_id=None,
+                                    season_number=3, episode_number=6)
+        db = _QueuedResultDB([None, None, existing])
+
+        with patch("routers.webhooks.create_media_safely", AsyncMock()) as create_mock:
+            result = await find_or_create_media_kodi(self._episode_data(series_name=None), db)
+
+        self.assertIs(result, existing)
+        create_mock.assert_not_awaited()
 
 
 if __name__ == "__main__":

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -650,7 +650,7 @@ export interface MediaItem {
   // for the show and their estimated total runtime in minutes.
   episodes_left?: number | null;
   remaining_runtime?: number | null;
-  // Next Up only (#237) — the show's most recent watch (or, mid-rewatch, that
+  // Next Up only (#237) - the show's most recent watch (or, mid-rewatch, that
   // rewatch's own progress/start time), for interleaving this feed with
   // /continue-watching's own watched_at into one activity-sorted list.
   last_watched_at?: string | null;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -650,6 +650,10 @@ export interface MediaItem {
   // for the show and their estimated total runtime in minutes.
   episodes_left?: number | null;
   remaining_runtime?: number | null;
+  // Next Up only (#237) — the show's most recent watch (or, mid-rewatch, that
+  // rewatch's own progress/start time), for interleaving this feed with
+  // /continue-watching's own watched_at into one activity-sorted list.
+  last_watched_at?: string | null;
   known_for_department?: string | null;
   in_library?: boolean;
   playable?: boolean;


### PR DESCRIPTION
Fixes #352.

Kodi stores the **show's** TMDB id in an episode's `uniqueid` whenever its scraper has no episode-level id, and add-ons forward it as-is. Shows and episodes are separate TMDB id spaces that reuse the same numbers, so matching that id against `Media.tmdb_id` can land on an unrelated episode — show `214546` (*Sleepers*) collides with episode `214546` (*Law & Order: SVU S04E10*), and playing Sleepers S03E06 scrobbled "Resilience".

That lookup also ran *before* the `show + season/episode` lookup, so a payload carrying a perfectly good `showtitle`, `season` and `episode` still resolved to the wrong episode. And when nothing collided, the show id was persisted on the newly created episode row, seeding the same mismatch for every later webhook.

### Changes

An episode payload's `tmdb_id` is now treated as a hint rather than an identity:

- a `tmdb_id` match is only accepted when the season/episode numbers (and the resolved show) agree — otherwise it falls through to the show + season/episode lookup;
- when nothing else resolves the series (no tvdb/imdb id, no `showtitle`), the id is tried as a **show** id against local shows;
- an unverified id is no longer stored on a newly created episode row, and the "not enough to identify anything" bail-out still fires when it is dropped.

Movies are untouched — their `uniqueid.tmdb` is unambiguous.

### Tests

Four regression tests in `test_webhooks.py` covering the collision, an id that does match (must still be accepted), resolving the series from the id when the payload has no `showtitle`, and not persisting an unverified id. All three failure cases fail on `main` and pass here; full backend suite green (874 passed).
