### PR TITLE
fix(webhooks): survive the open/open race on a brand-new playback session (#392)

### DIFF
--- a/backend/routers/webhooks.py
+++ b/backend/routers/webhooks.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select, delete, func, or_, and_
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm.exc import StaleDataError
 
 from db import get_db
@@ -513,23 +514,45 @@ async def _get_or_open_session(
     user_id: int,
     media_id: int,
 ) -> PlaybackSession:
+    """Returns the PlaybackSession for session_key, creating it if missing.
+
+    The check-then-create isn't atomic: Jellyfin/Emby fire PlaybackStart and
+    the first PlaybackProgress back to back, so two requests for a brand-new
+    session can both find no row and both INSERT. The loser blocks on the
+    session_key unique index until the winner commits, then fails with
+    IntegrityError and takes its whole request down with a 500 - dropping
+    that event's scrobble-start calls with it (#392). The add()+flush() runs
+    inside a savepoint so the failed INSERT rolls back cleanly (add() must
+    happen *inside* begin_nested(), see create_media_safely), and the loser
+    re-selects and carries on with the row the winner created.
+    """
     result = await db.execute(
         select(PlaybackSession).where(PlaybackSession.session_key == session_key)
     )
     session = result.scalar_one_or_none()
-    if not session:
-        session = PlaybackSession(
-            session_key=session_key,
-            source=source,
-            user_id=user_id,
-            media_id=media_id,
-            progress_percent=0.0,
-            progress_seconds=0,
-            started_at=datetime.utcnow(),
-            updated_at=datetime.utcnow(),
+    if session:
+        return session
+    session = PlaybackSession(
+        session_key=session_key,
+        source=source,
+        user_id=user_id,
+        media_id=media_id,
+        progress_percent=0.0,
+        progress_seconds=0,
+        started_at=datetime.utcnow(),
+        updated_at=datetime.utcnow(),
+    )
+    try:
+        async with db.begin_nested():
+            db.add(session)
+            await db.flush()
+    except IntegrityError:
+        result = await db.execute(
+            select(PlaybackSession).where(PlaybackSession.session_key == session_key)
         )
-        db.add(session)
-        await db.flush()
+        session = result.scalar_one_or_none()
+        if session is None:
+            raise
     return session
 
 

--- a/backend/tests/test_webhooks.py
+++ b/backend/tests/test_webhooks.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, patch
 os.environ.setdefault("SECRET_KEY", "test-secret")
 os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://test:test@localhost/test")
 
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm.exc import StaleDataError
 
 from models.base import MediaType
@@ -16,6 +17,7 @@ from routers.webhooks import (
     _backfill_jellyfin_runtimes,
     _backfill_plex_runtime,
     _commit_playback_session_update,
+    _get_or_open_session,
     _consume_recently_pushed_watched,
     _ensure_collection_entry,
     _episode_for_progress,
@@ -1089,6 +1091,100 @@ class CommitPlaybackSessionUpdateTests(IsolatedAsyncioTestCase):
         with self.assertRaises(RuntimeError):
             await _commit_playback_session_update(db)
         self.assertFalse(db.rollback_called)
+
+
+class _FakeNestedTxn:
+    def __init__(self, db):
+        self._db = db
+
+    async def __aenter__(self):
+        self._db.events.append("begin_nested")
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False  # let the failed flush propagate, like a real SAVEPOINT rollback
+
+
+class _FakeSessionOpenDB:
+    """Fakes just enough of AsyncSession for _get_or_open_session: each
+    execute() returns the next queued scalar_one_or_none() value, flush()
+    optionally raises, and begin_nested()/add() are logged in order so the
+    savepoint discipline (add() *inside* begin_nested(), see
+    create_media_safely) is asserted as a regression guard."""
+
+    def __init__(self, queued_scalars, flush_raises=None):
+        self._queued = list(queued_scalars)
+        self._flush_raises = flush_raises
+        self.added = []
+        self.events = []
+        self.execute_calls = 0
+
+    async def execute(self, stmt):
+        self.execute_calls += 1
+        value = self._queued.pop(0) if self._queued else None
+        return _ScalarResult(value)
+
+    def begin_nested(self):
+        return _FakeNestedTxn(self)
+
+    def add(self, obj):
+        self.events.append("add")
+        self.added.append(obj)
+
+    async def flush(self):
+        if self._flush_raises is not None:
+            raise self._flush_raises
+
+
+class GetOrOpenSessionTests(IsolatedAsyncioTestCase):
+    """Regression tests for #392: Jellyfin/Emby fire PlaybackStart and the
+    first PlaybackProgress back to back, so two requests for a brand-new
+    session can both SELECT nothing and both INSERT. The loser blocks on the
+    session_key unique index until the winner commits, then its flush raises
+    IntegrityError and the whole request 500s. It must instead pick up the
+    row the winner created and carry on."""
+
+    _KEY = "jellyfin:1:abc"
+
+    async def test_returns_existing_session_without_inserting(self):
+        existing = SimpleNamespace(session_key=self._KEY)
+        db = _FakeSessionOpenDB([existing])
+        session = await _get_or_open_session(db, self._KEY, "jellyfin", 1, 42)
+        self.assertIs(session, existing)
+        self.assertEqual(db.added, [])
+        self.assertEqual(db.events, [])
+
+    async def test_creates_session_inside_savepoint(self):
+        db = _FakeSessionOpenDB([None])
+        session = await _get_or_open_session(db, self._KEY, "jellyfin", 1, 42)
+        self.assertEqual(session.session_key, self._KEY)
+        self.assertEqual(session.source, "jellyfin")
+        self.assertEqual(session.user_id, 1)
+        self.assertEqual(session.media_id, 42)
+        self.assertEqual(db.added, [session])
+        # add() must happen *after* the savepoint is entered - see _FakeSessionOpenDB.
+        self.assertEqual(db.events, ["begin_nested", "add"])
+        self.assertEqual(db.execute_calls, 1)
+
+    async def test_lost_race_returns_the_winners_row(self):
+        winner = SimpleNamespace(session_key=self._KEY)
+        db = _FakeSessionOpenDB(
+            [None, winner],
+            flush_raises=IntegrityError("stmt", {}, Exception("duplicate key")),
+        )
+        session = await _get_or_open_session(db, self._KEY, "jellyfin", 1, 42)
+        self.assertIs(session, winner)
+        self.assertEqual(db.execute_calls, 2)
+        self.assertEqual(db.events, ["begin_nested", "add"])
+
+    async def test_integrity_error_with_no_winner_still_propagates(self):
+        db = _FakeSessionOpenDB(
+            [None, None],
+            flush_raises=IntegrityError("stmt", {}, Exception("some other constraint")),
+        )
+        with self.assertRaises(IntegrityError):
+            await _get_or_open_session(db, self._KEY, "jellyfin", 1, 42)
+        self.assertEqual(db.execute_calls, 2)
 
 
 class EpisodeForProgressTests(unittest.TestCase):


### PR DESCRIPTION
Fixes #392.

### What
`_get_or_open_session` is a plain check-then-create. When two webhook events for a session that doesn't exist yet run concurrently (Jellyfin/Emby send `PlaybackStart` and the first `PlaybackProgress` back to back), both SELECT nothing and both INSERT; the loser blocks on the `session_key` unique index until the winner commits, then fails with `IntegrityError` and the request 500s, dropping that event's scrobble-start calls.

### How
Same recovery as `create_media_safely` (58dddce): `add()`+`flush()` inside `db.begin_nested()`, and on `IntegrityError` re-select and return the row the winner created, so the loser applies its own state/progress update on top. `add()` stays inside the savepoint, for the session-state reason documented on `create_media_safely`. The helper is shared by the Jellyfin, Emby, Kodi and Plex handlers, so all of them get it.

### Tests
- 4 unit tests in `GetOrOpenSessionTests` (existing row, creation with savepoint ordering, lost race → winner's row, unrelated IntegrityError still propagates), fakes modelled on the `create_media_safely` and `_commit_playback_session_update` tests. Full backend suite: 999 tests OK.
- Reproduced against a live Postgres 17 with two concurrent `AsyncSession`s racing on the same `session_key`: `main` raises `UniqueViolationError`; with this branch the loser ends up on the winner's row, its update commits, and one row remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
