### PR TITLE
feat(rpdb): add per-user rating posters

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Scrob syncs your libraries from **Jellyfin**, **Plex**, **Emby**, **Nuvio**, **A
   - [Updating](#updating)
 - [Configuration](#configuration)
   - [TheTVDB metadata](#thetvdb-metadata)
+  - [RPDB rating posters](#rpdb-rating-posters)
 - [ARVIO Cloud Synchronization](#arvio-cloud-synchronization)
 - [Nuvio Cloud Synchronization](#nuvio-cloud-synchronization)
   - [Connect Nuvio](#connect-nuvio)
@@ -70,6 +71,7 @@ Scrob syncs your libraries from **Jellyfin**, **Plex**, **Emby**, **Nuvio**, **A
 - **Social**: Follow other users and see their activity.
 - **Release schedule**: Movie pages show the full release schedule - theatrical, digital, and physical dates - sourced from TMDB.
 - **TMDB integration**: Rich metadata for every title - posters, backdrops, cast, crew, trailers, collections, and more.
+- **RPDB rating posters**: Optionally use RatingPosterDB movie and show posters with embedded ratings. Configure your own key and customize the artwork and rating sources through RPDB.
 - **Metadata language**: Set a preferred display language per profile - titles, overviews, and episode names show translated where available, independent of the rest of the UI's language.
 - **Search**: Search TMDB across movies, shows, people, and collections, merged with your local library data.
 - **Pick a Movie / Pick a Show**: Get a suggestion on what to watch next from your library or your streaming services based on your preferences.
@@ -340,6 +342,14 @@ With no key configured, all of the above fall back to TMDB-only behaviour; nothi
 Configure it per-user in **Settings → General → TVDB API Key** (with the **Subscriber PIN** field for a subscriber key), or server-wide in **Admin → Settings → TVDB** as a fallback for all users. Use **Test key** to verify the pair before saving.
 
 **Rotation / revocation.** Scrob caches the TheTVDB login token in memory for up to 29 days per key. After changing or removing the key or PIN in settings, the new credential takes effect on the next lookup; a stale token for the old credential is discarded on restart.
+
+### RPDB rating posters
+
+To enable [RatingPosterDB](https://ratingposterdb.com/) posters, enter your RPDB API key in **Settings → General → RPDB API Key**, test it, and save. This is a personal display preference: it applies only to your browsing, including when viewing another user's public profile or list. Clear the key and save to return to the original artwork.
+
+Choose poster styles and rating sources in the [RPDB manager](https://manager.ratingposterdb.com/); available customizations depend on your RPDB plan. Scrob uses RPDB's account-default posters and falls back to the original artwork when an RPDB image cannot load. Movie and show portraits, including parent-show portraits in history and Next Up, can use RPDB. Episode stills, season-specific artwork, backdrops, people and collection artwork stay unchanged.
+
+Images load directly from RPDB, so your key is visible in your own browser's image requests. It is not written into shared media metadata, and data exports include it only when you explicitly select **API Keys**. Existing metadata and the server's TMDB/TheTVDB image cache are unchanged.
 
 ## ARVIO Cloud Synchronization
 

--- a/backend/core/data_export.py
+++ b/backend/core/data_export.py
@@ -357,6 +357,7 @@ def build_api_keys(user: User, settings: UserSettings | None) -> dict:
         "tmdb_api_key": settings.tmdb_api_key if settings else None,
         "tvdb_api_key": settings.tvdb_api_key if settings else None,
         "tvdb_subscriber_pin": settings.tvdb_subscriber_pin if settings else None,
+        "rpdb_api_key": settings.rpdb_api_key if settings else None,
     }
 
 

--- a/backend/core/rpdb.py
+++ b/backend/core/rpdb.py
@@ -1,0 +1,32 @@
+"""Personal RatingPosterDB credential validation."""
+
+from urllib.parse import quote
+
+import httpx
+
+MAX_API_KEY_LENGTH = 255
+
+
+def normalize_api_key(key: str | None) -> str | None:
+    if key is None:
+        return None
+    key = key.strip()
+    if len(key) > MAX_API_KEY_LENGTH:
+        raise ValueError("RPDB API key must be at most 255 characters")
+    return key or None
+
+
+async def validate_api_key(key: str | None) -> bool:
+    try:
+        key = normalize_api_key(key)
+        if not key:
+            return False
+        async with httpx.AsyncClient(timeout=10.0, follow_redirects=False) as client:
+            response = await client.get(
+                f"https://api.ratingposterdb.com/{quote(key, safe='')}/isValid"
+            )
+            response.raise_for_status()
+            data = response.json()
+            return isinstance(data, dict) and data.get("valid") is True
+    except (httpx.HTTPError, ValueError):
+        return False

--- a/backend/core/scrob_import.py
+++ b/backend/core/scrob_import.py
@@ -619,8 +619,17 @@ async def apply_scrob_import(
         settings_result = await db.execute(select(UserSettings).where(UserSettings.user_id == user_id))
         settings = settings_result.scalar_one_or_none()
         if settings:
-            for field_name in ("tmdb_api_key", "tvdb_api_key", "tvdb_subscriber_pin"):
+            for field_name in ("tmdb_api_key", "tvdb_api_key", "tvdb_subscriber_pin", "rpdb_api_key"):
                 value = data.api_keys.get(field_name)
+                if field_name == "rpdb_api_key":
+                    from core.rpdb import normalize_api_key
+                    try:
+                        if value is not None and not isinstance(value, str):
+                            raise ValueError("Invalid RPDB API key")
+                        value = normalize_api_key(value)
+                    except ValueError:
+                        stats["errors"] += 1
+                        continue
                 if value and not getattr(settings, field_name):
                     setattr(settings, field_name, value)
                     stats["connections"] += 1

--- a/backend/migrations/versions/rpdb377_add_rpdb_api_key.py
+++ b/backend/migrations/versions/rpdb377_add_rpdb_api_key.py
@@ -1,0 +1,25 @@
+"""add personal RPDB API key
+
+Revision ID: rpdb377
+Revises: runtimebackfill
+Create Date: 2026-09-10
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "rpdb377"
+down_revision = "runtimebackfill"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "user_settings",
+        sa.Column("rpdb_api_key", sa.String(length=255), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("user_settings", "rpdb_api_key")

--- a/backend/models/users.py
+++ b/backend/models/users.py
@@ -49,6 +49,7 @@ class UserSettings(Base):
     id             : Mapped[int]            = mapped_column(Integer, primary_key=True)
     user_id        : Mapped[int]            = mapped_column(Integer, ForeignKey("users.id", ondelete="CASCADE"), unique=True, nullable=False)
     tmdb_api_key   : Mapped[Optional[str]]  = mapped_column(String(255))
+    rpdb_api_key   : Mapped[Optional[str]]  = mapped_column(String(255))
 
     # Radarr integration
     radarr_url             : Mapped[Optional[str]] = mapped_column(String(500))

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -425,6 +425,12 @@ async def update_user_settings(
     READ_ONLY_FIELDS = {"trakt_connected", "simkl_connected", "mdblist_connected", "bingebase_connected", "has_global_tmdb_key", "has_effective_tmdb_key", "has_global_tvdb_key", "has_effective_tvdb_key"}
     update_data = {k: v for k, v in settings_in.model_dump(exclude_unset=True).items() if k not in READ_ONLY_FIELDS}
 
+    new_rpdb_key = update_data.get("rpdb_api_key")
+    if new_rpdb_key and new_rpdb_key != settings.rpdb_api_key:
+        from core import rpdb
+        if not await rpdb.validate_api_key(new_rpdb_key):
+            raise HTTPException(status_code=400, detail="RPDB could not validate this API key. Check the key and try again.")
+
     if "tmdb_api_key" in update_data and update_data["tmdb_api_key"]:
         success = await tmdb.validate_api_key(update_data["tmdb_api_key"])
         if not success:
@@ -841,6 +847,16 @@ async def test_tmdb(
     if not success:
         raise HTTPException(status_code=400, detail="Invalid TMDB API Key")
     return {"status": "ok", "message": "TMDB API key is valid."}
+
+@router.post("/test-rpdb")
+async def test_rpdb(
+    body: schemas.ApiKeyTestRequest,
+    response: Response,
+    current_user: User = Depends(get_current_user)
+):
+    from core import rpdb
+    _prevent_sensitive_response_caching(response)
+    return {"success": await rpdb.validate_api_key(body.key.get_secret_value())}
 
 @router.post("/test-tvdb")
 async def test_tvdb(

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -119,6 +119,7 @@ class TotpBackupCodesResponse(BaseModel):
 
 class UserSettings(BaseModel):
     tmdb_api_key: Optional[str] = None
+    rpdb_api_key: Optional[str] = Field(default=None, max_length=255)
     has_effective_tmdb_key: bool = False
     has_global_tmdb_key: bool = False
 
@@ -210,6 +211,12 @@ class UserSettings(BaseModel):
     hide_watched_from_recently_added: Optional[bool] = None
     rate_prompt_movies: Optional[bool] = None
     rate_prompt_episodes: Optional[bool] = None
+
+    @field_validator("rpdb_api_key", mode="before")
+    @classmethod
+    def normalize_rpdb_api_key(cls, value):
+        from core.rpdb import normalize_api_key
+        return normalize_api_key(value) if isinstance(value, str) or value is None else value
 
     class Config:
         from_attributes = True

--- a/backend/tests/test_data_export.py
+++ b/backend/tests/test_data_export.py
@@ -192,6 +192,7 @@ class SecretCategoryTests(unittest.IsolatedAsyncioTestCase):
         user = SimpleNamespace(api_key="scrob-secret")
         settings = SimpleNamespace(
             tmdb_api_key="tmdb-secret", tvdb_api_key=None, tvdb_subscriber_pin="sub-pin",
+            rpdb_api_key="rpdb-secret",
         )
 
         out = data_export.build_api_keys(user, settings)
@@ -200,6 +201,7 @@ class SecretCategoryTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(out["tmdb_api_key"], "tmdb-secret")
         self.assertIsNone(out["tvdb_api_key"])
         self.assertEqual(out["tvdb_subscriber_pin"], "sub-pin")
+        self.assertEqual(out["rpdb_api_key"], "rpdb-secret")
 
     async def test_media_connection_includes_token(self) -> None:
         conn = SimpleNamespace(type="plex", name="Plex", url="http://x", token="plex-token",
@@ -245,6 +247,24 @@ class SecretCategoryTests(unittest.IsolatedAsyncioTestCase):
         names = zipfile.ZipFile(io.BytesIO(payload)).namelist()
         for secret_file in ("api-keys.json", "media-connections.json", "scrobble-connections.json", "connections.json"):
             self.assertNotIn(secret_file, names)
+
+    async def test_rpdb_secret_requires_api_keys_opt_in(self) -> None:
+        user = SimpleNamespace(id=1, username="alice", api_key="scrob-secret", created_at=datetime(2026, 1, 1))
+        settings = SimpleNamespace(**{field: None for field in data_export._SAFE_SETTINGS_FIELDS},
+                                   tmdb_api_key=None, tvdb_api_key=None, tvdb_subscriber_pin=None,
+                                   rpdb_api_key="rpdb-secret")
+        for include in (False, True):
+            payload = await data_export.build_export_zip(
+                _FakeSession([[None]]), user, settings,
+                include_watched=False, include_ratings=False, include_collection=False,
+                include_lists=False, include_comments=False, include_api_keys=include,
+            )
+            with zipfile.ZipFile(io.BytesIO(payload)) as archive:
+                self.assertNotIn("rpdb-secret", archive.read("user-settings.json").decode())
+                if include:
+                    self.assertEqual(json.loads(archive.read("api-keys.json"))["rpdb_api_key"], "rpdb-secret")
+                else:
+                    self.assertNotIn("api-keys.json", archive.namelist())
 
 
 class ZipRoundTripTests(unittest.TestCase):

--- a/backend/tests/test_rpdb.py
+++ b/backend/tests/test_rpdb.py
@@ -1,0 +1,125 @@
+import os
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import httpx
+from fastapi import FastAPI
+
+os.environ.setdefault("SECRET_KEY", "test-secret")
+os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://test:test@localhost/test")
+
+from core import rpdb
+from db import get_db
+from dependencies import get_current_user
+from models.users import UserSettings
+from routers import auth
+
+
+class RpdbProviderTests(unittest.IsolatedAsyncioTestCase):
+    async def test_provider_requires_explicit_valid_boolean(self):
+        for payload, expected in [({"valid": True}, True), ({"valid": False}, False),
+                                  ({"valid": "true"}, False), ({"valid": 1}, False),
+                                  (True, False), ({}, False)]:
+            with self.subTest(payload=payload):
+                client = AsyncMock()
+                client.get.return_value = httpx.Response(
+                    200, json=payload, request=httpx.Request("GET", "https://example.test")
+                )
+                with patch.object(rpdb.httpx, "AsyncClient") as factory:
+                    factory.return_value.__aenter__.return_value = client
+                    self.assertEqual(await rpdb.validate_api_key("key"), expected)
+
+    async def test_provider_failures_and_malformed_json_are_not_valid(self):
+        for response in [httpx.Response(401), httpx.Response(503), httpx.Response(200, text="not json")]:
+            response.request = httpx.Request("GET", "https://example.test")
+            client = AsyncMock()
+            client.get.return_value = response
+            with patch.object(rpdb.httpx, "AsyncClient") as factory:
+                factory.return_value.__aenter__.return_value = client
+                self.assertFalse(await rpdb.validate_api_key("key"))
+        with patch.object(rpdb.httpx, "AsyncClient") as factory:
+            factory.return_value.__aenter__.return_value.get.side_effect = httpx.ReadTimeout("timeout")
+            self.assertFalse(await rpdb.validate_api_key("key"))
+
+    async def test_key_cannot_change_provider_host_path_or_query(self):
+        seen = []
+        def respond(request):
+            seen.append(request.url)
+            return httpx.Response(200, json={"valid": True})
+        client = httpx.AsyncClient(transport=httpx.MockTransport(respond))
+        with patch.object(rpdb.httpx, "AsyncClient", return_value=client):
+            self.assertTrue(await rpdb.validate_api_key("  key/evil?x=#fragment  "))
+        self.assertEqual(str(seen[0]), "https://api.ratingposterdb.com/key%2Fevil%3Fx%3D%23fragment/isValid")
+
+
+class RpdbSettingsTests(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.rows = {1: UserSettings(user_id=1, rpdb_api_key="original"),
+                     2: UserSettings(user_id=2, rpdb_api_key="other-user")}
+        self.user_id = 1
+        async def execute(query):
+            if query.column_descriptions[0]["entity"] is UserSettings:
+                user_id = query.compile().params["user_id_1"]
+                value = self.rows.get(user_id)
+            else:
+                value = None
+            return SimpleNamespace(scalar_one_or_none=lambda: value)
+        self.db = SimpleNamespace(execute=execute, commit=AsyncMock(), refresh=AsyncMock())
+        app = FastAPI()
+        app.include_router(auth.router, prefix="/auth")
+        app.dependency_overrides[get_db] = lambda: self.db
+        app.dependency_overrides[get_current_user] = lambda: SimpleNamespace(id=self.user_id)
+        self.app = app
+        self.client = httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test")
+
+    async def asyncTearDown(self):
+        await self.client.aclose()
+
+    async def test_changed_key_validates_and_is_scoped_to_current_user(self):
+        with patch.object(rpdb, "validate_api_key", AsyncMock(return_value=True)):
+            response = await self.client.patch("/auth/settings", json={"rpdb_api_key": "  new-key  "})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["rpdb_api_key"], "new-key")
+        self.user_id = 2
+        response = await self.client.get("/auth/settings")
+        self.assertEqual(response.json()["rpdb_api_key"], "other-user")
+
+    async def test_provider_rejection_preserves_key_and_other_preferences(self):
+        with patch.object(rpdb, "validate_api_key", AsyncMock(return_value=False)):
+            response = await self.client.patch("/auth/settings", json={"rpdb_api_key": "bad", "blur_explicit": False})
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(self.rows[1].rpdb_api_key, "original")
+        self.assertIsNone(self.rows[1].blur_explicit)
+        self.db.commit.assert_not_awaited()
+
+    async def test_unchanged_unrelated_and_clear_work_without_provider(self):
+        with patch.object(rpdb, "validate_api_key", AsyncMock(side_effect=AssertionError("must not validate"))):
+            for body in ({"rpdb_api_key": " original "}, {"blur_explicit": False}, {"rpdb_api_key": " \t "}):
+                response = await self.client.patch("/auth/settings", json=body)
+                self.assertEqual(response.status_code, 200)
+        self.assertIsNone(response.json()["rpdb_api_key"])
+        self.assertFalse(response.json()["blur_explicit"])
+        self.assertEqual(self.rows[2].rpdb_api_key, "other-user")
+
+    async def test_overlong_key_rejected_without_mutation(self):
+        response = await self.client.patch("/auth/settings", json={"rpdb_api_key": "x" * 256})
+        self.assertEqual(response.status_code, 422)
+        self.assertEqual(self.rows[1].rpdb_api_key, "original")
+
+    async def test_key_test_is_no_store_and_does_not_save(self):
+        for valid in (True, False):
+            with patch.object(rpdb, "validate_api_key", AsyncMock(return_value=valid)):
+                response = await self.client.post("/auth/test-rpdb", json={"key": "candidate"})
+            self.assertEqual(response.json(), {"success": valid})
+            self.assertEqual(response.headers["cache-control"], "no-store")
+        self.assertEqual(self.rows[1].rpdb_api_key, "original")
+        self.db.commit.assert_not_awaited()
+
+    async def test_anonymous_requests_cannot_read_save_or_test_keys(self):
+        del self.app.dependency_overrides[get_current_user]
+        for method, path, body in [("GET", "/auth/settings", None),
+                                   ("PATCH", "/auth/settings", {"rpdb_api_key": "key"}),
+                                   ("POST", "/auth/test-rpdb", {"key": "key"})]:
+            response = await self.client.request(method, path, json=body)
+            self.assertIn(response.status_code, (401, 403))

--- a/backend/tests/test_scrob_import.py
+++ b/backend/tests/test_scrob_import.py
@@ -293,6 +293,30 @@ class ApiKeysImportTests(unittest.IsolatedAsyncioTestCase):
         # scrob_api_key was never even an attribute the import touches.
         self.assertFalse(hasattr(settings, "scrob_api_key"))
 
+    async def test_rpdb_import_requires_opt_in_and_never_overwrites(self) -> None:
+        for include, existing, expected in ((False, None, None), (True, None, "imported"), (True, "existing", "existing")):
+            with self.subTest(include=include, existing=existing):
+                settings = SimpleNamespace(rpdb_api_key=existing)
+                db = _FakeSession([[], [settings], []] if include else [[], []])
+                await apply_scrob_import(
+                    db, job_id=1, user_id=1,
+                    data=ScrobImportData(api_keys={"rpdb_api_key": "  imported  "}), api_key=None,
+                    **{**_EMPTY_INCLUDE, "include_api_keys": include},
+                )
+                self.assertEqual(settings.rpdb_api_key, expected)
+
+    async def test_rpdb_import_skips_malformed_or_overlong_credentials(self) -> None:
+        for value in ("x" * 256, {"key": "not-a-string"}):
+            settings = SimpleNamespace(rpdb_api_key=None)
+            db = _FakeSession([[], [settings], []])
+            stats = await apply_scrob_import(
+                db, job_id=1, user_id=1,
+                data=ScrobImportData(api_keys={"rpdb_api_key": value}), api_key=None,
+                **{**_EMPTY_INCLUDE, "include_api_keys": True},
+            )
+            self.assertIsNone(settings.rpdb_api_key)
+            self.assertEqual(stats["errors"], 1)
+
 
 class MediaConnectionsImportTests(unittest.IsolatedAsyncioTestCase):
     async def test_creates_new_connection_when_none_matches(self) -> None:

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -1,7 +1,7 @@
 // Scrob — Service Worker
 // Strategy:
 //   - Static assets (JS/CSS/fonts/icons): NetworkFirst, cached for offline fallback
-//   - TMDB / Proxy images: bypass service worker (fall through to native network/disk cache)
+//   - TMDB / RPDB / Proxy images: bypass service worker (native HTTP cache)
 //   - /api/proxy/*: NetworkOnly — library data must always be fresh
 //   - Navigation (HTML pages): NetworkFirst, offline fallback if all fail
 
@@ -33,8 +33,8 @@ self.addEventListener('fetch', (event) => {
   // Only handle GET — leave POST/PATCH/DELETE to the network
   if (request.method !== 'GET') return;
 
-  // TMDB images and proxy images: bypass service worker entirely to use native browser HTTP cache (much faster)
-  if (url.hostname === 'image.tmdb.org' || url.pathname.startsWith('/api/proxy/media/image/')) {
+  // Poster images use native HTTP caching, not the app-shell cache.
+  if (url.hostname === 'image.tmdb.org' || url.hostname === 'api.ratingposterdb.com' || url.pathname.startsWith('/api/proxy/media/image/')) {
     return; // fall through to browser default (native network/disk cache)
   }
 

--- a/frontend/src/components/ContinueWatchingCard.astro
+++ b/frontend/src/components/ContinueWatchingCard.astro
@@ -1,6 +1,7 @@
 ---
 import type { ContinueWatchingItem } from "../lib/api";
 import { tmdbImageUrl } from "../lib/api";
+import { ratingPosterUrl } from "../lib/posters";
 import { episodeHref } from "../lib/episodeHref";
 
 interface Props {
@@ -19,10 +20,10 @@ const sxe =
 const progressPct =
   progress_percent != null ? Math.round(progress_percent * 100) : 0;
 
-const posterSrc = tmdbImageUrl(
+const posterSrc = ratingPosterUrl(tmdbImageUrl(
   isEpisode && media.show_poster_path ? media.show_poster_path : media.poster_path,
   "w500"
-);
+), media, Astro.locals.rpdbApiKey);
 
 const href = episodeHref(media) ?? `/media/${media.type}/${media.tmdb_id}`;
 ---

--- a/frontend/src/components/HistoryCard.astro
+++ b/frontend/src/components/HistoryCard.astro
@@ -1,6 +1,7 @@
 ---
 import type { WatchEvent } from "../lib/api";
 import { tmdbImageUrl } from "../lib/api";
+import { ratingPosterUrl } from "../lib/posters";
 import { episodeHref } from "../lib/episodeHref";
 
 interface Props {
@@ -20,7 +21,7 @@ const showOrMovieTitle = isEpisode ? (media.show_title || media.title) : media.t
 const year = media.release_date?.slice(0, 4);
 
 const rawPoster = isEpisode ? (media.show_poster_path || media.poster_path) : media.poster_path;
-const posterPath = tmdbImageUrl(rawPoster, "w500");
+const posterPath = ratingPosterUrl(tmdbImageUrl(rawPoster, "w500"), media, Astro.locals.rpdbApiKey);
 
 // Watch history is movie/episode only (enforced server-side, see #358).
 // Anything else still routes through episodeHref rather than a movie URL that

--- a/frontend/src/components/MediaCard.astro
+++ b/frontend/src/components/MediaCard.astro
@@ -1,6 +1,7 @@
 ---
 import type { MediaItem } from "../lib/api";
 import { tmdbImageUrl } from "../lib/api";
+import { ratingPosterUrl } from "../lib/posters";
 import CardActionBar from "./CardActionBar.astro";
 import { episodeHref } from "../lib/episodeHref";
 
@@ -31,10 +32,10 @@ const href = isPerson
     : episodeHref(item);
 
 const cardTitle = isSeason ? `Season ${item.season_number}` : item.title;
-const posterPath = tmdbImageUrl(
+const posterPath = ratingPosterUrl(tmdbImageUrl(
   (isEpisode || isSeason) && item.show_poster_path ? item.show_poster_path : item.poster_path,
   "w500"
-);
+), item, Astro.locals.rpdbApiKey);
 
 const showActionBar = !isPerson && !isCollection && !!user;
 // Seasons get the same percentage-style Watched/Collected labels as a whole show

--- a/frontend/src/env.d.ts
+++ b/frontend/src/env.d.ts
@@ -11,5 +11,12 @@ declare namespace App {
       role: string;
     } | null;
     token: string | undefined;
+    settings?: import('./lib/api').UserSettings;
+    rpdbApiKey?: string | null;
   }
+}
+
+interface Window {
+  __RPDB_API_KEY__: string | null;
+  ratingPosterUrl: typeof import('./lib/posters').ratingPosterUrl;
 }

--- a/frontend/src/layouts/Base.astro
+++ b/frontend/src/layouts/Base.astro
@@ -17,7 +17,7 @@ if (user?.is_admin && token) {
     pendingRequestCount = data.pending;
   } catch {}
   try {
-    const settings = await api.auth.getSettings(token);
+    const settings = Astro.locals.settings ?? await api.auth.getSettings(token);
     radarrCustomizeOnAdd = settings.radarr_customize_on_add === true;
     sonarrCustomizeOnAdd = settings.sonarr_customize_on_add === true;
   } catch {}
@@ -105,26 +105,43 @@ const bottomNavItem = (active: boolean) =>
 
     // Poster/backdrop image fallback — registered here (head, inline) so the
     // capture-phase listener is active before any <img> tags are parsed and
-    // start loading. Covers TMDB/TheTVDB images loaded directly and via the
-    // backend image proxy/cache.
+    // start loading. RPDB images carry the existing artwork in a URL fragment
+    // so a failed request can recover without another server round-trip.
     (function () {
-      var svgIcon = '<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" style="opacity:0.25"><rect width="20" height="20" x="2" y="2" rx="2.18" ry="2.18"/><line x1="7" x2="7" y1="2" y2="22"/><line x1="17" x2="17" y1="2" y2="22"/><line x1="2" x2="22" y1="7" y2="7"/><line x1="2" x2="22" y1="12" y2="12"/><line x1="2" x2="22" y1="17" y2="17"/></svg>';
+      var svgIcon = '<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" style="opacity:0.25"><rect width="20" height="20" x="2" y="2" rx="2.18"/><line x1="7" x2="7" y1="2" y2="22"/><line x1="17" x2="17" y1="2" y2="22"/><line x1="2" x2="22" y1="7" y2="7"/><line x1="2" x2="22" y1="12" y2="12"/><line x1="2" x2="22" y1="17" y2="17"/></svg>';
       function applyFallback(img) {
-        if (!img.src.includes('image.tmdb.org') && !img.src.includes('artworks.thetvdb.com') && !img.src.includes('/api/proxy/media/image/')) return;
+        var source = img.currentSrc || img.src;
+        var isRpdb = source.startsWith('https://api.ratingposterdb.com/');
+        if (isRpdb) {
+          var hash = '';
+          try { hash = new URL(source, window.location.href).hash; } catch { /* malformed source */ }
+          if (hash.startsWith('#scrob-fallback=')) {
+            try {
+              img.src = decodeURIComponent(hash.slice('#scrob-fallback='.length));
+              return true;
+            } catch { /* use the normal placeholder below */ }
+          }
+        }
+        if (!isRpdb && !source.includes('image.tmdb.org') && !source.includes('artworks.thetvdb.com') && !source.includes('/api/proxy/media/image/')) return false;
         img.style.display = 'none';
         // Decorative images (alt="") — just hide, no placeholder needed
-        if (!img.alt) return;
+        if (!img.alt) return true;
         var parent = img.parentElement;
-        if (!parent || parent.querySelector('.tmdb-img-fallback')) return;
+        if (!parent || parent.querySelector('.tmdb-img-fallback')) return true;
         // Ensure parent is a positioning context so absolute inset-0 stays contained
         if (getComputedStyle(parent).position === 'static') parent.style.position = 'relative';
         var fb = document.createElement('div');
         fb.className = 'tmdb-img-fallback';
         fb.innerHTML = svgIcon;
         parent.appendChild(fb);
+        return true;
       }
       document.addEventListener('error', function (e) {
-        if (e.target && e.target.tagName === 'IMG') applyFallback(e.target);
+        if (e.target && e.target.tagName === 'IMG') {
+          var img = e.target;
+          var isRpdb = (img.currentSrc || img.src).startsWith('https://api.ratingposterdb.com/');
+          if (applyFallback(img) && isRpdb) e.stopPropagation();
+        }
       }, true);
       // Safety net: catch images that already failed by the time DOM is ready
       document.addEventListener('DOMContentLoaded', function () {
@@ -133,6 +150,40 @@ const bottomNavItem = (active: boolean) =>
         });
       });
     })();
+  </script>
+
+  <script define:vars={{ __rpdbApiKey: Astro.locals.rpdbApiKey ?? null }}>
+    // Only this viewer's key is used. Direct RPDB image requests expose it to
+    // their browser, never through shared media metadata or public profiles.
+    window.__RPDB_API_KEY__ = __rpdbApiKey;
+
+    // Inline counterpart of lib/posters.ts, for define:vars scripts.
+    window.ratingPosterUrl = function (fallback, item, apiKey) {
+      if (!apiKey) return fallback ?? null;
+      var type = item.type ?? item.media_type;
+      var isEpisode = type === 'episode';
+      if (type !== 'movie' && type !== 'series' && !isEpisode) return fallback ?? null;
+      if (type === 'series' && item.season_number != null) return fallback ?? null;
+      var tmdbId = isEpisode ? item.show_tmdb_id : item.tmdb_id;
+      var tvdbId = isEpisode ? item.show_tvdb_id : item.tvdb_id;
+      var mediaType = type === 'movie' ? 'movie' : 'series';
+      var provider;
+      var id;
+      if (Number.isInteger(tmdbId) && tmdbId > 0) {
+        provider = 'tmdb';
+        id = mediaType + '-' + tmdbId;
+      } else if (Number.isInteger(tvdbId) && tvdbId > 0) {
+        provider = 'tvdb';
+        id = mediaType + '-' + tvdbId;
+      } else if (!isEpisode && /^tt\d+$/.test(item.imdb_id || '')) {
+        provider = 'imdb';
+        id = item.imdb_id;
+      } else {
+        return fallback ?? null;
+      }
+      var recovery = fallback ? '#scrob-fallback=' + encodeURIComponent(fallback) : '';
+      return 'https://api.ratingposterdb.com/' + encodeURIComponent(apiKey) + '/' + provider + '/poster-default/' + id + '.jpg?fallback=true' + recovery;
+    };
   </script>
 </head>
 <body class="bg-zinc-950 text-zinc-100 min-h-screen overflow-x-hidden">
@@ -718,7 +769,7 @@ const bottomNavItem = (active: boolean) =>
           : `<span class="relative shrink-0 flex w-2 h-2"><span class="animate-ping absolute inline-flex h-full w-full rounded-full ${dotColor} opacity-75"></span><span class="relative inline-flex rounded-full w-2 h-2 ${dotColor}"></span></span>`;
 
         const rawPoster = isEpisode ? (m.show_poster_path ?? m.poster_path) : m.poster_path;
-        const posterUrl = tmdbImageUrl(rawPoster, 'w185');
+        const posterUrl = window.ratingPosterUrl(tmdbImageUrl(rawPoster, 'w185'), m, window.__RPDB_API_KEY__);
 
         // #319 - movie-only mid/post-credits scene indicator. Movies never
         // use the subtitle line (that's episode-only), so it doubles as a
@@ -1117,7 +1168,9 @@ const bottomNavItem = (active: boolean) =>
       openRatingPopover(null, String(m.tmdb_id), m.type, null, null, 'tmdb', {
         title: isEpisode ? (m.show_title ?? m.title) : m.title,
         subtitle: isEpisode ? [sxe, m.title].filter(Boolean).join(' · ') : undefined,
-        posterUrl: ratingPosterUrl(m.poster_path),
+        posterUrl: isEpisode
+          ? ratingPosterUrl(m.poster_path)
+          : window.ratingPosterUrl(ratingPosterUrl(m.poster_path), m, window.__RPDB_API_KEY__) ?? undefined,
         landscape: isEpisode,
       });
     }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -426,6 +426,8 @@ export interface UserSettings {
   has_effective_tvdb_key: boolean;
   has_global_tvdb_key: boolean;
 
+  rpdb_api_key: string | null;
+
   radarr_url: string | null;
   radarr_token: string | null;
   radarr_root_folder: string | null;

--- a/frontend/src/lib/posters.ts
+++ b/frontend/src/lib/posters.ts
@@ -1,0 +1,47 @@
+export interface PosterMedia {
+  type?: string;
+  media_type?: string;
+  tmdb_id?: number | null;
+  tvdb_id?: number | null;
+  imdb_id?: string | null;
+  show_tmdb_id?: number | null;
+  show_tvdb_id?: number | null;
+  season_number?: number | null;
+}
+
+// Keep the inline counterpart in Base.astro in sync: define:vars scripts cannot
+// import this module. Only call for portrait slots, never episode stills.
+export function ratingPosterUrl(
+  fallback: string | null | undefined,
+  item: PosterMedia,
+  apiKey?: string | null,
+): string | null {
+  if (!apiKey) return fallback ?? null;
+  const type = item.type ?? item.media_type;
+  const isEpisode = type === "episode";
+  if (type !== "movie" && type !== "series" && !isEpisode) return fallback ?? null;
+  if (type === "series" && item.season_number != null) return fallback ?? null;
+
+  const tmdbId = isEpisode ? item.show_tmdb_id : item.tmdb_id;
+  const tvdbId = isEpisode ? item.show_tvdb_id : item.tvdb_id;
+  const mediaType = type === "movie" ? "movie" : "series";
+  let provider: string;
+  let id: string;
+  if (Number.isInteger(tmdbId) && tmdbId! > 0) {
+    provider = "tmdb";
+    id = `${mediaType}-${tmdbId}`;
+  } else if (Number.isInteger(tvdbId) && tvdbId! > 0) {
+    provider = "tvdb";
+    id = `${mediaType}-${tvdbId}`;
+  } else if (!isEpisode && /^tt\d+$/.test(item.imdb_id ?? "")) {
+    provider = "imdb";
+    id = item.imdb_id!;
+  } else {
+    return fallback ?? null;
+  }
+
+  // The fragment stays in the browser, so the original artwork is available
+  // on failure without leaking that URL to RPDB or adding a proxy request.
+  const recovery = fallback ? `#scrob-fallback=${encodeURIComponent(fallback)}` : "";
+  return `https://api.ratingposterdb.com/${encodeURIComponent(apiKey)}/${provider}/poster-default/${id}.jpg?fallback=true${recovery}`;
+}

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -144,7 +144,17 @@ export const onRequest = defineMiddleware(async (context, next) => {
     }
   }
 
+  // Resolve once per page/partial, not per image or proxied API request. A
+  // failed preference lookup leaves the normal artwork and session intact.
+  if (context.locals.user && token && !isStaticAsset && !pathname.startsWith('/api/')) {
+    context.locals.settings = await api.auth.getSettings(token).catch(() => undefined);
+    context.locals.rpdbApiKey = context.locals.settings?.rpdb_api_key ?? null;
+  }
+
   const response = await next();
+  if (context.locals.rpdbApiKey) {
+    response.headers.set('Cache-Control', 'private, no-store');
+  }
   for (const [header, value] of Object.entries(SECURITY_HEADERS)) {
     response.headers.set(header, value);
   }

--- a/frontend/src/pages/calendar.astro
+++ b/frontend/src/pages/calendar.astro
@@ -60,9 +60,16 @@ Astro.response.headers.set("Cache-Control", "no-store");
       e.collected ? '<span class="text-[10px] font-bold uppercase tracking-wide px-1.5 py-0.5 rounded-full bg-purple-500/20 text-purple-400">Collected</span>' : '',
       e.watched ? '<span class="text-[10px] font-bold uppercase tracking-wide px-1.5 py-0.5 rounded-full bg-green-500/20 text-green-400">Watched</span>' : '',
     ].filter(Boolean).join('');
+    const poster = (e.show_tmdb_id || e.show_tvdb_id)
+      ? window.ratingPosterUrl(e.poster_path, {
+          type: 'series',
+          tmdb_id: e.show_tmdb_id ?? null,
+          tvdb_id: e.show_tvdb_id ?? null,
+        }, window.__RPDB_API_KEY__)
+      : e.poster_path;
     return `
       <a href="${esc(href)}" class="flex items-center gap-4 p-3 bg-zinc-900 border border-zinc-800 rounded-xl hover:border-blue-500/50 transition-colors">
-        ${e.poster_path ? `<img src="${esc(e.poster_path)}" alt="" class="w-10 rounded-md object-cover shrink-0" loading="lazy" style="height:60px"/>`
+        ${poster ? `<img src="${esc(poster)}" alt="" class="w-10 rounded-md object-cover shrink-0" loading="lazy" style="height:60px"/>`
               : '<div class="w-10 shrink-0 text-2xl text-center opacity-30" style="height:60px;line-height:60px">📺</div>'}
         <div class="min-w-0 flex-1">
           <div class="flex items-center gap-2">

--- a/frontend/src/pages/continue-watching.astro
+++ b/frontend/src/pages/continue-watching.astro
@@ -90,7 +90,8 @@ Astro.response.headers.set("Cache-Control", "no-store");
         : m.show_tvdb_id ? `/show/tvdb/${m.show_tvdb_id}`
         : m.tmdb_id ? `/media/${m.type}/${m.tmdb_id}` : '#';
 
-    const posterSrc = tmdbImageUrl(isEpisode && m.show_poster_path ? m.show_poster_path : m.poster_path, 'w500');
+    const originalPosterSrc = tmdbImageUrl(isEpisode && m.show_poster_path ? m.show_poster_path : m.poster_path, 'w500');
+    const posterSrc = window.ratingPosterUrl(originalPosterSrc, m, window.__RPDB_API_KEY__);
     const sxe = isEpisode && m.season_number != null && m.episode_number != null
       ? `S${String(m.season_number).padStart(2, '0')}E${String(m.episode_number).padStart(2, '0')}`
       : null;

--- a/frontend/src/pages/dropped.astro
+++ b/frontend/src/pages/dropped.astro
@@ -1,6 +1,7 @@
 ---
 import Base from "../layouts/Base.astro";
 import { api, tmdbImageUrl, type DroppedShow, type DroppedMovie } from "../lib/api";
+import { ratingPosterUrl } from "../lib/posters";
 export const prerender = false;
 
 const { token } = Astro.locals;
@@ -49,13 +50,15 @@ const total = shows.length + movies.length;
     <section class="mb-12">
       <h2 class="section-headline mb-4">Shows</h2>
       <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-6">
-        {shows.map((s) => (
+        {shows.map((s) => {
+          const posterPath = ratingPosterUrl(tmdbImageUrl(s.poster_path, "w500"), { type: "series", tmdb_id: s.tmdb_id, tvdb_id: s.tvdb_id }, Astro.locals.rpdbApiKey);
+          return (
           <div class="group relative flex flex-col rounded-2xl overflow-hidden bg-zinc-900 border border-zinc-800 hover:border-blue-500/50 hover:shadow-2xl hover:shadow-blue-900/20 transition-all duration-300 transform hover:-translate-y-1">
             <a href={showHref(s)} class="block active:scale-95 active:opacity-70 transition-all duration-100">
               <div class="aspect-[2/3] bg-zinc-950 relative overflow-hidden ring-1 ring-white/5 group-hover:ring-blue-500/30 transition-all duration-300">
-                {tmdbImageUrl(s.poster_path, "w500") ? (
+                {posterPath ? (
                   <img
-                    src={tmdbImageUrl(s.poster_path, "w500")}
+                    src={posterPath}
                     alt={s.title}
                     class="w-full h-full object-cover group-hover:scale-110 transition-transform duration-500"
                     loading="lazy"
@@ -86,7 +89,8 @@ const total = shows.length + movies.length;
               </div>
             </a>
           </div>
-        ))}
+          );
+        })}
       </div>
     </section>
   )}
@@ -95,13 +99,15 @@ const total = shows.length + movies.length;
     <section class="mb-12">
       <h2 class="section-headline mb-4">Movies</h2>
       <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-6">
-        {movies.map((m) => (
+        {movies.map((m) => {
+          const posterPath = ratingPosterUrl(tmdbImageUrl(m.poster_path, "w500"), { type: "movie", tmdb_id: m.tmdb_id }, Astro.locals.rpdbApiKey);
+          return (
           <div class="group relative flex flex-col rounded-2xl overflow-hidden bg-zinc-900 border border-zinc-800 hover:border-blue-500/50 hover:shadow-2xl hover:shadow-blue-900/20 transition-all duration-300 transform hover:-translate-y-1">
             <a href={m.tmdb_id ? `/media/movie/${m.tmdb_id}` : "#"} class="block active:scale-95 active:opacity-70 transition-all duration-100">
               <div class="aspect-[2/3] bg-zinc-950 relative overflow-hidden ring-1 ring-white/5 group-hover:ring-blue-500/30 transition-all duration-300">
-                {tmdbImageUrl(m.poster_path, "w500") ? (
+                {posterPath ? (
                   <img
-                    src={tmdbImageUrl(m.poster_path, "w500")}
+                    src={posterPath}
                     alt={m.title}
                     class="w-full h-full object-cover group-hover:scale-110 transition-transform duration-500"
                     loading="lazy"
@@ -129,7 +135,8 @@ const total = shows.length + movies.length;
               {m.year && <span class="text-[11px] font-medium text-zinc-500 mt-1 block">{m.year}</span>}
             </a>
           </div>
-        ))}
+          );
+        })}
       </div>
     </section>
   )}

--- a/frontend/src/pages/index.astro
+++ b/frontend/src/pages/index.astro
@@ -16,7 +16,7 @@ const apiUrl = import.meta.env.PUBLIC_API_URL ?? "http://localhost:8000";
 let settings: Awaited<ReturnType<typeof api.auth.getSettings>> | null = null;
 let hasTmdbKey = false;
 if (token) {
-  settings = await api.auth.getSettings(token);
+  settings = Astro.locals.settings ?? await api.auth.getSettings(token);
   hasTmdbKey = !!settings?.has_effective_tmdb_key;
 } else {
   // Anonymous visitor - only reachable at all when the admin enabled
@@ -418,7 +418,7 @@ const discoverBackdropUrl = discoverPick?.backdrop_path
           const year = item.release_date ? item.release_date.slice(0, 4) : null;
           const rating = item.tmdb_rating ? Number(item.tmdb_rating).toFixed(1) : null;
           const raw = item.poster_path;
-          const posterUrl = tmdbImageUrl(raw, 'w500');
+          const posterUrl = window.ratingPosterUrl(tmdbImageUrl(raw, 'w500'), item, window.__RPDB_API_KEY__);
           const typeLabel = isSeries ? 'Show' : 'Movie';
           const watched = item.watched ?? false;
           const inLists = item.in_lists ?? [];

--- a/frontend/src/pages/list/[id].astro
+++ b/frontend/src/pages/list/[id].astro
@@ -644,7 +644,7 @@ const sonarrUrl = `${origin}/api/proxy/sonarr-compat/${list?.id}`;
       searchResults.classList.remove('hidden');
 
       items.slice(0, 12).forEach(item => {
-        const poster = tmdbImageUrl(item.poster_path, 'w300');
+        const poster = window.ratingPosterUrl(tmdbImageUrl(item.poster_path, 'w300'), item, window.__RPDB_API_KEY__);
         const year = item.release_date?.slice(0, 4) || '';
         const isPerson = item.type === 'person';
         const rating = item.tmdb_rating ? Number(item.tmdb_rating).toFixed(1) : '';
@@ -709,7 +709,8 @@ const sonarrUrl = `${origin}/api/proxy/sonarr-compat/${list?.id}`;
       ? `/person/${media.tmdb_id}`
       : `/media/${media.type}/${media.tmdb_id}`;
 
-    const poster = tmdbImageUrl(isSeason && media.show_poster_path ? media.show_poster_path : media.poster_path, 'w500');
+    const originalPoster = tmdbImageUrl(isSeason && media.show_poster_path ? media.show_poster_path : media.poster_path, 'w500');
+    const poster = window.ratingPosterUrl(originalPoster, media, window.__RPDB_API_KEY__);
 
     const rating = media.tmdb_rating ? Number(media.tmdb_rating).toFixed(1) : null;
     const year = media.release_date?.slice(0, 4) ?? '';

--- a/frontend/src/pages/media/[type]/[id].astro
+++ b/frontend/src/pages/media/[type]/[id].astro
@@ -6,6 +6,7 @@ import CommentsSection from "../../../components/CommentsSection.astro";
 import VideoPlayer from "../../../components/VideoPlayer.astro";
 import ManualScrobble from "../../../components/ManualScrobble.astro";
 import { api, type MediaItem } from "../../../lib/api";
+import { ratingPosterUrl } from "../../../lib/posters";
 export const prerender = false;
 
 const { type, id } = Astro.params;
@@ -30,6 +31,9 @@ const rating = item?.tmdb_rating ? item.tmdb_rating.toFixed(1) : null;
 const isEpisode = item?.type === "episode";
 const isMovie = item?.type === "movie";
 const collection = item?.collection;
+const posterPath = item && !isEpisode
+  ? ratingPosterUrl(item.poster_path, item, Astro.locals.rpdbApiKey)
+  : item?.poster_path;
 
 // Header for the shared rating popover (shown once the modal dims the page).
 // ActionBar prefixes the SxxExx itself, so pass just the episode name here.
@@ -37,7 +41,7 @@ const rateTitle = isEpisode ? (item?.show_title ?? item?.title) : item?.title;
 const rateSubtitle = isEpisode ? (item?.title ?? "") : "";
 // Episode: the landscape still (ActionBar flags episodes landscape), show
 // poster as fallback. Movie: its poster.
-const ratePosterPath = isEpisode ? (item?.poster_path ?? item?.show_poster_path) : item?.poster_path;
+const ratePosterPath = isEpisode ? (item?.poster_path ?? item?.show_poster_path) : posterPath;
 const showRefreshBtn = !!user && item?.in_library && (item.type === "movie" || (isEpisode && !!item.show_tmdb_id));
 
 const today = new Date();
@@ -101,10 +105,10 @@ const refreshUrl = isEpisode
           <!-- Poster -->
           <div class="w-64 shrink-0 mx-auto md:mx-0">
             <div class="aspect-[2/3] rounded-2xl overflow-hidden shadow-2xl border border-zinc-800 bg-zinc-900 ring-1 ring-white/10 relative" data-adult={item.adult ? "true" : undefined}>
-              {item.poster_path ? (
+              {posterPath ? (
                 <button id="poster-zoom-btn" class="w-full h-full group/poster block cursor-zoom-in" aria-label={`Enlarge poster for ${item.title}`}>
                   <img
-                    src={item.poster_path}
+                    src={posterPath}
                     alt={item.title}
                     class="w-full h-full object-cover transition-transform duration-300 group-hover/poster:scale-105"
                     loading="eager"
@@ -484,11 +488,11 @@ const refreshUrl = isEpisode
   }
 </script>
 
-{item?.poster_path && (
+{item && posterPath && (
   <div id="poster-modal" class="fixed inset-0 z-[999] flex items-center justify-center hidden" role="dialog" aria-modal="true">
     <div id="poster-modal-backdrop" class="absolute inset-0 bg-black/90 backdrop-blur-sm cursor-pointer"></div>
     <img
-      src={item.poster_path}
+      src={posterPath}
       alt={item.title}
       class="relative max-h-[90vh] max-w-[85vw] md:max-w-[50vw] object-contain rounded-2xl shadow-2xl ring-1 ring-white/10"
     />

--- a/frontend/src/pages/next-up.astro
+++ b/frontend/src/pages/next-up.astro
@@ -170,7 +170,8 @@ Astro.response.headers.set("Cache-Control", "no-store");
         : item.show_tvdb_id ? `/show/tvdb/${item.show_tvdb_id}`
         : item.tmdb_id ? `/media/${item.type}/${item.tmdb_id}` : '#';
 
-    const posterSrc = tmdbImageUrl(item.show_poster_path || item.poster_path, 'w500');
+    const originalPosterSrc = tmdbImageUrl(item.show_poster_path || item.poster_path, 'w500');
+    const posterSrc = window.ratingPosterUrl(originalPosterSrc, item, window.__RPDB_API_KEY__);
 
     const rating = item.tmdb_rating ? Number(item.tmdb_rating).toFixed(1) : null;
     const sxe = item.season_number != null && item.episode_number != null

--- a/frontend/src/pages/profile/[id].astro
+++ b/frontend/src/pages/profile/[id].astro
@@ -2,6 +2,7 @@
 import Base from "../../layouts/Base.astro";
 import ListCard from "../../components/ListCard.astro";
 import { api, type PublicProfile, type ProfileListItem, type ProfileFollowEntry, tmdbImageUrl } from "../../lib/api";
+import { ratingPosterUrl } from "../../lib/posters";
 
 export const prerender = false;
 
@@ -241,7 +242,7 @@ Recently Watched Movies
                 </div>
                 <div class="flex gap-3 overflow-x-auto pb-3 scrollbar-none">
                   {profile.recently_watched_movies.map((item) => {
-                    const thumb = posterUrl(item.poster_path);
+                    const thumb = ratingPosterUrl(posterUrl(item.poster_path), item, Astro.locals.rpdbApiKey);
                     const href = mediaUrl(item.media_type, item.tmdb_id);
                     return (
                       <a href={href} class="flex-shrink-0 w-32 group active:scale-95 active:opacity-70 transition-all duration-150">
@@ -324,7 +325,7 @@ Top Rated Movies
                 </div>
                 <div class="flex gap-3 overflow-x-auto pb-3 scrollbar-none">
                   {profile.top_rated_movies.map((item) => {
-                    const thumb = posterUrl(item.poster_path);
+                    const thumb = ratingPosterUrl(posterUrl(item.poster_path), item, Astro.locals.rpdbApiKey);
                     const href = mediaUrl(item.media_type, item.tmdb_id);
                     return (
                       <a href={href} class="flex-shrink-0 w-32 group active:scale-95 active:opacity-70 transition-all duration-150">
@@ -360,7 +361,7 @@ Top Rated Shows
                 </div>
                 <div class="flex gap-3 overflow-x-auto pb-3 scrollbar-none">
                   {profile.top_rated_shows.map((item) => {
-                    const thumb = posterUrl(item.poster_path);
+                    const thumb = ratingPosterUrl(posterUrl(item.poster_path), item, Astro.locals.rpdbApiKey);
                     const href = mediaUrl(item.media_type, item.tmdb_id);
                     return (
                       <a href={href} class="flex-shrink-0 w-32 group active:scale-95 active:opacity-70 transition-all duration-150">
@@ -393,7 +394,7 @@ Recent Comments
                   {profile.recent_comments.map((comment) => {
                     const href = commentUrl(comment);
                     const label = commentLabel(comment);
-                    const thumb = posterUrl(comment.poster_path, "w92");
+                    const thumb = ratingPosterUrl(posterUrl(comment.poster_path, "w92"), comment, Astro.locals.rpdbApiKey);
                     return (
                       <div
                         class="flex gap-4 bg-zinc-900/60 border border-zinc-800 rounded-2xl p-4 hover:border-zinc-600 transition-all group"

--- a/frontend/src/pages/progress.astro
+++ b/frontend/src/pages/progress.astro
@@ -3,6 +3,7 @@ import Base from "../layouts/Base.astro";
 import Pagination from "../components/Pagination.astro";
 import SortButton from "../components/SortButton.astro";
 import { api, tmdbImageUrl, type ShowProgress } from "../lib/api";
+import { ratingPosterUrl } from "../lib/posters";
 export const prerender = false;
 
 const { token } = Astro.locals;
@@ -139,6 +140,7 @@ const sortOptions = isCollection
     <>
       <div class="space-y-2">
         {shows.map((s) => {
+          const posterPath = ratingPosterUrl(tmdbImageUrl(s.poster_path, "w500"), { type: "series", tmdb_id: s.tmdb_id, tvdb_id: s.tvdb_id }, Astro.locals.rpdbApiKey);
           const pct = metricPct(s);
           const remaining = Math.max(0, s.episodes_total - metricDone(s));
           const meta = `${metricDone(s)}/${s.episodes_total}`
@@ -150,8 +152,8 @@ const sortOptions = isCollection
               class="flex items-center gap-3 sm:gap-4 rounded-xl bg-zinc-900 border border-zinc-800 hover:border-blue-500/40 hover:bg-zinc-900/60 transition-colors p-2.5 sm:p-3"
             >
               <div class="w-11 sm:w-12 shrink-0 aspect-[2/3] rounded-md overflow-hidden bg-zinc-950 ring-1 ring-white/5">
-                {tmdbImageUrl(s.poster_path, "w500") ? (
-                  <img src={tmdbImageUrl(s.poster_path, "w500")} alt={s.title} class="w-full h-full object-cover" loading="lazy" decoding="async" />
+                {posterPath ? (
+                  <img src={posterPath} alt={s.title} class="w-full h-full object-cover" loading="lazy" decoding="async" />
                 ) : (
                   <div class="w-full h-full flex items-center justify-center text-zinc-700 text-lg">📺</div>
                 )}

--- a/frontend/src/pages/recently-watched-movies/[id].astro
+++ b/frontend/src/pages/recently-watched-movies/[id].astro
@@ -2,6 +2,7 @@
 import Base from "../../layouts/Base.astro";
 import Pagination from "../../components/Pagination.astro";
 import { api, type ProfileWatchedItem, tmdbImageUrl } from "../../lib/api";
+import { ratingPosterUrl } from "../../lib/posters";
 
 export const prerender = false;
 
@@ -89,7 +90,7 @@ function timeAgo(dateStr: string): string {
       ) : (
         <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-6">
           {data.results.map((item) => {
-            const thumb = posterUrl(item.poster_path);
+            const thumb = ratingPosterUrl(posterUrl(item.poster_path), item, Astro.locals.rpdbApiKey);
             const href = `/media/movie/${item.tmdb_id}`;
             return (
               <a href={href} class="group active:scale-95 active:opacity-70 transition-all duration-150">

--- a/frontend/src/pages/requests.astro
+++ b/frontend/src/pages/requests.astro
@@ -1,6 +1,7 @@
 ---
 import Base from "../layouts/Base.astro";
 import { api, type MediaRequestItem } from "../lib/api";
+import { ratingPosterUrl } from "../lib/posters";
 
 const { token, user } = Astro.locals;
 
@@ -32,11 +33,13 @@ const itemUrl = (r: MediaRequestItem) =>
         <p class="text-zinc-600 text-sm">No pending requests.</p>
       ) : (
         <div class="space-y-3">
-          {pending.map(r => (
+          {pending.map(r => {
+            const posterPath = ratingPosterUrl(r.poster_path, r, Astro.locals.rpdbApiKey);
+            return (
             <div class="flex items-center gap-4 bg-zinc-900 border border-zinc-800 rounded-xl px-4 py-3" data-request-id={r.id}>
               <a href={itemUrl(r)} class="flex items-center gap-4 flex-1 min-w-0 transition-all active:scale-95 active:opacity-70">
-              {r.poster_path && (
-                <img src={r.poster_path} alt={r.title} class="w-10 h-14 rounded object-cover shrink-0" />
+              {posterPath && (
+                <img src={posterPath} alt={r.title} class="w-10 h-14 rounded object-cover shrink-0" />
               )}
               <div class="flex-1 min-w-0">
                 <p class="text-sm font-semibold text-zinc-100 truncate">{r.title}</p>
@@ -59,7 +62,8 @@ const itemUrl = (r: MediaRequestItem) =>
                 </button>
               </div>
             </div>
-          ))}
+            );
+          })}
         </div>
       )}
     </section>
@@ -80,11 +84,13 @@ const itemUrl = (r: MediaRequestItem) =>
         <p class="text-zinc-600 text-sm">No approved requests.</p>
       ) : (
         <div class="space-y-2">
-          {approved.map(r => (
+          {approved.map(r => {
+            const posterPath = ratingPosterUrl(r.poster_path, r, Astro.locals.rpdbApiKey);
+            return (
             <div class="flex items-center gap-4 bg-zinc-900/50 border border-zinc-800/60 rounded-xl px-4 py-3 opacity-75">
               <a href={itemUrl(r)} class="flex items-center gap-4 flex-1 min-w-0 transition-all active:scale-95 active:opacity-70">
-              {r.poster_path && (
-                <img src={r.poster_path} alt={r.title} class="w-8 h-12 rounded object-cover shrink-0" />
+              {posterPath && (
+                <img src={posterPath} alt={r.title} class="w-8 h-12 rounded object-cover shrink-0" />
               )}
               <div class="flex-1 min-w-0">
                 <p class="text-sm font-semibold text-zinc-300 truncate">{r.title}</p>
@@ -93,7 +99,8 @@ const itemUrl = (r: MediaRequestItem) =>
               </a>
               <span class="text-xs font-bold text-green-500 bg-green-500/10 border border-green-500/20 px-2 py-1 rounded-lg shrink-0">Approved</span>
             </div>
-          ))}
+            );
+          })}
         </div>
       )}
       </div>
@@ -114,11 +121,13 @@ const itemUrl = (r: MediaRequestItem) =>
         {rejected.length === 0 ? (
           <p class="text-zinc-600 text-sm">No rejected requests.</p>
         ) : (
-          rejected.map(r => (
+          rejected.map(r => {
+            const posterPath = ratingPosterUrl(r.poster_path, r, Astro.locals.rpdbApiKey);
+            return (
             <div class="flex items-center gap-4 bg-zinc-900/50 border border-zinc-800/60 rounded-xl px-4 py-3 opacity-75" data-request-id={r.id}>
               <a href={itemUrl(r)} class="flex items-center gap-4 flex-1 min-w-0 transition-all active:scale-95 active:opacity-70">
-              {r.poster_path && (
-                <img src={r.poster_path} alt={r.title} class="w-8 h-12 rounded object-cover shrink-0" />
+              {posterPath && (
+                <img src={posterPath} alt={r.title} class="w-8 h-12 rounded object-cover shrink-0" />
               )}
               <div class="flex-1 min-w-0">
                 <p class="text-sm font-semibold text-zinc-300 truncate">{r.title}</p>
@@ -135,7 +144,8 @@ const itemUrl = (r: MediaRequestItem) =>
                 </button>
               </div>
             </div>
-          ))
+            );
+          })
         )}
       </div>
     </section>

--- a/frontend/src/pages/settings.astro
+++ b/frontend/src/pages/settings.astro
@@ -5,7 +5,7 @@ import type { TotpBackupCode } from "../lib/api";
 
 const { token } = Astro.locals;
 const [settings, me] = await Promise.all([
-  api.auth.getSettings(token!),
+  Astro.locals.settings ?? api.auth.getSettings(token!),
   api.auth.me(token!),
 ]);
 const hasTmdbKey = settings.has_effective_tmdb_key;
@@ -157,6 +157,49 @@ if (me.totp_enabled) {
                 <a href="https://thetvdb.com/api-information" target="_blank" rel="noopener noreferrer" class="text-blue-400 hover:underline">thetvdb.com/api-information</a>
                 (key only, no PIN; requires attribution, which Scrob shows on TVDB pages). A <span class="text-zinc-400">subscriber-supported</span> key also needs your account's subscriber PIN above.
               </p>
+            </div>
+          </div>
+          <!-- RPDB API Key -->
+          <div class="space-y-2">
+            <label for="rpdb_api_key" class="block text-sm font-medium text-zinc-400">RPDB API Key</label>
+            <div class="flex gap-2">
+              <div class="relative flex-1 group/field">
+                <input
+                  type="password"
+                  name="rpdb_api_key"
+                  id="rpdb_api_key"
+                  value={settings.rpdb_api_key || ""}
+                  maxlength="255"
+                  class="w-full bg-zinc-950 border border-zinc-800 rounded-lg pl-4 pr-10 py-3 text-zinc-100 focus:outline-none focus:ring-2 focus:ring-blue-500 transition-all"
+                />
+                <button
+                  type="button"
+                  class="password-toggle absolute right-2 top-1/2 -translate-y-1/2 text-zinc-500 hover:text-zinc-300 p-1 cursor-pointer transition-colors"
+                  aria-label="Toggle password visibility"
+                >
+                  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 eye-icon">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M2.036 12.322a1.012 1.012 0 010-.644C3.412 7.943 7.213 5 12 5c4.787 0 8.588 2.943 9.964 6.678.066.18.066.362 0 .544C20.588 16.057 16.787 19 12 19c-4.787 0-8.588-2.943-9.964-6.678z" />
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                  </svg>
+                  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 eye-slash-icon hidden">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M3.98 8.223A10.477 10.477 0 001.934 12C3.226 16.338 7.244 19.5 12 19.5c.993 0 1.953-.138 2.863-.395M6.228 6.228A10.45 10.45 0 0112 4.5c4.756 0 8.773 3.162 10.065 7.498a10.523 10.523 0 01-4.293 5.774M6.228 6.228L3 3m3.228 3.228l3.65 3.65m7.894 7.894L21 21m-3.228-3.228l-3.65-3.65m0 0a3 3 0 10-4.243-4.243m4.242 4.242L9.88 9.88" />
+                  </svg>
+                </button>
+              </div>
+              <button
+                type="button"
+                data-action="test_rpdb"
+                title="Test RPDB key"
+                class="js-action-btn px-3 py-2 bg-zinc-800 hover:bg-zinc-700 border border-zinc-700 text-zinc-300 rounded-lg transition-colors cursor-pointer disabled:opacity-50"
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M5.25 5.653c0-.856.917-1.398 1.667-.986l11.54 6.347a1.125 1.125 0 010 1.972l-11.54 6.347a1.125 1.125 0 01-1.667-.986V5.653z" />
+                </svg>
+              </button>
+            </div>
+            <div class="text-xs text-zinc-500 space-y-1">
+              <p>Optional personal key for rating posters. Leave blank to disable and use original artwork. Your key is sent to RPDB when loading posters.</p>
+              <p>Choose poster style and ratings in the <a href="https://manager.ratingposterdb.com/" target="_blank" rel="noopener noreferrer" class="text-blue-400 hover:underline">RPDB manager</a>. Feature availability for your current plan is managed by RPDB.</p>
             </div>
           </div>
           </div>
@@ -1121,6 +1164,10 @@ if (me.totp_enabled) {
             const pin = (document.getElementById('tvdb_subscriber_pin') as HTMLInputElement)?.value;
             url = '/api/proxy/auth/test-tvdb';
             requestBody = { key: val, pin: pin || null };
+          } else if (action === 'test_rpdb') {
+            const val = (document.getElementById('rpdb_api_key') as HTMLInputElement).value;
+            url = '/api/proxy/auth/test-rpdb';
+            requestBody = { key: val };
           }
 
           const res = await fetch(url, {
@@ -1132,6 +1179,9 @@ if (me.totp_enabled) {
             body: requestBody ? JSON.stringify(requestBody) : undefined,
           });
           const data = await res.json();
+          if (action === 'test_rpdb' && data.success !== true) {
+            throw new Error('RPDB could not validate this API key. Check the key and try again.');
+          }
 
           if (res.ok) {
             showMessage(data.message || 'Action successful!');
@@ -1370,6 +1420,13 @@ if (me.totp_enabled) {
     const form = document.getElementById('settings-form');
     const saveBtn = document.getElementById('save-settings-btn');
     if (!form || !saveBtn) return;
+    const fields = ['tmdb_api_key', 'tvdb_api_key', 'tvdb_subscriber_pin', 'rpdb_api_key'];
+    const fieldValue = (data: FormData, field: string) => {
+      const value = String(data.get(field) || '');
+      return (field === 'rpdb_api_key' ? value.trim() : value) || null;
+    };
+    const initialData = new FormData(form as HTMLFormElement);
+    const savedValues = Object.fromEntries(fields.map(field => [field, fieldValue(initialData, field)]));
 
     form.addEventListener('submit', async (e) => {
       e.preventDefault();
@@ -1380,11 +1437,11 @@ if (me.totp_enabled) {
 
       try {
         const formData = new FormData(form);
-        const settings = {
-          tmdb_api_key: formData.get('tmdb_api_key') || null,
-          tvdb_api_key: formData.get('tvdb_api_key') || null,
-          tvdb_subscriber_pin: formData.get('tvdb_subscriber_pin') || null,
-        };
+        const settings: Record<string, string | null> = {};
+        for (const field of fields) {
+          const value = fieldValue(formData, field);
+          if (value !== savedValues[field]) settings[field] = value;
+        }
 
         const res = await fetch(`/api/proxy/auth/settings`, {
           method: 'PATCH',
@@ -1396,6 +1453,7 @@ if (me.totp_enabled) {
           const data = await res.json();
           throw new Error(data.detail || 'Failed to update settings');
         }
+        Object.assign(savedValues, settings);
 
         showMessage('Settings updated successfully!');
       } catch (e) {

--- a/frontend/src/pages/show/[id].astro
+++ b/frontend/src/pages/show/[id].astro
@@ -6,6 +6,7 @@ import CommentsSection from "../../components/CommentsSection.astro";
 import EpisodeOrderSelector from "../../components/EpisodeOrderSelector.astro";
 import { api, type Show } from "../../lib/api";
 import { countAiredRegularSeasons } from "../../lib/seasonCount";
+import { ratingPosterUrl } from "../../lib/posters";
 export const prerender = false;
 
 const { id } = Astro.params;
@@ -53,6 +54,9 @@ const langNames = new Intl.DisplayNames(["en"], { type: "language" });
 const originalLanguage = show?.original_language
   ? langNames.of(show.original_language) ?? show.original_language
   : null;
+const posterPath = show
+  ? ratingPosterUrl(show.poster_path, { type: "series", tmdb_id: show.tmdb_id, tvdb_id: show.tvdb_id, imdb_id: show.imdb_id }, Astro.locals.rpdbApiKey)
+  : null;
 ---
 
 <Base title={show?.title || "Show Details"}>
@@ -93,10 +97,10 @@ const originalLanguage = show?.original_language
           <!-- Poster -->
           <div class="w-64 shrink-0 mx-auto md:mx-0">
             <div class="aspect-[2/3] rounded-2xl overflow-hidden shadow-2xl border border-zinc-800 bg-zinc-900 ring-1 ring-white/10 relative" data-adult={show.adult ? "true" : undefined}>
-              {show.poster_path ? (
+              {posterPath ? (
                 <button id="poster-zoom-btn" class="w-full h-full group/poster block cursor-zoom-in" aria-label={`Enlarge poster for ${show.title}`}>
                   <img
-                    src={show.poster_path}
+                    src={posterPath}
                     alt={show.title}
                     class="w-full h-full object-cover transition-transform duration-300 group-hover/poster:scale-105"
                     loading="eager"
@@ -200,7 +204,7 @@ const originalLanguage = show?.original_language
                   requestStatus={show.request_status ?? null}
                   userRating={show.user_rating ?? null}
                   ratingTitle={show.title}
-                  ratingPosterPath={show.poster_path}
+                  ratingPosterPath={posterPath}
                   showRewatch={true}
                   rewatch={show.rewatch ?? null}
                   showDrop={true}
@@ -396,11 +400,11 @@ const originalLanguage = show?.original_language
   )}
 </Base>
 
-{show?.poster_path && (
+{show && posterPath && (
   <div id="poster-modal" class="fixed inset-0 z-[999] flex items-center justify-center hidden" role="dialog" aria-modal="true">
     <div id="poster-modal-backdrop" class="absolute inset-0 bg-black/90 backdrop-blur-sm cursor-pointer"></div>
     <img
-      src={show.poster_path}
+      src={posterPath}
       alt={show.title}
       class="relative max-h-[90vh] max-w-[85vw] md:max-w-[50vw] object-contain rounded-2xl shadow-2xl ring-1 ring-white/10"
     />

--- a/frontend/src/pages/show/tvdb/[id].astro
+++ b/frontend/src/pages/show/tvdb/[id].astro
@@ -7,6 +7,7 @@ import TvdbAttribution from "../../../components/TvdbAttribution.astro";
 import { api, type TvdbShow } from "../../../lib/api";
 import { formatSeasonTitle } from "../../../lib/media-format";
 import { countAiredRegularSeasons } from "../../../lib/seasonCount";
+import { ratingPosterUrl } from "../../../lib/posters";
 export const prerender = false;
 
 const { id } = Astro.params;
@@ -37,6 +38,9 @@ const year = show?.first_air_date?.slice(0, 4) ?? null;
 const langNames = new Intl.DisplayNames(["en"], { type: "language" });
 const originalLanguage = show?.original_language
   ? langNames.of(show.original_language) ?? show.original_language
+  : null;
+const posterPath = show
+  ? ratingPosterUrl(show.poster_path, { type: "series", tmdb_id: show.tmdb_id_cross, tvdb_id: show.tvdb_id, imdb_id: show.imdb_id }, Astro.locals.rpdbApiKey)
   : null;
 ---
 
@@ -78,10 +82,10 @@ const originalLanguage = show?.original_language
           <!-- Poster -->
           <div class="w-64 shrink-0 mx-auto md:mx-0">
             <div class="aspect-[2/3] rounded-2xl overflow-hidden shadow-2xl border border-zinc-800 bg-zinc-900 ring-1 ring-white/10 relative">
-              {show.poster_path ? (
+              {posterPath ? (
                 <button id="poster-zoom-btn" class="w-full h-full group/poster block cursor-zoom-in" aria-label={`Enlarge poster for ${show.title}`}>
                   <img
-                    src={show.poster_path}
+                    src={posterPath}
                     alt={show.title}
                     class="w-full h-full object-cover transition-transform duration-300 group-hover/poster:scale-105"
                     loading="eager"
@@ -174,7 +178,7 @@ const originalLanguage = show?.original_language
                   requestStatus={show.request_status}
                   userRating={show.user_rating}
                   ratingTitle={show.title}
-                  ratingPosterPath={show.poster_path}
+                  ratingPosterPath={posterPath}
                   showRewatch={true}
                   rewatch={show.rewatch ?? null}
                   showDrop={true}
@@ -389,11 +393,11 @@ const originalLanguage = show?.original_language
   )}
 </Base>
 
-{show?.poster_path && (
+{show && posterPath && (
   <div id="poster-modal" class="fixed inset-0 z-[999] flex items-center justify-center hidden" role="dialog" aria-modal="true">
     <div id="poster-modal-backdrop" class="absolute inset-0 bg-black/90 backdrop-blur-sm cursor-pointer"></div>
     <img
-      src={show.poster_path}
+      src={posterPath}
       alt={show.title}
       class="relative max-h-[90vh] max-w-[85vw] md:max-w-[50vw] object-contain rounded-2xl shadow-2xl ring-1 ring-white/10"
     />

--- a/frontend/src/pages/top-rated-movies/[id].astro
+++ b/frontend/src/pages/top-rated-movies/[id].astro
@@ -2,6 +2,7 @@
 import Base from "../../layouts/Base.astro";
 import Pagination from "../../components/Pagination.astro";
 import { api, type ProfileRatedItem, tmdbImageUrl } from "../../lib/api";
+import { ratingPosterUrl } from "../../lib/posters";
 
 export const prerender = false;
 
@@ -76,7 +77,7 @@ function posterUrl(path: string | null): string | null {
       ) : (
         <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-6">
           {data.results.map((item) => {
-            const thumb = posterUrl(item.poster_path);
+            const thumb = ratingPosterUrl(posterUrl(item.poster_path), item, Astro.locals.rpdbApiKey);
             const href = `/media/movie/${item.tmdb_id}`;
             return (
               <a href={href} class="group active:scale-95 active:opacity-70 transition-all duration-150">

--- a/frontend/src/pages/top-rated-shows/[id].astro
+++ b/frontend/src/pages/top-rated-shows/[id].astro
@@ -2,6 +2,7 @@
 import Base from "../../layouts/Base.astro";
 import Pagination from "../../components/Pagination.astro";
 import { api, type ProfileRatedItem, tmdbImageUrl } from "../../lib/api";
+import { ratingPosterUrl } from "../../lib/posters";
 
 export const prerender = false;
 
@@ -76,7 +77,7 @@ function posterUrl(path: string | null): string | null {
       ) : (
         <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-6">
           {data.results.map((item) => {
-            const thumb = posterUrl(item.poster_path);
+            const thumb = ratingPosterUrl(posterUrl(item.poster_path), item, Astro.locals.rpdbApiKey);
             const href = `/show/${item.tmdb_id}`;
             return (
               <a href={href} class="group active:scale-95 active:opacity-70 transition-all duration-150">


### PR DESCRIPTION
## Summary

Closes #377.

- Add an optional personal RPDB API key in **Settings → General**, with credential testing, validation on changes, and support for clearing the key to disable rating posters.
- Apply RPDB account-default movie and show posters across server-rendered and dynamically loaded views, using parent-show identifiers for episode portrait cards.
- Fall back to the original artwork if RPDB cannot load, without hiding the recovered image. Preserve episode stills, season-specific artwork, backdrops, people, and collection artwork.
- Keep preferences scoped to the viewer. Add the nullable `rpdb377` migration, include the credential only in opt-in API-key exports/imports, and bypass the app-shell cache for RPDB images.
- Document setup, customization through the RPDB manager, fallback behavior, and credential privacy.

## Verification

- `npm run build` in `frontend` — passed.
- `uv run --with aiosqlite python -m unittest tests.test_rpdb tests.test_data_export tests.test_scrob_import tests.test_auth_integration_credentials` in `backend` — **74 tests passed**.
- `uv run alembic upgrade head` — passed on a fresh PostgreSQL 16 database, including `rpdb377`.
- Production-browser smoke checks with seeded local media and live RPDB image requests: key testing/saving/clearing, movie collection posters, show detail/zoom/rating-dialog posters, Next Up parent-show IDs, fallback after an invalid RPDB request, restoration of original artwork after disabling, and isolation between two users.

## Commits

- `feat(rpdb): add per-user rating posters (#377)`
- `docs(rpdb): document rating poster setup (#377)`