### PR TITLE
feat(episode-order): server-wide TVDB/TMDB default plus a bulk re-map action

### DIFF
--- a/backend/core/episode_order.py
+++ b/backend/core/episode_order.py
@@ -17,8 +17,11 @@ from models.events import WatchEvent
 from models.lists import ListItem
 from models.media import Media
 from models.playback_progress import PlaybackProgress
+from models.global_settings import GlobalSettings
 from models.ratings import Rating
 from models.rewatch import RewatchProgress
+from models.show import Show
+from models.users import UserSettings
 
 logger = logging.getLogger(__name__)
 
@@ -52,6 +55,55 @@ async def get_episode_order(
         )
     )
     return result.scalar_one_or_none()
+
+
+async def get_default_episode_order(db: AsyncSession, user_id: int) -> str:
+    """The effective episode-order default for this user: their own choice,
+    else the server-wide one an admin set, else "tmdb". Same override chain as
+    the TVDB API key (see routers/shows.py:get_user_tvdb_key).
+
+    This is only the fallback for shows the user made no choice for - an
+    explicit per-show UserShowEpisodeOrder row always wins over it."""
+    result = await db.execute(
+        select(UserSettings.default_episode_order).where(UserSettings.user_id == user_id)
+    )
+    own = result.scalar_one_or_none()
+    if own:
+        return own
+    gs_result = await db.execute(
+        select(GlobalSettings.default_episode_order).where(GlobalSettings.id == 1)
+    )
+    return gs_result.scalar_one_or_none() or "tmdb"
+
+
+async def user_series_tmdb_ids(db: AsyncSession, user_id: int) -> list[int]:
+    """Every show the user collected or watched, by series TMDB id - the set the
+    global default applies to. Watch history is included because a show can be
+    tracked (Trakt/Simkl import, manual log) without any local file."""
+    collected = (
+        select(Show.tmdb_id)
+        .join(Media, Media.show_id == Show.id)
+        .join(Collection, Collection.media_id == Media.id)
+        .where(Collection.user_id == user_id, Show.tmdb_id.isnot(None))
+    )
+    watched = (
+        select(Show.tmdb_id)
+        .join(Media, Media.show_id == Show.id)
+        .join(WatchEvent, WatchEvent.media_id == Media.id)
+        .where(WatchEvent.user_id == user_id, Show.tmdb_id.isnot(None))
+    )
+    result = await db.execute(collected.union(watched))
+    return [row[0] for row in result.all()]
+
+
+async def series_tmdb_ids_with_preference(db: AsyncSession, user_id: int) -> set[int]:
+    """Shows the user already made an explicit episode-order choice for."""
+    result = await db.execute(
+        select(UserShowEpisodeOrder.series_tmdb_id).where(
+            UserShowEpisodeOrder.user_id == user_id
+        )
+    )
+    return {row[0] for row in result.all()}
 
 
 async def get_mappings_for_tvdb_season(

--- a/backend/migrations/versions/eodefault_add_default_episode_order.py
+++ b/backend/migrations/versions/eodefault_add_default_episode_order.py
@@ -1,0 +1,34 @@
+"""add default_episode_order to global_settings and user_settings
+
+The user column is nullable on purpose: NULL means "inherit the server-wide
+default", the same override chain the TVDB API key already uses.
+
+Revision ID: eodefault
+Revises: we355created
+Create Date: 2026-09-07
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "eodefault"
+down_revision = "we355created"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "global_settings",
+        sa.Column("default_episode_order", sa.String(length=20), nullable=True),
+    )
+    op.add_column(
+        "user_settings",
+        sa.Column("default_episode_order", sa.String(length=20), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("user_settings", "default_episode_order")
+    op.drop_column("global_settings", "default_episode_order")

--- a/backend/models/global_settings.py
+++ b/backend/models/global_settings.py
@@ -29,6 +29,10 @@ class GlobalSettings(Base):
     sonarr_customize_on_add      : Mapped[bool]          = mapped_column(Boolean, nullable=False, server_default="false")
     tvdb_api_key                 : Mapped[Optional[str]] = mapped_column(String(255))
     tvdb_subscriber_pin          : Mapped[Optional[str]] = mapped_column(String(255))
+    # Server-wide episode order ("tmdb" | "tvdb") for users who haven't picked
+    # one themselves - same override chain as the API keys above. NULL means
+    # "tmdb", the historical behaviour.
+    default_episode_order        : Mapped[Optional[str]] = mapped_column(String(20), nullable=True)
     image_cache_enabled          : Mapped[bool]          = mapped_column(Boolean, nullable=False, server_default="false")
     image_cache_limit_gb         : Mapped[Optional[float]] = mapped_column(Float, nullable=True)
     enable_logged_out_navigation : Mapped[bool]          = mapped_column(Boolean, nullable=False, server_default="false")

--- a/backend/models/users.py
+++ b/backend/models/users.py
@@ -148,6 +148,12 @@ class UserSettings(Base):
     rate_prompt_movies   : Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="false")
     rate_prompt_episodes : Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="false")
 
+    # Episode order ("tmdb" | "tvdb") applied to shows the user has no explicit
+    # per-show choice for - see UserShowEpisodeOrder, which always wins. NULL
+    # inherits the server-wide default from GlobalSettings, the same override
+    # chain as tvdb_api_key above.
+    default_episode_order : Mapped[Optional[str]] = mapped_column(String(20), nullable=True)
+
     # MDBList — API key authentication
     mdblist_api_key: Mapped[Optional[str]] = mapped_column(String(255))
     mdblist_sync_watched: Mapped[bool] = mapped_column(Boolean, default=True, server_default="true")

--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -61,6 +61,20 @@ async def update_global_settings(
         if field in update_data and update_data[field]:
             update_data[field] = await validate_service_url(update_data[field], label)
 
+    # NULL/empty is meaningful here (it means "tmdb", the historical
+    # behaviour), so only a value that is actually set gets validated.
+    if update_data.get("default_episode_order"):
+        from core.episode_order import validate_episode_order
+
+        try:
+            validate_episode_order(update_data["default_episode_order"])
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc))
+        if update_data["default_episode_order"] == "tvdb" and not (
+            update_data.get("tvdb_api_key") or gs.tvdb_api_key
+        ):
+            raise HTTPException(status_code=400, detail="TVDB API key not configured")
+
     for field, value in update_data.items():
         if hasattr(gs, field):
             setattr(gs, field, value)

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -373,6 +373,9 @@ async def _settings_response(settings: UserSettings, db: AsyncSession) -> schema
     data.has_effective_tmdb_key = bool(settings.tmdb_api_key) or data.has_global_tmdb_key
     data.has_global_tvdb_key = bool(gs and gs.tvdb_api_key)
     data.has_effective_tvdb_key = bool(settings.tvdb_api_key) or data.has_global_tvdb_key
+    # What default_episode_order = NULL resolves to, so the settings page can
+    # label its "server default" option with the order it actually inherits.
+    data.server_episode_order = (gs.default_episode_order if gs else None) or "tmdb"
     # Same "all 4 fields set, user config first" rule as _effective_radarr/
     # _effective_sonarr in routers/media.py - inlined rather than imported to
     # avoid a routers.media <-> routers.auth cross-import.
@@ -422,7 +425,7 @@ async def update_user_settings(
         db.add(settings)
 
     # Computed read-only fields; never write them back
-    READ_ONLY_FIELDS = {"trakt_connected", "simkl_connected", "mdblist_connected", "bingebase_connected", "has_global_tmdb_key", "has_effective_tmdb_key", "has_global_tvdb_key", "has_effective_tvdb_key"}
+    READ_ONLY_FIELDS = {"trakt_connected", "simkl_connected", "mdblist_connected", "bingebase_connected", "has_global_tmdb_key", "has_effective_tmdb_key", "has_global_tvdb_key", "has_effective_tvdb_key", "server_episode_order"}
     update_data = {k: v for k, v in settings_in.model_dump(exclude_unset=True).items() if k not in READ_ONLY_FIELDS}
 
     if "tmdb_api_key" in update_data and update_data["tmdb_api_key"]:
@@ -443,6 +446,22 @@ async def update_user_settings(
                 detail="TVDB rejected the key" + (" / PIN" if new_tvdb_pin else "")
                 + ". A subscriber-supported key needs its account PIN; a free project key needs no PIN.",
             )
+
+    # Switching the default to TVDB is only useful with both keys present -
+    # the mapping job needs TMDB for the episode lists and TVDB for the
+    # positions, same requirement as the per-show switch in routers/shows.py.
+    if update_data.get("default_episode_order"):
+        from core.episode_order import validate_episode_order
+
+        try:
+            validate_episode_order(update_data["default_episode_order"])
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc))
+        if update_data["default_episode_order"] == "tvdb":
+            from routers.shows import get_user_tvdb_key
+
+            if not await get_user_tvdb_key(db, current_user.id):
+                raise HTTPException(status_code=400, detail="TVDB API key not configured")
 
     if "mdblist_api_key" in update_data and update_data["mdblist_api_key"]:
         from core import mdblist

--- a/backend/routers/shows.py
+++ b/backend/routers/shows.py
@@ -28,8 +28,11 @@ from core import tmdb
 from core import tvdb as tvdb_client
 from core.episode_order import (
     ensure_episode_order_mapping,
+    get_default_episode_order,
     get_episode_order,
     reconcile_divergent_episode_media,
+    series_tmdb_ids_with_preference,
+    user_series_tmdb_ids,
     validate_episode_order,
 )
 from core.enrichment import (
@@ -439,6 +442,165 @@ class EpisodeOrderRequest(BaseModel):
     force_refresh: bool = False
 
 
+async def _switch_show_to_tvdb_order(
+    db: AsyncSession,
+    user_id: int,
+    series_tmdb_id: int,
+    tmdb_api_key: str,
+    tvdb_api_key: str,
+    *,
+    force: bool = False,
+    on_progress=None,
+) -> dict:
+    """Build the show's TMDB<->TVDB position mapping and point the user's
+    preference at TVDB. Shared by the per-show switch and the bulk apply, so
+    both leave a show in exactly the same state."""
+    mapping_summary = await ensure_episode_order_mapping(
+        db, series_tmdb_id, tmdb_api_key, tvdb_api_key,
+        force=force, on_progress=on_progress,
+    )
+    tvdb_id = mapping_summary["tvdb_id"]
+
+    preference = await get_episode_order(db, user_id, series_tmdb_id)
+    if preference:
+        preference.episode_order = "tvdb"
+        preference.tvdb_id = tvdb_id
+    else:
+        db.add(UserShowEpisodeOrder(
+            user_id=user_id,
+            series_tmdb_id=series_tmdb_id,
+            episode_order="tvdb",
+            tvdb_id=tvdb_id,
+        ))
+
+    show_result = await db.execute(
+        select(ShowModel).where(ShowModel.tmdb_id == series_tmdb_id)
+    )
+    local_show = show_result.scalar_one_or_none()
+    if local_show:
+        local_show.tvdb_id = tvdb_id
+        # #162: this show's TMDB<->TVDB positions are now fully known -
+        # merge any episode that was previously tracked under the "wrong"
+        # (TVDB-native) numbering into its canonical TMDB-numbered row.
+        await reconcile_divergent_episode_media(db, local_show)
+
+    return mapping_summary
+
+
+async def _switch_show_to_tmdb_order(db: AsyncSession, user_id: int, series_tmdb_id: int) -> None:
+    """The counterpart for the "tmdb" default. Keeps the row rather than
+    deleting it - an explicit "tmdb" choice and no row mean the same thing to
+    every reader, and keeping it means a later bulk apply can tell the two
+    apart."""
+    preference = await get_episode_order(db, user_id, series_tmdb_id)
+    if preference:
+        preference.episode_order = "tmdb"
+    else:
+        db.add(UserShowEpisodeOrder(
+            user_id=user_id,
+            series_tmdb_id=series_tmdb_id,
+            episode_order="tmdb",
+            tvdb_id=None,
+        ))
+
+
+async def _run_default_episode_order(
+    user_id: int,
+    job_id: int,
+    series_tmdb_ids: list[int],
+    order: str,
+    tmdb_api_key: str | None,
+    tvdb_api_key: str | None,
+) -> None:
+    """Apply one episode order to many shows. Shows are done one at a time:
+    a single show's mapping already fans out a TMDB request per episode, so
+    this loop is the throttle. One show's failure (no TVDB match, a dead
+    request) is recorded and skipped rather than failing the whole run."""
+    async_session = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+
+    async with async_session() as db:
+        await db.execute(update(SyncJob).where(SyncJob.id == job_id).values(
+            status=SyncStatus.running,
+            total_items=len(series_tmdb_ids),
+            processed_items=0,
+            current_step=f"Applying {order.upper()} episode order",
+        ))
+        await db.commit()
+
+        done = 0
+        switched = 0
+        failures: list[dict] = []
+
+        for series_tmdb_id in series_tmdb_ids:
+            try:
+                if order == "tvdb":
+                    await _switch_show_to_tvdb_order(
+                        db, user_id, series_tmdb_id, tmdb_api_key, tvdb_api_key,
+                    )
+                else:
+                    await _switch_show_to_tmdb_order(db, user_id, series_tmdb_id)
+                await db.commit()
+                switched += 1
+            except Exception as exc:
+                await db.rollback()
+                failures.append({"series_tmdb_id": series_tmdb_id, "error": str(exc)[:200]})
+
+            done += 1
+            if done % 5 == 0 or done == len(series_tmdb_ids):
+                await db.execute(update(SyncJob).where(SyncJob.id == job_id).values(
+                    processed_items=done, updated_at=func.now(),
+                ))
+                await db.commit()
+
+        await db.execute(update(SyncJob).where(SyncJob.id == job_id).values(
+            status=SyncStatus.completed,
+            processed_items=done,
+            stats={"episode_order": order, "switched": switched, "failed": len(failures)},
+            warnings=failures or None,
+        ))
+        await db.commit()
+
+
+async def apply_default_episode_order_to_new_shows(user_id: int) -> None:
+    """Fire-and-forget hook for the end of a sync: bring shows the user has no
+    explicit choice for in line with their global default. Shows that already
+    have a preference (including one set by an earlier run of this) are left
+    alone, so this is a no-op on every sync after the first."""
+    async_session = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+    try:
+        async with async_session() as db:
+            order = await get_default_episode_order(db, user_id)
+            if order != "tvdb":
+                # "tmdb" is what a show without a preference row already
+                # behaves as - nothing to write.
+                return
+            tmdb_api_key, tvdb_api_key = await asyncio.gather(
+                get_user_tmdb_key(db, user_id), get_user_tvdb_key(db, user_id),
+            )
+            if not check_tmdb_key(tmdb_api_key) or not tvdb_api_key:
+                return
+            already_chosen = await series_tmdb_ids_with_preference(db, user_id)
+            pending = [
+                sid for sid in await user_series_tmdb_ids(db, user_id)
+                if sid not in already_chosen
+            ]
+            if not pending:
+                return
+
+        for series_tmdb_id in pending:
+            async with async_session() as db:
+                try:
+                    await _switch_show_to_tvdb_order(
+                        db, user_id, series_tmdb_id, tmdb_api_key, tvdb_api_key,
+                    )
+                    await db.commit()
+                except Exception as exc:
+                    await db.rollback()
+                    print(f"Default episode order: show tmdb={series_tmdb_id} skipped ({exc})")
+    except Exception as exc:
+        print(f"Default episode order for user {user_id} failed: {exc}")
+
+
 async def _run_episode_order_mapping(
     user_id: int,
     job_id: int,
@@ -464,38 +626,11 @@ async def _run_episode_order_mapping(
             await db.execute(update(SyncJob).where(SyncJob.id == job_id).values(status=SyncStatus.running))
             await db.commit()
 
-            mapping_summary = await ensure_episode_order_mapping(
-                db,
-                series_tmdb_id,
-                tmdb_api_key,
-                tvdb_api_key,
-                force=force_refresh,
-                on_progress=report_progress,
+            mapping_summary = await _switch_show_to_tvdb_order(
+                db, user_id, series_tmdb_id, tmdb_api_key, tvdb_api_key,
+                force=force_refresh, on_progress=report_progress,
             )
             tvdb_id = mapping_summary["tvdb_id"]
-
-            preference = await get_episode_order(db, user_id, series_tmdb_id)
-            if preference:
-                preference.episode_order = "tvdb"
-                preference.tvdb_id = tvdb_id
-            else:
-                db.add(UserShowEpisodeOrder(
-                    user_id=user_id,
-                    series_tmdb_id=series_tmdb_id,
-                    episode_order="tvdb",
-                    tvdb_id=tvdb_id,
-                ))
-
-            show_result = await db.execute(
-                select(ShowModel).where(ShowModel.tmdb_id == series_tmdb_id)
-            )
-            local_show = show_result.scalar_one_or_none()
-            if local_show:
-                local_show.tvdb_id = tvdb_id
-                # #162: this show's TMDB<->TVDB positions are now fully known -
-                # merge any episode that was previously tracked under the "wrong"
-                # (TVDB-native) numbering into its canonical TMDB-numbered row.
-                await reconcile_divergent_episode_media(db, local_show)
 
             await db.execute(update(SyncJob).where(SyncJob.id == job_id).values(
                 status=SyncStatus.completed,
@@ -514,6 +649,63 @@ async def _run_episode_order_mapping(
                 status=SyncStatus.failed, error_message=str(exc)[:900],
             ))
             await db.commit()
+
+
+class ApplyDefaultEpisodeOrderRequest(BaseModel):
+    # Defaults to the user's saved global default; passing it explicitly lets
+    # the settings page apply a just-picked order without saving it first.
+    order: str | None = None
+
+
+@router.post("/episode-order/apply-default")
+async def apply_default_episode_order(
+    body: ApplyDefaultEpisodeOrderRequest,
+    background_tasks: BackgroundTasks,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Force every show the user collected or watched onto one episode order,
+    overriding per-show choices. The global default alone only covers shows
+    with no choice yet (see apply_default_episode_order_to_new_shows)."""
+    try:
+        order = validate_episode_order(
+            body.order or await get_default_episode_order(db, current_user.id)
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+    tmdb_api_key = tvdb_api_key = None
+    if order == "tvdb":
+        tmdb_api_key, tvdb_api_key = await asyncio.gather(
+            get_user_tmdb_key(db, current_user.id),
+            get_user_tvdb_key(db, current_user.id),
+        )
+        if not check_tmdb_key(tmdb_api_key):
+            raise HTTPException(status_code=400, detail="TMDB API key not configured")
+        if not tvdb_api_key:
+            raise HTTPException(status_code=400, detail="TVDB API key not configured")
+
+    series_tmdb_ids = await user_series_tmdb_ids(db, current_user.id)
+    if not series_tmdb_ids:
+        return {"status": "noop", "shows": 0, "episode_order": order}
+
+    job = SyncJob(
+        user_id=current_user.id,
+        source=CollectionSource.tmdb,
+        job_type="episode_order_bulk",
+        status=SyncStatus.pending,
+        total_items=len(series_tmdb_ids),
+        stats={"episode_order": order},
+    )
+    db.add(job)
+    await db.commit()
+    await db.refresh(job)
+
+    background_tasks.add_task(
+        _run_default_episode_order,
+        current_user.id, job.id, series_tmdb_ids, order, tmdb_api_key, tvdb_api_key,
+    )
+    return {"status": "started", "job_id": job.id, "shows": len(series_tmdb_ids), "episode_order": order}
 
 
 @router.get("/episode-order/jobs/{job_id}")

--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -328,6 +328,15 @@ def extract_jellyfin_quality(item: dict) -> dict:
     return quality
 
 
+def _apply_default_episode_order_bg(user_id: int) -> None:
+    """Bring shows this sync just pulled in line with the user's global
+    episode-order default. A no-op unless that default is TVDB and the show
+    has no per-show choice yet - see routers/shows.py."""
+    from routers.shows import apply_default_episode_order_to_new_shows
+
+    asyncio.create_task(apply_default_episode_order_to_new_shows(user_id))
+
+
 async def sync_shows_batch(
     series_tmdb_map: dict,  # source_series_id → tmdb_id
     db: AsyncSession,
@@ -2595,6 +2604,7 @@ async def _run_jellyfin_sync(user_id: int, job_id: int, movie_limit: int, show_l
             await db.execute(update(SyncJob).where(SyncJob.id == job_id).values(status=SyncStatus.completed, stats=stats, warnings=all_warnings or None, updated_at=func.now()))
             await db.commit()
             asyncio.create_task(pre_cache_all_collected_bg())
+            _apply_default_episode_order_bg(user_id)
         except SyncCancelled:
             print(f"Jellyfin sync job {job_id} cancelled")
             await db.rollback()
@@ -2805,6 +2815,7 @@ async def _run_emby_sync(user_id: int, job_id: int, movie_limit: int, show_limit
             await db.execute(update(SyncJob).where(SyncJob.id == job_id).values(status=SyncStatus.completed, stats=stats, warnings=all_warnings or None, updated_at=func.now()))
             await db.commit()
             asyncio.create_task(pre_cache_all_collected_bg())
+            _apply_default_episode_order_bg(user_id)
         except SyncCancelled:
             print(f"Emby sync job {job_id} cancelled")
             await db.rollback()
@@ -3884,6 +3895,7 @@ async def _run_plex_sync(user_id: int, job_id: int, movie_limit: int, show_limit
             await db.execute(update(SyncJob).where(SyncJob.id == job_id).values(status=SyncStatus.completed, stats=stats, warnings=all_warnings or None, updated_at=func.now()))
             await db.commit()
             asyncio.create_task(pre_cache_all_collected_bg())
+            _apply_default_episode_order_bg(user_id)
         except SyncCancelled:
             print(f"Plex sync job {job_id} cancelled")
             await db.rollback()
@@ -4504,6 +4516,7 @@ async def _run_nuvio_sync(
             )
             await db.commit()
             asyncio.create_task(pre_cache_all_collected_bg())
+            _apply_default_episode_order_bg(user_id)
             logger.info("Nuvio sync job %s completed. Stats: %s", job_id, stats)
         except SyncCancelled:
             logger.info("Nuvio sync job %s cancelled", job_id)
@@ -5004,6 +5017,7 @@ async def _run_stremio_sync(
             )
             await db.commit()
             asyncio.create_task(pre_cache_all_collected_bg())
+            _apply_default_episode_order_bg(user_id)
         except Exception as exc:
             logger.exception("Stremio sync job %s failed", job_id)
             await db.rollback()

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -210,6 +210,10 @@ class UserSettings(BaseModel):
     hide_watched_from_recently_added: Optional[bool] = None
     rate_prompt_movies: Optional[bool] = None
     rate_prompt_episodes: Optional[bool] = None
+    # NULL inherits server_episode_order, the admin-configured default below
+    # (read-only, computed).
+    default_episode_order: Optional[str] = None
+    server_episode_order: Optional[str] = None
 
     class Config:
         from_attributes = True
@@ -474,6 +478,7 @@ class GlobalSettings(BaseModel):
     sonarr_require_approval     : bool = False
     radarr_customize_on_add     : bool = False
     sonarr_customize_on_add     : bool = False
+    default_episode_order       : Optional[str] = None
     image_cache_enabled         : bool = False
     image_cache_limit_gb        : Optional[float] = None
     enable_logged_out_navigation: bool = False

--- a/backend/tests/test_admin.py
+++ b/backend/tests/test_admin.py
@@ -7,11 +7,12 @@ os.environ.setdefault("SECRET_KEY", "test-secret")
 os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://test:test@localhost/test")
 
 import httpx
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlalchemy.pool import StaticPool
 
+import schemas
 from db import get_db
 from dependencies import require_admin
 from routers import admin
@@ -95,6 +96,72 @@ class AdminHealTmdbKeyResolutionTests(unittest.IsolatedAsyncioTestCase):
         detail = res.json()["detail"]
         self.assertIn("TMDB", detail)
         self.assertIn("Settings", detail)  # points the user somewhere
+
+
+class _GlobalSettingsDB:
+    """AsyncSession stand-in for update_global_settings: every lookup returns
+    the same GlobalSettings row."""
+
+    def __init__(self, gs):
+        self.gs = gs
+        self.committed = False
+
+    async def execute(self, _stmt):
+        return _Result(self.gs)
+
+    def add(self, obj):
+        pass
+
+    async def flush(self):
+        pass
+
+    async def commit(self):
+        self.committed = True
+
+    async def refresh(self, obj):
+        pass
+
+
+class AdminDefaultEpisodeOrderTests(unittest.IsolatedAsyncioTestCase):
+    """The server-wide episode order is the fallback for users who picked
+    none, so it is validated the same way the per-user and per-show switches
+    are - an unusable value must not be storable."""
+
+    async def _patch(self, gs, **fields):
+        db = _GlobalSettingsDB(gs)
+        result = await admin.update_global_settings(
+            body=schemas.GlobalSettings(**fields), db=db, _=SimpleNamespace(id=1, is_admin=True),
+        )
+        return result, db
+
+    async def test_tvdb_is_stored_when_a_server_key_exists(self):
+        gs = SimpleNamespace(default_episode_order=None, tvdb_api_key="key")
+        _, db = await self._patch(gs, default_episode_order="tvdb")
+        self.assertEqual(gs.default_episode_order, "tvdb")
+        self.assertTrue(db.committed)
+
+    async def test_tvdb_without_any_key_is_rejected(self):
+        gs = SimpleNamespace(default_episode_order=None, tvdb_api_key=None)
+        with self.assertRaises(HTTPException) as ctx:
+            await self._patch(gs, default_episode_order="tvdb")
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertIsNone(gs.default_episode_order)
+
+    async def test_a_key_saved_in_the_same_request_counts(self):
+        gs = SimpleNamespace(default_episode_order=None, tvdb_api_key=None)
+        await self._patch(gs, default_episode_order="tvdb", tvdb_api_key="key")
+        self.assertEqual(gs.default_episode_order, "tvdb")
+
+    async def test_an_unknown_order_is_rejected(self):
+        gs = SimpleNamespace(default_episode_order=None, tvdb_api_key="key")
+        with self.assertRaises(HTTPException) as ctx:
+            await self._patch(gs, default_episode_order="imdb")
+        self.assertEqual(ctx.exception.status_code, 400)
+
+    async def test_tmdb_needs_no_key(self):
+        gs = SimpleNamespace(default_episode_order="tvdb", tvdb_api_key=None)
+        await self._patch(gs, default_episode_order="tmdb")
+        self.assertEqual(gs.default_episode_order, "tmdb")
 
 
 class AdminCreateUserTests(unittest.IsolatedAsyncioTestCase):

--- a/backend/tests/test_episode_order.py
+++ b/backend/tests/test_episode_order.py
@@ -3,9 +3,12 @@ from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 from types import SimpleNamespace
 
+from fastapi import HTTPException
+
 from core.episode_order import (
     _merge_episode_media,
     ensure_episode_order_mapping,
+    get_default_episode_order,
     ensure_episode_order_mapping_for_season,
     get_episode_orders_for_series,
     get_tmdb_to_tvdb_positions,
@@ -23,8 +26,17 @@ from models.playback_progress import PlaybackProgress
 from models.ratings import Rating
 from models.rewatch import RewatchProgress
 from models.show import Show as ShowModel
+from models.sync import SyncStatus
 from routers.ratings import RatingIn, submit_rating
-from routers.shows import _enrich_tvdb_seasons, _run_episode_order_mapping, get_tvdb_season
+from routers.shows import (
+    ApplyDefaultEpisodeOrderRequest,
+    _enrich_tvdb_seasons,
+    _run_default_episode_order,
+    _run_episode_order_mapping,
+    apply_default_episode_order,
+    apply_default_episode_order_to_new_shows,
+    get_tvdb_season,
+)
 
 
 class _EmptyResult:
@@ -842,6 +854,233 @@ class BatchedLookupTests(unittest.IsolatedAsyncioTestCase):
         result = await get_tmdb_to_tvdb_positions(db, series_tmdb_ids=[])
         self.assertEqual(result, {})
         db.execute.assert_not_called()
+
+
+class _DefaultOrderResult:
+    def __init__(self, value):
+        self._value = value
+
+    def scalar_one_or_none(self):
+        return self._value
+
+
+class GetDefaultEpisodeOrderTests(unittest.IsolatedAsyncioTestCase):
+    """Resolution order: the user's own setting, else the admin's server-wide
+    one, else TMDB - the same override chain as the TVDB API key. This default
+    only applies to shows with no UserShowEpisodeOrder row of their own."""
+
+    def _db(self, own, server):
+        """First query reads user_settings, second global_settings."""
+        return SimpleNamespace(execute=AsyncMock(side_effect=[
+            _DefaultOrderResult(own), _DefaultOrderResult(server),
+        ]))
+
+    async def test_nothing_configured_anywhere_means_tmdb(self) -> None:
+        self.assertEqual(await get_default_episode_order(self._db(None, None), 1), "tmdb")
+
+    async def test_the_users_own_choice_wins(self) -> None:
+        db = self._db("tmdb", "tvdb")
+        self.assertEqual(await get_default_episode_order(db, 1), "tmdb")
+        # The server-wide value isn't even read once the user has their own.
+        self.assertEqual(db.execute.await_count, 1)
+
+    async def test_the_server_default_is_inherited_when_the_user_has_none(self) -> None:
+        self.assertEqual(await get_default_episode_order(self._db(None, "tvdb"), 1), "tvdb")
+
+
+class _BulkJobDB:
+    def __init__(self):
+        self.executed = []
+        self.commit = AsyncMock()
+        self.rollback = AsyncMock()
+        self.add = MagicMock()
+
+    async def execute(self, stmt, *args, **kwargs):
+        self.executed.append(stmt)
+        return _EmptyResult()
+
+    def job_values(self):
+        """The bound values of every SyncJob UPDATE this run issued."""
+        return [stmt.compile().params for stmt in self.executed]
+
+
+class RunDefaultEpisodeOrderTests(unittest.IsolatedAsyncioTestCase):
+    """The bulk apply behind the settings action: one order for every show the
+    user has, overriding per-show choices."""
+
+    def _patches(self, db, switch):
+        class _Ctx:
+            async def __aenter__(self):
+                return db
+
+            async def __aexit__(self, *exc):
+                return False
+
+        return (
+            patch("routers.shows.async_sessionmaker", MagicMock(return_value=lambda: _Ctx())),
+            patch("routers.shows._switch_show_to_tvdb_order", switch),
+        )
+
+    async def test_every_show_is_switched_and_the_job_reports_the_count(self) -> None:
+        db = _BulkJobDB()
+        switch = AsyncMock(return_value={"tvdb_id": 1})
+        p1, p2 = self._patches(db, switch)
+        with p1, p2:
+            await _run_default_episode_order(7, 99, [10, 20, 30], "tvdb", "tmdb-key", "tvdb-key")
+
+        self.assertEqual([call.args[2] for call in switch.await_args_list], [10, 20, 30])
+        final = db.job_values()[-1]
+        self.assertEqual(final["status"], SyncStatus.completed)
+        self.assertEqual(final["stats"], {"episode_order": "tvdb", "switched": 3, "failed": 0})
+
+    async def test_one_unmappable_show_does_not_abort_the_rest(self) -> None:
+        db = _BulkJobDB()
+        switch = AsyncMock(side_effect=[
+            {"tvdb_id": 1},
+            ValueError("No TMDB episodes could be matched to TVDB"),
+            {"tvdb_id": 3},
+        ])
+        p1, p2 = self._patches(db, switch)
+        with p1, p2:
+            await _run_default_episode_order(7, 99, [10, 20, 30], "tvdb", "tmdb-key", "tvdb-key")
+
+        final = db.job_values()[-1]
+        self.assertEqual(final["status"], SyncStatus.completed)
+        self.assertEqual(final["stats"], {"episode_order": "tvdb", "switched": 2, "failed": 1})
+        # The failure is reported per show rather than swallowed silently.
+        self.assertEqual(final["warnings"][0]["series_tmdb_id"], 20)
+        db.rollback.assert_awaited_once()
+
+    async def test_tmdb_order_needs_no_mapping_work(self) -> None:
+        db = _BulkJobDB()
+        switch = AsyncMock()
+        p1, p2 = self._patches(db, switch)
+        with p1, p2, patch("routers.shows._switch_show_to_tmdb_order", AsyncMock()) as to_tmdb:
+            await _run_default_episode_order(7, 99, [10, 20], "tmdb", None, None)
+
+        switch.assert_not_awaited()
+        self.assertEqual([call.args[2] for call in to_tmdb.await_args_list], [10, 20])
+
+
+class ApplyDefaultToNewShowsTests(unittest.IsolatedAsyncioTestCase):
+    """The post-sync hook: catches up shows the user has made no choice for,
+    and leaves everything else alone."""
+
+    def _session(self, db):
+        class _Ctx:
+            async def __aenter__(self):
+                return db
+
+            async def __aexit__(self, *exc):
+                return False
+
+        return patch("routers.shows.async_sessionmaker", MagicMock(return_value=lambda: _Ctx()))
+
+    async def test_tmdb_default_touches_nothing(self) -> None:
+        db = _BulkJobDB()
+        switch = AsyncMock()
+        with (
+            self._session(db),
+            patch("routers.shows.get_default_episode_order", AsyncMock(return_value="tmdb")),
+            patch("routers.shows.user_series_tmdb_ids", AsyncMock(return_value=[10])) as ids,
+            patch("routers.shows._switch_show_to_tvdb_order", switch),
+        ):
+            await apply_default_episode_order_to_new_shows(7)
+
+        # A show with no preference row already behaves as TMDB - the hook must
+        # not write a row (or fetch anything) just to say so.
+        ids.assert_not_awaited()
+        switch.assert_not_awaited()
+
+    async def test_only_shows_without_a_choice_are_switched(self) -> None:
+        db = _BulkJobDB()
+        switch = AsyncMock(return_value={"tvdb_id": 1})
+        with (
+            self._session(db),
+            patch("routers.shows.get_default_episode_order", AsyncMock(return_value="tvdb")),
+            patch("routers.shows.get_user_tmdb_key", AsyncMock(return_value="tmdb-key")),
+            patch("routers.shows.get_user_tvdb_key", AsyncMock(return_value="tvdb-key")),
+            patch("routers.shows.check_tmdb_key", MagicMock(return_value=True)),
+            patch("routers.shows.user_series_tmdb_ids", AsyncMock(return_value=[10, 20, 30])),
+            patch("routers.shows.series_tmdb_ids_with_preference", AsyncMock(return_value={20})),
+            patch("routers.shows._switch_show_to_tvdb_order", switch),
+        ):
+            await apply_default_episode_order_to_new_shows(7)
+
+        self.assertEqual([call.args[2] for call in switch.await_args_list], [10, 30])
+
+    async def test_missing_tvdb_key_is_not_an_error(self) -> None:
+        db = _BulkJobDB()
+        switch = AsyncMock()
+        with (
+            self._session(db),
+            patch("routers.shows.get_default_episode_order", AsyncMock(return_value="tvdb")),
+            patch("routers.shows.get_user_tmdb_key", AsyncMock(return_value="tmdb-key")),
+            patch("routers.shows.get_user_tvdb_key", AsyncMock(return_value=None)),
+            patch("routers.shows.check_tmdb_key", MagicMock(return_value=True)),
+            patch("routers.shows._switch_show_to_tvdb_order", switch),
+        ):
+            await apply_default_episode_order_to_new_shows(7)
+
+        switch.assert_not_awaited()
+
+
+class ApplyDefaultEndpointTests(unittest.IsolatedAsyncioTestCase):
+    """POST /shows/episode-order/apply-default - the settings action."""
+
+    async def test_tvdb_without_a_key_is_rejected_before_any_job_is_queued(self) -> None:
+        db = _BulkJobDB()
+        tasks = SimpleNamespace(add_task=MagicMock())
+        with (
+            patch("routers.shows.get_user_tmdb_key", AsyncMock(return_value="tmdb-key")),
+            patch("routers.shows.get_user_tvdb_key", AsyncMock(return_value=None)),
+            patch("routers.shows.check_tmdb_key", MagicMock(return_value=True)),
+        ):
+            with self.assertRaises(HTTPException) as ctx:
+                await apply_default_episode_order(
+                    ApplyDefaultEpisodeOrderRequest(order="tvdb"),
+                    tasks, db=db, current_user=SimpleNamespace(id=7),
+                )
+        self.assertEqual(ctx.exception.status_code, 400)
+        tasks.add_task.assert_not_called()
+
+    async def test_an_unknown_order_is_rejected(self) -> None:
+        db = _BulkJobDB()
+        tasks = SimpleNamespace(add_task=MagicMock())
+        with self.assertRaises(HTTPException) as ctx:
+            await apply_default_episode_order(
+                ApplyDefaultEpisodeOrderRequest(order="imdb"),
+                tasks, db=db, current_user=SimpleNamespace(id=7),
+            )
+        self.assertEqual(ctx.exception.status_code, 400)
+
+    async def test_a_user_with_no_shows_starts_no_job(self) -> None:
+        db = _BulkJobDB()
+        tasks = SimpleNamespace(add_task=MagicMock())
+        with patch("routers.shows.user_series_tmdb_ids", AsyncMock(return_value=[])):
+            result = await apply_default_episode_order(
+                ApplyDefaultEpisodeOrderRequest(order="tmdb"),
+                tasks, db=db, current_user=SimpleNamespace(id=7),
+            )
+        self.assertEqual(result, {"status": "noop", "shows": 0, "episode_order": "tmdb"})
+        tasks.add_task.assert_not_called()
+
+    async def test_the_saved_default_is_used_when_no_order_is_passed(self) -> None:
+        db = _BulkJobDB()
+        db.refresh = AsyncMock()
+        tasks = SimpleNamespace(add_task=MagicMock())
+        with (
+            patch("routers.shows.get_default_episode_order", AsyncMock(return_value="tmdb")),
+            patch("routers.shows.user_series_tmdb_ids", AsyncMock(return_value=[10, 20])),
+        ):
+            result = await apply_default_episode_order(
+                ApplyDefaultEpisodeOrderRequest(),
+                tasks, db=db, current_user=SimpleNamespace(id=7),
+            )
+        self.assertEqual(result["episode_order"], "tmdb")
+        self.assertEqual(result["shows"], 2)
+        self.assertEqual(tasks.add_task.call_args.args[3], [10, 20])
+        self.assertEqual(tasks.add_task.call_args.args[4], "tmdb")
 
 
 if __name__ == "__main__":

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -329,6 +329,7 @@ export interface GlobalSettings {
   sonarr_season_folder: boolean;
   radarr_require_approval: boolean;
   sonarr_require_approval: boolean;
+  default_episode_order: "tmdb" | "tvdb" | null;
   image_cache_enabled: boolean;
   image_cache_limit_gb: number | null;
   enable_logged_out_navigation: boolean;
@@ -479,6 +480,9 @@ export interface UserSettings {
   minimalist_next_up: boolean;
   rate_prompt_movies: boolean;
   rate_prompt_episodes: boolean;
+  default_episode_order: "tmdb" | "tvdb" | null;
+  /** What default_episode_order = null resolves to (admin-configured). */
+  server_episode_order: "tmdb" | "tvdb";
 }
 
 export interface MediaServerConnection {
@@ -1345,6 +1349,22 @@ export const api = {
         { episode_order: episodeOrder, force_refresh: forceRefresh },
         token,
       ),
+
+    applyDefaultEpisodeOrder: (episodeOrder: "tmdb" | "tvdb", token: string) =>
+      post<{
+        status: "started" | "noop";
+        job_id?: number;
+        shows: number;
+        episode_order: "tmdb" | "tvdb";
+      }>(`/shows/episode-order/apply-default`, { order: episodeOrder }, token),
+
+    getEpisodeOrderJob: (jobId: number, token: string) =>
+      get<{
+        status: string;
+        total_items: number | null;
+        processed_items: number | null;
+        stats: { episode_order?: string; switched?: number; failed?: number } | null;
+      }>(`/shows/episode-order/jobs/${jobId}`, undefined, token),
 
     getTvdb: (tvdbId: number, token?: string) =>
       get<TvdbShow>(`/shows/tvdb/${tvdbId}`, undefined, token),

--- a/frontend/src/pages/admin.astro
+++ b/frontend/src/pages/admin.astro
@@ -121,6 +121,17 @@ const adminCount = users.filter((u: AdminUser) => u.is_admin).length;
                     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 eye-slash-icon hidden"><path stroke-linecap="round" stroke-linejoin="round" d="M3.98 8.223A10.477 10.477 0 001.934 12C3.226 16.338 7.244 19.5 12 19.5c.993 0 1.953-.138 2.863-.395M6.228 6.228A10.45 10.45 0 0112 4.5c4.756 0 8.773 3.162 10.065 7.498a10.523 10.523 0 01-4.293 5.774M6.228 6.228L3 3m3.228 3.228l3.65 3.65m7.894 7.894L21 21m-3.228-3.228l-3.65-3.65m0 0a3 3 0 10-4.243-4.243m4.242 4.242L9.88 9.88" /></svg>
                   </button>
                 </div>
+
+                <label for="default_episode_order" class="block text-sm font-medium text-zinc-400 pt-3">Default episode order</label>
+                <select
+                  name="default_episode_order"
+                  id="default_episode_order"
+                  class="w-full bg-zinc-950 border border-zinc-800 rounded-lg px-4 py-3 text-zinc-100 focus:outline-none focus:ring-2 focus:ring-blue-500 transition-all cursor-pointer"
+                >
+                  <option value="tmdb" selected={globalSettings.default_episode_order !== "tvdb"}>TMDB</option>
+                  <option value="tvdb" selected={globalSettings.default_episode_order === "tvdb"}>TVDB</option>
+                </select>
+                <p class="text-xs text-zinc-500">Season/episode numbering for users who haven't picked one in their own settings. TVDB is the order Sonarr names files by and needs a key above. Users can override this, and a per-show choice always wins.</p>
               </div>
             </div>
           </div>
@@ -966,7 +977,7 @@ const adminCount = users.filter((u: AdminUser) => u.is_admin).length;
     const fd = new FormData(form);
     const body: Record<string, string | number | boolean | number[] | null> = {};
 
-    for (const f of ['tmdb_api_key', 'tvdb_api_key', 'tvdb_subscriber_pin', 'radarr_url', 'radarr_token', 'radarr_root_folder', 'sonarr_url', 'sonarr_token', 'sonarr_root_folder']) {
+    for (const f of ['tmdb_api_key', 'tvdb_api_key', 'tvdb_subscriber_pin', 'default_episode_order', 'radarr_url', 'radarr_token', 'radarr_root_folder', 'sonarr_url', 'sonarr_token', 'sonarr_root_folder']) {
       const v = ((fd.get(f) as string) ?? '').trim();
       body[f] = v || null;
     }

--- a/frontend/src/pages/settings.astro
+++ b/frontend/src/pages/settings.astro
@@ -9,6 +9,9 @@ const [settings, me] = await Promise.all([
   api.auth.me(token!),
 ]);
 const hasTmdbKey = settings.has_effective_tmdb_key;
+const hasTvdbKey = settings.has_effective_tvdb_key;
+const defaultEpisodeOrder = settings.default_episode_order ?? '';
+const serverEpisodeOrder = settings.server_episode_order === 'tvdb' ? 'TVDB' : 'TMDB';
 let backupCodes: TotpBackupCode[] = [];
 if (me.totp_enabled) {
   try {
@@ -312,6 +315,57 @@ if (me.totp_enabled) {
                   {label}
                 </button>
               ))}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Episode Order -->
+      <section>
+        <h2 class="section-headline mb-4 border-b border-zinc-800 pb-2">Episode Order</h2>
+        <div class="space-y-3 max-w-xl">
+          <div class="bg-zinc-900 border border-zinc-800 rounded-xl overflow-hidden">
+            <div class="flex items-start justify-between gap-6 px-5 py-4">
+              <div>
+                <p class="text-sm font-medium text-zinc-200">Default for new shows</p>
+                <p class="text-xs text-zinc-500 mt-0.5">Whose season/episode numbering shows use. TVDB is the order Sonarr names files by and needs a TVDB API key. A per-show choice always wins over this default, and leaving this on the server default follows whatever the admin configured.</p>
+              </div>
+              <select
+                id="default-episode-order"
+                data-server-order={settings.server_episode_order ?? 'tmdb'}
+                disabled={!hasTvdbKey && defaultEpisodeOrder !== 'tvdb'}
+                title={!hasTvdbKey ? "A TVDB API key is required for TVDB ordering" : ""}
+                class="ml-4 shrink-0 text-sm px-3 py-2 rounded-lg bg-zinc-800 border border-zinc-700 text-zinc-200 cursor-pointer disabled:opacity-50"
+              >
+                <option value="" selected={defaultEpisodeOrder === ''}>Server default ({serverEpisodeOrder})</option>
+                <option value="tmdb" selected={defaultEpisodeOrder === 'tmdb'}>TMDB</option>
+                <option value="tvdb" selected={defaultEpisodeOrder === 'tvdb'}>TVDB</option>
+              </select>
+            </div>
+            <div class="flex items-start justify-between gap-6 px-5 py-4 border-t border-zinc-800">
+              <div>
+                <p class="text-sm font-medium text-zinc-200">Apply to all existing shows</p>
+                <p class="text-xs text-zinc-500 mt-0.5">Re-maps every show you collected or watched to the order above, overriding per-show choices. Shows are done one at a time — building a missing TVDB mapping takes a moment per show.</p>
+              </div>
+              <button
+                id="apply-episode-order-btn"
+                type="button"
+                class="ml-4 shrink-0 text-sm px-4 py-2 rounded-lg transition-colors cursor-pointer disabled:opacity-50 bg-blue-600/20 hover:bg-blue-600/30 text-blue-400 border border-blue-500/30"
+              >
+                Apply
+              </button>
+            </div>
+            <div id="episode-order-progress" class="hidden border-t border-zinc-800 px-5 py-3">
+              <div class="flex justify-between items-center mb-1.5">
+                <span id="episode-order-label" class="text-xs font-semibold uppercase tracking-wider text-zinc-500">Working…</span>
+                <span id="episode-order-pct" class="text-xs font-bold text-zinc-400"></span>
+              </div>
+              <div class="w-full bg-zinc-800 rounded-full h-1.5 overflow-hidden">
+                <div id="episode-order-bar" class="h-1.5 rounded-full transition-all duration-500 bg-blue-600 animate-pulse" style="width: 100%"></div>
+              </div>
+              <div class="flex justify-between text-xs text-zinc-500 mt-1">
+                <span id="episode-order-items"></span>
+              </div>
             </div>
           </div>
         </div>
@@ -1642,6 +1696,127 @@ if (me.totp_enabled) {
   setupPasswordToggles();
   setupSettingsForm();
   setupPasswordForm();
+
+  // ── Episode order: global default + bulk apply ─────────────────────────────
+  const episodeOrderSelect = document.getElementById('default-episode-order') as HTMLSelectElement | null;
+  const applyEpisodeOrderBtn = document.getElementById('apply-episode-order-btn') as HTMLButtonElement | null;
+  let episodeOrderPoller: ReturnType<typeof setTimeout> | null = null;
+
+  function renderEpisodeOrderJob(job: any) {
+    const strip = document.getElementById('episode-order-progress');
+    const bar = document.getElementById('episode-order-bar');
+    const pctEl = document.getElementById('episode-order-pct');
+    const label = document.getElementById('episode-order-label');
+    const items = document.getElementById('episode-order-items');
+    if (!strip) return;
+
+    if (!job) { strip.classList.add('hidden'); return; }
+    strip.classList.remove('hidden');
+
+    const total = job.total_items || 0;
+    const done = job.processed_items || 0;
+    const pct = total > 0 ? Math.min(100, Math.round((done / total) * 100)) : 0;
+
+    if (job.status === 'failed') {
+      if (bar) { bar.className = 'h-1.5 rounded-full bg-red-500'; bar.style.width = '100%'; }
+      if (label) label.textContent = 'Failed';
+      if (pctEl) pctEl.textContent = '';
+      if (items) items.textContent = job.error_message || 'Unknown error';
+      return;
+    }
+
+    if (job.status === 'completed') {
+      const failed = job.stats?.failed || 0;
+      if (bar) { bar.className = 'h-1.5 rounded-full bg-blue-600'; bar.style.width = '100%'; }
+      if (label) label.textContent = 'Done';
+      if (pctEl) pctEl.textContent = '100%';
+      if (items) items.textContent = `${job.stats?.switched ?? done} show${(job.stats?.switched ?? done) !== 1 ? 's' : ''} re-mapped`
+        + (failed ? `, ${failed} skipped` : '');
+      return;
+    }
+
+    if (bar) {
+      bar.className = `h-1.5 rounded-full transition-all duration-500 bg-blue-600${pct === 0 ? ' animate-pulse' : ''}`;
+      bar.style.width = pct === 0 ? '100%' : `${pct}%`;
+    }
+    if (label) label.textContent = job.status === 'pending' ? 'Queued…' : 'Re-mapping shows…';
+    if (pctEl) pctEl.textContent = pct > 0 ? `${pct}%` : '';
+    if (items) items.textContent = total > 0 ? `${done} / ${total} shows` : 'Loading…';
+  }
+
+  async function pollEpisodeOrderJob(jobId: number) {
+    try {
+      const res = await fetch(`/api/proxy/shows/episode-order/jobs/${jobId}`, {
+        headers: { 'Authorization': `Bearer ${token}` },
+      });
+      if (!res.ok) return;
+      const job = await res.json();
+      renderEpisodeOrderJob(job);
+      if (job.status === 'pending' || job.status === 'running') {
+        episodeOrderPoller = setTimeout(() => pollEpisodeOrderJob(jobId), 2000);
+      } else {
+        episodeOrderPoller = null;
+        if (applyEpisodeOrderBtn) { applyEpisodeOrderBtn.disabled = false; applyEpisodeOrderBtn.textContent = 'Apply'; }
+      }
+    } catch {
+      episodeOrderPoller = null;
+    }
+  }
+
+  // What the "server default" option resolves to (see server_episode_order).
+  const serverEpisodeOrderValue = episodeOrderSelect?.dataset.serverOrder || 'tmdb';
+
+  if (episodeOrderSelect) {
+    let lastSavedOrder = episodeOrderSelect.value;
+    episodeOrderSelect.addEventListener('change', async () => {
+      const order = episodeOrderSelect.value;
+      const res = await fetch('/api/proxy/auth/settings', {
+        method: 'PATCH',
+        headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ default_episode_order: order || null }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        showMessage(data.detail || 'Could not save the episode order', 'error');
+        episodeOrderSelect.value = lastSavedOrder;
+        return;
+      }
+      lastSavedOrder = order;
+      const effective = order || serverEpisodeOrderValue;
+      showMessage(effective === 'tvdb'
+        ? 'New shows will use TVDB ordering. Use "Apply to all existing shows" for the ones you already have.'
+        : 'New shows will use TMDB ordering.');
+    });
+  }
+
+  if (applyEpisodeOrderBtn) {
+    applyEpisodeOrderBtn.addEventListener('click', async () => {
+      if (episodeOrderPoller != null) return;
+      applyEpisodeOrderBtn.disabled = true;
+      applyEpisodeOrderBtn.textContent = '...';
+      try {
+        const res = await fetch('/api/proxy/shows/episode-order/apply-default', {
+          method: 'POST',
+          headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' },
+          body: JSON.stringify({ order: episodeOrderSelect?.value || serverEpisodeOrderValue }),
+        });
+        const data = await res.json().catch(() => ({}));
+        if (!res.ok) throw new Error(data.detail || 'Could not start the re-mapping');
+        if (data.status === 'noop') {
+          showMessage('No shows to re-map yet.');
+          applyEpisodeOrderBtn.disabled = false;
+          applyEpisodeOrderBtn.textContent = 'Apply';
+          return;
+        }
+        renderEpisodeOrderJob({ status: 'pending', total_items: data.shows, processed_items: 0 });
+        pollEpisodeOrderJob(data.job_id);
+      } catch (err: any) {
+        showMessage(err.message || 'Could not start the re-mapping', 'error');
+        applyEpisodeOrderBtn.disabled = false;
+        applyEpisodeOrderBtn.textContent = 'Apply';
+      }
+    });
+  }
 
   const shuffleNextUpToggle = document.getElementById('shuffle-next-up-toggle') as HTMLInputElement | null;
   if (shuffleNextUpToggle) {


### PR DESCRIPTION
## What this changes

Until now the TVDB episode order could only be picked per show. If your library is numbered by TVDB (the way Sonarr names files), you had to go through every show one by one, and each newly synced show started on TMDB again.

This adds a default episode order you set once. An admin sets one for the whole server, and each user can override it for their own account - if they don't, they follow the server. It only decides the order for shows nobody has explicitly chosen an order for; a choice made on a show itself always stays.

Shows that arrive later follow the default on their own, right after a library sync. For the shows you already have, there is an "Apply to all existing shows" button that puts your whole library on the chosen order, including shows you had set differently before.

## Roughly how it works

The default is stored as one nullable column on the server settings and one on the user settings, where empty means "inherit" - the same way the TVDB API key already falls back from user to server. One helper resolves the two into the order that actually applies, and everything else asks that helper.

Switching a show to TVDB means building a TMDB-to-TVDB episode mapping, which costs one TMDB request per episode. That part already existed for the per-show switch; it is now a shared helper so the per-show switch, the automatic one after a sync and the bulk action all end up with the same result.

Because of that cost, the bulk action runs in the background, one show after another, and shows a progress bar. A show TVDB has no match for is listed as a warning on the job instead of stopping the rest. Existing mappings are reused - rebuilding one is what the per-show "Refresh Metadata" is for.

Picking TVDB needs a TVDB API key, so both the user and the admin setting refuse it without one.

## Tests

18 new tests cover which setting wins, the bulk run (including one broken show not taking down the others), the automatic run after a sync, and both settings endpoints rejecting bad input. The full suite is at 941 passing, up from 923. The migration ran against a real PostgreSQL 16 and the frontend builds.

The README doesn't mention the new setting yet.